### PR TITLE
add version functions

### DIFF
--- a/doc/author_ranocha.txt
+++ b/doc/author_ranocha.txt
@@ -1,0 +1,1 @@
+I place my contributions to p4est under the FreeBSD license. Hendrik Ranocha

--- a/src/p4est_base.c
+++ b/src/p4est_base.c
@@ -121,4 +121,36 @@ P4EST_LOG_IMP (ESSENTIAL, ESSENTIAL)
 P4EST_LOG_IMP (LERROR, ERROR)
 /* *INDENT-ON* */
 
+const char         *
+p4est_version (void)
+{
+  return P4EST_VERSION;
+}
+
+int
+p4est_version_major (void)
+{
+  return P4EST_VERSION_MAJOR;
+}
+
+int
+p4est_version_minor (void)
+{
+  return P4EST_VERSION_MINOR;
+}
+
+/* Define helper macros temporally to convert the point version */
+#define _TOSTRING(x) #x
+#define TOSTRING(x) _TOSTRING(x)
+
+int
+p4est_version_point (void)
+{
+  /* P4EST_VERSION_POINT may contain a dot and/or dash, followed by additional information */
+  return strtol (TOSTRING (P4EST_VERSION_POINT), NULL, 10);
+}
+
+#undef TOSTRING
+#undef _TOSTRING
+
 #endif

--- a/src/p4est_base.c
+++ b/src/p4est_base.c
@@ -139,12 +139,4 @@ p4est_version_minor (void)
   return P4EST_VERSION_MINOR;
 }
 
-int
-p4est_version_point (void)
-{
-  /* P4EST_VERSION_POINT may contain a dot and/or dash,
-     followed by additional information */
-  return atoi (SC_TOSTRING (P4EST_VERSION_POINT));
-}
-
 #endif

--- a/src/p4est_base.c
+++ b/src/p4est_base.c
@@ -139,16 +139,12 @@ p4est_version_minor (void)
   return P4EST_VERSION_MINOR;
 }
 
-/* Define helper macros to convert the point version */
-#define _P4EST_TOSTRING(x) #x
-#define P4EST_TOSTRING(x) _P4EST_TOSTRING(x)
-
 int
 p4est_version_point (void)
 {
   /* P4EST_VERSION_POINT may contain a dot and/or dash,
      followed by additional information */
-  return strtol (P4EST_TOSTRING (P4EST_VERSION_POINT), NULL, 10);
+  return atoi (SC_TOSTRING (P4EST_VERSION_POINT));
 }
 
 #endif

--- a/src/p4est_base.c
+++ b/src/p4est_base.c
@@ -139,18 +139,16 @@ p4est_version_minor (void)
   return P4EST_VERSION_MINOR;
 }
 
-/* Define helper macros temporally to convert the point version */
-#define _TOSTRING(x) #x
-#define TOSTRING(x) _TOSTRING(x)
+/* Define helper macros to convert the point version */
+#define _P4EST_TOSTRING(x) #x
+#define P4EST_TOSTRING(x) _P4EST_TOSTRING(x)
 
 int
 p4est_version_point (void)
 {
-  /* P4EST_VERSION_POINT may contain a dot and/or dash, followed by additional information */
-  return strtol (TOSTRING (P4EST_VERSION_POINT), NULL, 10);
+  /* P4EST_VERSION_POINT may contain a dot and/or dash,
+     followed by additional information */
+  return strtol (P4EST_TOSTRING (P4EST_VERSION_POINT), NULL, 10);
 }
-
-#undef TOSTRING
-#undef _TOSTRING
 
 #endif

--- a/src/p4est_base.h
+++ b/src/p4est_base.h
@@ -518,6 +518,36 @@ p4est_partition_cut_gloidx (p4est_gloidx_t global_num, int p, int num_procs)
   return result;
 }
 
+/** Return the full version of p4est.
+ *
+ * \return          Return the version of p4est using the format
+ *                  `VERSION_MAJOR.VERSION_MINOR.VERSION_POINT`,
+ *                  where `VERSION_POINT` can contain dots and
+ *                  characters, e.g. to indicate the additional
+ *                  number of commits and a git commit hash.
+ */
+const char         *p4est_version (void);
+
+/** Return the major version of p4est.
+ *
+ * \return          Return the major version of p4est.
+ */
+int                 p4est_version_major (void);
+
+/** Return the minor version of p4est.
+ *
+ * \return          Return the minor version of p4est.
+ */
+int                 p4est_version_minor (void);
+
+/** Return the point version of p4est.
+ *
+ * \return          Return the (first part of the) point version of p4est,
+ *                  without information about the additional number of commits
+ *                  and commit hash.
+ */
+int                 p4est_version_point (void);
+
 SC_EXTERN_C_END;
 
 #endif /* !P4EST_BASE_H */

