### PR TITLE
Allowing user to preallocated p4est_t/p8est_t

### DIFF
--- a/doc/author_kozdon.txt
+++ b/doc/author_kozdon.txt
@@ -1,0 +1,1 @@
+I place my contributions to p4est under the CC0 license. Jeremy E Kozdon (jekozdon@nps.edu)

--- a/src/p4est_extended.h
+++ b/src/p4est_extended.h
@@ -130,6 +130,50 @@ p4est_t            *p4est_new_ext (sc_MPI_Comm mpicomm,
                                    size_t data_size, p4est_init_t init_fn,
                                    void *user_pointer);
 
+/** Initialize a preallocated forest.
+ * The initializes forest consists of equi-partitioned root quadrants.
+ * When there are more processors than trees, some processors are empty.
+ *
+ * \param [in,out] p4est     preallocated p4est
+ * \param [in] mpicomm       A valid MPI communicator.
+ * \param [in] connectivity  This is the connectivity information that
+ *                           the forest is built with.  Note the p4est
+ *                           does not take ownership of the memory.
+ * \param [in] min_quadrants Minimum initial quadrants per processor.
+ *                           Makes the refinement pattern mpisize-specific.
+ * \param [in] min_level     The forest is refined at least to this level.
+ *                           May be negative or 0, then it has no effect.
+ * \param [in] fill_uniform  If true, fill the forest with a uniform mesh
+ *                           instead of the coarsest possible one.
+ *                           The latter is partition-specific so that
+ *                           is usually not a good idea.
+ * \param [in] data_size     This is the size of data for each quadrant which
+ *                           can be zero.  Then user_data_pool is set to NULL.
+ * \param [in] init_fn       Callback function to initialize the user_data
+ *                           which is already allocated automatically.
+ * \param [in] user_pointer  Assign to the user_pointer member of the p4est
+ *                           before init_fn is called the first time.
+ *
+ * \note The connectivity structure must not be destroyed
+ *       during the lifetime of this forest.
+ */
+void                p4est_init_ext (p4est_t * p4est, sc_MPI_Comm mpicomm,
+                                    p4est_connectivity_t * connectivity,
+                                    p4est_locidx_t min_quadrants,
+                                    int min_level, int fill_uniform,
+                                    size_t data_size, p4est_init_t init_fn,
+                                    void *user_pointer);
+
+/** Destroy a p4est
+ * \param [in,out] p4est   p4est to destroy
+ * \param [in] free_p4est  Boolean on whether the p4est_t pointer should be
+ *                         freed
+ *
+ * \note The connectivity structure is not destroyed with the p4est.
+ */
+void                p4est_destroy_ext (p4est_t * p4est, int free_p4est);
+
+
 /** Create a new mesh.
  * \param [in] p4est                A forest that is fully 2:1 balanced.
  * \param [in] ghost                The ghost layer created from the

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -187,6 +187,8 @@
 /* functions in p4est_extended */
 #define p4est_replace_t                 p8est_replace_t
 #define p4est_new_ext                   p8est_new_ext
+#define p4est_init_ext                  p8est_init_ext
+#define p4est_destroy_ext               p8est_destroy_ext
 #define p4est_mesh_new_ext              p8est_mesh_new_ext
 #define p4est_copy_ext                  p8est_copy_ext
 #define p4est_refine_ext                p8est_refine_ext

