### PR TITLE
Define an abs macro for gloidx

### DIFF
--- a/src/p4est.c
+++ b/src/p4est.c
@@ -2801,8 +2801,9 @@ p4est_partition_for_coarsening (p4est_t * p4est,
         quad_id_near_cut = partition_new[i];
       }
       else {
-        if (abs (partition_new[i] - partition_now[rank]) <
-            abs (partition_new[i] - partition_now[rank + 1] + 1)) {
+        if (P4EST_GLOIDX_ABS (partition_new[i] - partition_now[rank]) <
+            P4EST_GLOIDX_ABS (partition_new[i] - partition_now[rank + 1] +
+                              1)) {
           quad_id_near_cut = partition_now[rank];
         }
         else {

--- a/src/p4est_base.h
+++ b/src/p4est_base.h
@@ -89,6 +89,7 @@ typedef int64_t     p4est_gloidx_t;
 #define P4EST_GLOIDX_MIN INT64_MIN
 #define P4EST_GLOIDX_MAX INT64_MAX
 #define P4EST_GLOIDX_1   ((p4est_gloidx_t) 1)
+#define P4EST_GLOIDX_ABS llabs
 
 /* some error checking possibly specific to p4est */
 #ifdef P4EST_ENABLE_DEBUG


### PR DESCRIPTION
This should be the correct abs function for `p4est_gloidx_t`.  As I understand it (from section 5.2.4.2.1 of the [C99 Standard](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf)) `long long` will be at least as big as a `int64_t`.