--- a/src/p4est_base.h
+++ b/src/p4est_base.h
@@ -540,14 +540,6 @@ int                 p4est_version_major (void);
  */
 int                 p4est_version_minor (void);
 
-/** Return the point version of p4est.
- *
- * \return          Return the (first part of the) point version of p4est,
- *                  without information about the additional number of commits
- *                  and commit hash.
- */
-int                 p4est_version_point (void);
-
 SC_EXTERN_C_END;
 
 #endif /* !P4EST_BASE_H */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -22,7 +22,8 @@ p4est_test_programs += \
         test/p4est_test_conn_reduce test/p4est_test_plex \
         test/p4est_test_connrefine \
         test/p4est_test_subcomm \
-        test/p4est_test_nodes
+        test/p4est_test_nodes \
+        test/p4est_test_version
 if P4EST_WITH_METIS
 p4est_test_programs += \
         test/p4est_test_reorder
@@ -45,7 +46,8 @@ p4est_test_programs += \
         test/p8est_test_conn_reduce test/p8est_test_plex \
         test/p8est_test_connrefine \
         test/p8est_test_subcomm \
-        test/p8est_test_nodes
+        test/p8est_test_nodes \
+        test/p8est_test_version
 if P4EST_WITH_METIS
 p4est_test_programs += \
         test/p8est_test_reorder
@@ -96,6 +98,7 @@ test_p4est_test_plex_SOURCES = test/test_plex2.c
 test_p4est_test_connrefine_SOURCES = test/test_connrefine2.c
 test_p4est_test_subcomm_SOURCES = test/test_subcomm2.c
 test_p4est_test_nodes_SOURCES = test/test_nodes2.c
+test_p4est_test_version_SOURCES = test/test_version.c
 if P4EST_WITH_METIS
 test_p4est_test_reorder_SOURCES = test/test_reorder2.c
 endif
@@ -133,6 +136,7 @@ test_p8est_test_plex_SOURCES = test/test_plex3.c
 test_p8est_test_connrefine_SOURCES = test/test_connrefine3.c
 test_p8est_test_subcomm_SOURCES = test/test_subcomm3.c
 test_p8est_test_nodes_SOURCES = test/test_nodes3.c
+test_p8est_test_version_SOURCES = test/test_version.c
 if P4EST_WITH_METIS
 test_p8est_test_reorder_SOURCES = test/test_reorder3.c
 endif
@@ -181,6 +185,7 @@ LINT_CSOURCES += \
         $(test_p4est_test_connrefine_SOURCES) \
         $(test_p4est_test_subcomm_SOURCES) \
         $(test_p4est_test_nodes_SOURCES) \
+        $(test_p4est_test_version_SOURCES) \
         $(test_p8est_test_quadrants_SOURCES) \
         $(test_p8est_test_balance_SOURCES) \
         $(test_p8est_test_partition_SOURCES) \
@@ -209,6 +214,7 @@ LINT_CSOURCES += \
         $(test_p8est_test_connrefine_SOURCES) \
         $(test_p8est_test_subcomm_SOURCES) \
         $(test_p8est_test_nodes_SOURCES) \
+        $(test_p8est_test_version_SOURCES) \
         $(test_p6est_test_all_SOURCES)
 
 if P4EST_WITH_METIS

--- a/test/test_version.c
+++ b/test/test_version.c
@@ -36,7 +36,7 @@ main (int argc, char **argv)
   int                 mpiret;
   sc_MPI_Comm         mpicomm;
   int                 num_failed_tests;
-  int                 version_major, version_minor, version_point;
+  int                 version_major, version_minor;
   const char         *version;
   char                version_tmp[32];
 
@@ -66,15 +66,6 @@ main (int argc, char **argv)
   snprintf (version_tmp, 32, "%d.%d", version_major, version_minor);
   if (strncmp (version, version_tmp, strlen (version_tmp))) {
     SC_VERBOSE ("Test failure for minor version of p4est\n");
-    num_failed_tests++;
-  }
-
-  version_point = p4est_version_point ();
-  SC_GLOBAL_LDEBUGF ("Point p4est version: %d\n", version_point);
-  snprintf (version_tmp, 32, "%d.%d.%d", version_major, version_minor,
-            version_point);
-  if (strncmp (version, version_tmp, strlen (version_tmp))) {
-    SC_VERBOSE ("Test failure for point version of p4est\n");
     num_failed_tests++;
   }
 