--- a/src/p6est.c
+++ b/src/p6est.c
@@ -382,6 +382,20 @@ p6est_new_ext (sc_MPI_Comm mpicomm, p6est_connectivity_t * connectivity,
                void *user_pointer)
 {
   p6est_t            *p6est = P4EST_ALLOC (p6est_t, 1);
+  p6est_init_ext (p6est, mpicomm, connectivity, min_quadrants, min_level,
+                  min_zlevel, num_zroot, fill_uniform, data_size, init_fn,
+                  user_pointer);
+  return p6est;
+}
+
+void
+p6est_init_ext (p6est_t * p6est, sc_MPI_Comm mpicomm,
+                p6est_connectivity_t * connectivity,
+                p4est_locidx_t min_quadrants, int min_level, int min_zlevel,
+                 int num_zroot,
+                int fill_uniform, size_t data_size, p6est_init_t init_fn,
+                void *user_pointer)
+{
   p4est_t            *p4est;
   sc_array_t         *layers;
   sc_mempool_t       *user_data_pool;
@@ -456,8 +470,6 @@ p6est_new_ext (sc_MPI_Comm mpicomm, p6est_connectivity_t * connectivity,
     ("Done p6est_new with %lld total layers in %lld total columns\n",
      (long long) p6est->global_first_layer[p6est->mpisize],
      (long long) p6est->columns->global_num_quadrants);
-
-  return p6est;
 }
 
 p6est_t            *
@@ -545,6 +557,12 @@ p6est_new_from_p4est (p4est_t * p4est, double *top_vertices, double height[3],
 void
 p6est_destroy (p6est_t * p6est)
 {
+  p6est_destroy_ext(p6est, 1);
+}
+
+void
+p6est_destroy_ext (p6est_t * p6est, int free_p6est)
+{
   sc_array_t         *layers = p6est->layers;
   size_t              layercount = layers->elem_count;
   size_t              zz;
@@ -565,7 +583,8 @@ p6est_destroy (p6est_t * p6est)
   sc_mempool_destroy (p6est->layer_pool);
   p6est_comm_parallel_env_release (p6est);
   P4EST_FREE (p6est->global_first_layer);
-  P4EST_FREE (p6est);
+  if (free_p6est)
+    P4EST_FREE (p6est);
 }
 
 p6est_t            *

--- a/src/p6est_extended.h
+++ b/src/p6est_extended.h
@@ -71,6 +71,56 @@ p6est_t            *p6est_new_ext (sc_MPI_Comm mpicomm,
                                    int fill_uniform, size_t data_size,
                                    p6est_init_t init_fn, void *user_pointer);
 
+/** Initialize a preallocated forest.
+ * This is a more general form of p6est_new_ext.
+ * See the documentation of p6est_new_ext for basic usage.
+ *
+ * \param [int, out] p6est    preallocated p6est
+ * \param [in] mpicomm        A valid MPI communicator.
+ * \param [in] connectivity   This is the connectivity information that
+ *                            the forest is built with.  Note the p6est
+ *                            does not take ownership of the memory.
+ * \param [in] min_quadrants  Minimum initial quadrants per processor.
+ *                            Makes the refinement pattern mpisize-specific.
+ * \param [in] min_level      The forest is horizontally refined at least to
+ *                            this level.  May be negative or 0, then it has
+ *                            no effect.
+ * \param [in] min_zlevel     The forest is vertically refined at least to
+ *                            this level.  May be negative or 0, then it has
+ *                            no effect.
+ * \parem [in] num_zroot      The number of "root" vertical layers
+ *                            (used when non-power-of-2 layers are desired)
+ * \param [in] fill_uniform   If true, fill the forest with a uniform mesh
+ *                            instead of the coarsest possible one.
+ *                            The latter is partition-specific so that
+ *                            is usually not a good idea.
+ * \param [in] data_size      This is the size of data for each quadrant which
+ *                            can be zero.  Then user_data_pool is set to NULL.
+ * \param [in] init_fn        Callback function to initialize the user_data
+ *                            which is already allocated automatically.
+ * \param [in] user_pointer   Assign to the user_pointer member of the p6est
+ *                            before init_fn is called the first time.
+ *
+ * \note The connectivity structure must not be destroyed
+ *       during the lifetime of this forest.
+ */
+void                p6est_init_ext (p6est_t * p6est, sc_MPI_Comm mpicomm,
+                                    p6est_connectivity_t * connectivity,
+                                    p4est_locidx_t min_quadrants,
+                                    int min_level, int min_zlevel,
+                                    int num_zroot,
+                                    int fill_uniform, size_t data_size,
+                                    p6est_init_t init_fn, void *user_pointer);
+
+/** Destroy a p6est
+ * \param [in,out] p6est   p6est to destroy
+ * \param [in] free_p6est  Boolean on whether the p6est_t pointer should be
+ *                         freed
+ *
+ * \note The connectivity structure is not destroyed with the p6est.
+ */
+void                p6est_destroy_ext (p6est_t * p6est, int free_p6est);
+
 /** Make a deep copy of a p6est.
  * The connectivity is not duplicated.
  * Copying of quadrant user data is optional.

--- a/src/p8est_extended.h
+++ b/src/p8est_extended.h
@@ -130,6 +130,49 @@ p8est_t            *p8est_new_ext (sc_MPI_Comm mpicomm,
                                    size_t data_size, p8est_init_t init_fn,
                                    void *user_pointer);
 
+/** Initialize a preallocated forest.
+ * The initializes forest consists of equi-partitioned root quadrants.
+ * When there are more processors than trees, some processors are empty.
+ *
+ * \param [in,out] p8est       preallocated p8est
+ * \param [in] mpicomm         A valid MPI communicator.
+ * \param [in] connectivity    This is the connectivity information that
+ *                             the forest is built with.  Note the p8est
+ *                             does not take ownership of the memory.
+ * \param [in] min_quadrants   Minimum initial quadrants per processor.
+ *                             Makes the refinement pattern mpisize-specific.
+ * \param [in] min_level       The forest is refined at least to this level.
+ *                             May be negative or 0, then it has no effect.
+ * \param [in] fill_uniform    If true, fill the forest with a uniform mesh
+ *                             instead of the coarsest possible one.
+ *                             The latter is partition-specific so that
+ *                             is usually not a good idea.
+ * \param [in] data_size       This is the size of data for each quadrant which
+ *                             can be zero.  Then user_data_pool is set to NULL.
+ * \param [in] init_fn         Callback function to initialize the user_data
+ *                             which is already allocated automatically.
+ * \param [in] user_pointer    Assign to the user_pointer member of the p8est
+ *                             before init_fn is called the first time.
+ *
+ * \note The connectivity structure must not be destroyed
+ *       during the lifetime of this forest.
+ */
+void                p8est_init_ext (p8est_t * p8est, sc_MPI_Comm mpicomm,
+                                    p8est_connectivity_t * connectivity,
+                                    p4est_locidx_t min_quadrants,
+                                    int min_level, int fill_uniform,
+                                    size_t data_size, p8est_init_t init_fn,
+                                    void *user_pointer);
+
+/** Destroy a p8est
+ * \param [in,out] p8est   p8est to destroy
+ * \param [in] free_p8est  Boolean on whether the p8est_t pointer should be
+ *                         freed
+ *
+ * \note The connectivity structure is not destroyed with the p8est.
+ */
+void                p8est_destroy_ext (p8est_t * p8est, int free_p8est);
+
 /** Create a new mesh.
  * \param [in] p8est                A forest that is fully 2:1 balanced.
  * \param [in] ghost                The ghost layer created from the


### PR DESCRIPTION
In an application I'm working on it was convenient to allow the user to be in charge of allocating the p4est_t/p8est_t. Thought this might be of use to others.