--- a/test/test_version.c
+++ b/test/test_version.c
@@ -57,7 +57,7 @@ main (int argc, char **argv)
   SC_GLOBAL_LDEBUGF ("Major p4est version: %d\n", version_major);
   snprintf (version_tmp, 32, "%d", version_major);
   if (strncmp (version, version_tmp, strlen (version_tmp))) {
-    SC_VERBOSE ("Test failure for major version of p4est\n");
+    SC_GLOBAL_VERBOSE ("Test failure for major version of p4est\n");
     num_failed_tests++;
   }
 
@@ -65,7 +65,7 @@ main (int argc, char **argv)
   SC_GLOBAL_LDEBUGF ("Minor p4est version: %d\n", version_minor);
   snprintf (version_tmp, 32, "%d.%d", version_major, version_minor);
   if (strncmp (version, version_tmp, strlen (version_tmp))) {
-    SC_VERBOSE ("Test failure for minor version of p4est\n");
+    SC_GLOBAL_VERBOSE ("Test failure for minor version of p4est\n");
     num_failed_tests++;
   }
 

--- a/test/test_version.c
+++ b/test/test_version.c
@@ -1,0 +1,88 @@
+/*
+  This file is part of p4est.
+  p4est is a C library to manage a collection (a forest) of multiple
+  connected adaptive quadtrees or octrees in parallel.
+
+  Copyright (C) 2010 The University of Texas System
+  Additional copyright (C) 2011 individual authors
+  Written by Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac
+
+  p4est is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  p4est is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with p4est; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#ifndef P4_TO_P8
+#include <p4est.h>
+#else
+#include <p8est.h>
+#endif
+#include <stdio.h>
+#include <string.h>
+
+int
+main (int argc, char **argv)
+{
+  int                 mpiret;
+  sc_MPI_Comm         mpicomm;
+  int                 num_failed_tests;
+  int                 version_major, version_minor, version_point;
+  const char         *version;
+  char                version_tmp[32];
+
+  /* standard initialization */
+  mpiret = sc_MPI_Init (&argc, &argv);
+  SC_CHECK_MPI (mpiret);
+  mpicomm = sc_MPI_COMM_WORLD;
+
+  sc_init (mpicomm, 1, 1, NULL, SC_LP_DEFAULT);
+  p4est_init (NULL, SC_LP_DEFAULT);
+
+  /* check all functions related to version numbers of p4est */
+  num_failed_tests = 0;
+  version = p4est_version ();
+  SC_GLOBAL_LDEBUGF ("Full p4est version: %s\n", version);
+
+  version_major = p4est_version_major ();
+  SC_GLOBAL_LDEBUGF ("Major p4est version: %d\n", version_major);
+  snprintf (version_tmp, 32, "%d", version_major);
+  if (strncmp (version, version_tmp, strlen (version_tmp))) {
+    SC_VERBOSE ("Test failure for major version of p4est\n");
+    num_failed_tests++;
+  }
+
+  version_minor = p4est_version_minor ();
+  SC_GLOBAL_LDEBUGF ("Minor p4est version: %d\n", version_minor);
+  snprintf (version_tmp, 32, "%d.%d", version_major, version_minor);
+  if (strncmp (version, version_tmp, strlen (version_tmp))) {
+    SC_VERBOSE ("Test failure for minor version of p4est\n");
+    num_failed_tests++;
+  }
+
+  version_point = p4est_version_point ();
+  SC_GLOBAL_LDEBUGF ("Point p4est version: %d\n", version_point);
+  snprintf (version_tmp, 32, "%d.%d.%d", version_major, version_minor,
+            version_point);
+  if (strncmp (version, version_tmp, strlen (version_tmp))) {
+    SC_VERBOSE ("Test failure for point version of p4est\n");
+    num_failed_tests++;
+  }
+
+  /* clean up and exit */
+  sc_finalize ();
+
+  mpiret = sc_MPI_Finalize ();
+  SC_CHECK_MPI (mpiret);
+
+  return num_failed_tests ? 1 : 0;
+}

--- a/test/test_version.c
+++ b/test/test_version.c
@@ -22,13 +22,7 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-#ifndef P4_TO_P8
-#include <p4est.h>
-#else
-#include <p8est.h>
-#endif
-#include <stdio.h>
-#include <string.h>
+#include <p4est_base.h>
 
 int
 main (int argc, char **argv)


### PR DESCRIPTION
This PR is similar to https://github.com/cburstedde/libsc/pull/24 and https://github.com/cburstedde/libsc/pull/25.
- I implemented functions returning the full version as string and the major/minor/point versions as `int`s.
- I added corresponding tests and verified that they pass locally.
- I added a license statement for my contributions in `docs`.
- I ran `p4estindent` and discarded changes to `__attribute__`.