### PR TITLE
Exposing 'p4est_vtk_write_cell_datav' function

### DIFF
--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -412,6 +412,7 @@
 #define p4est_vtk_write_file            p8est_vtk_write_file
 #define p4est_vtk_write_header          p8est_vtk_write_header
 #define p4est_vtk_write_cell_dataf      p8est_vtk_write_cell_dataf
+#define p4est_vtk_write_cell_datav      p8est_vtk_write_cell_datav
 #define p4est_vtk_write_cell_data       p8est_vtk_write_cell_data
 #define p4est_vtk_write_point_dataf     p8est_vtk_write_point_dataf
 #define p4est_vtk_write_point_data      p8est_vtk_write_point_data

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -403,6 +403,8 @@
 #define p4est_geometry_destroy          p8est_geometry_destroy
 #define p4est_geometry_new_connectivity p8est_geometry_new_connectivity
 
+
+//asdasd
 /* functions in p4est_vtk */
 #define p4est_vtk_context_new           p8est_vtk_context_new
 #define p4est_vtk_context_destroy       p8est_vtk_context_destroy

--- a/src/p4est_vtk.c
+++ b/src/p4est_vtk.c
@@ -1009,27 +1009,7 @@ p4est_vtk_write_point_dataf (p4est_vtk_context_t * cont,
   return cont;
 }
 
-/** Write VTK cell data.
- *
- * This function exports custom cell data to the vtk file; it is functionally
- * the same as \b p4est_vtk_write_cell_dataf with the only difference being
- * that instead of a variable argument list, an initialized \a va_list is
- * passed as the last argument. The \a va_list is initialized from the variable
- * argument list of the calling function.
- *
- * \note This function is actually called from \b p4est_vtk_write_cell_dataf
- * and does all of the work.
- *
- * \param [in,out] cont    A vtk context created by \ref p4est_vtk_context_new.
- * \param [in] num_point_scalars Number of point scalar datasets to output.
- * \param [in] num_point_vectors Number of point vector datasets to output.
- * \param [in,out] ap      An initialized va_list used to access the
- *                         scalar/vector data.
- *
- * \return          On success, the context that has been passed in.
- *                  On failure, returns NULL and deallocates the context.
- */
-static p4est_vtk_context_t *
+p4est_vtk_context_t *
 p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
                             int write_tree, int write_level,
                             int write_rank, int wrap_rank,

--- a/src/p4est_vtk.h
+++ b/src/p4est_vtk.h
@@ -200,6 +200,45 @@ p4est_vtk_context_t *p4est_vtk_write_cell_dataf (p4est_vtk_context_t * cont,
                                                  int num_cell_scalars,
                                                  int num_cell_vectors, ...);
 
+/** Write VTK cell data.
+ *
+ * This function exports custom cell data to the vtk file; it is functionally
+ * the same as \b p4est_vtk_write_cell_dataf with the only difference being
+ * that instead of a variable argument list, an initialized \a va_list is
+ * passed as the last argument. That means \a va_start has already been called.
+ * The \a va_list is initialized from the variable
+ * argument list of the calling function. Elements of va_list are processed as "pairs" of (fieldname, fieldvalues).
+ * That means <va_list[0], va_list[1]> represents one pair, <va_list[2], va_list[3]> next one and so on.
+ * Each 'fieldname' shall be a char string containing the name of the data
+ * contained in the following 'fieldvalues'. Each of the 'fieldvalues'
+ * shall be an sc_array_t * holding double variables.
+ * The cell scalar pairs come first, followed by the cell vector pairs, followed
+ * by VTK context \a cont (same as the first argument).
+ * The number of * doubles in each sc_array must be exactly \a p4est->local_num_quadrants for
+ * scalar data and \a 3*p4est->local_num_quadrants for vector data.
+ *
+ * \note This function is actually called from \b p4est_vtk_write_cell_dataf
+ * and does all of the work.
+ *
+ * \param [in,out] cont    A vtk context created by \ref p4est_vtk_context_new.
+ * \param [in] num_point_scalars Non-negative number of point scalar datasets to output.
+ * \param [in] num_point_vectors Non-negative number of point vector datasets to output.
+ * \param [in,out] ap      An initialized va_list used to access the
+ *                         scalar/vector data.
+ *
+ * \return          On success, the context that has been passed in.
+ *                  On failure, returns NULL and deallocates the context.
+ *
+ * \note Using P4EST_ASSERT (num_cell_scalars >= 0 && num_cell_vectors >= 0) before calling this function might prove beneficial.
+ *
+ */
+p4est_vtk_context_t *
+p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
+                            int write_tree, int write_level,
+                            int write_rank, int wrap_rank,
+                            int num_cell_scalars,
+                            int num_cell_vectors, va_list ap);
+
 /** This is an alternate version of the varargs function.
  * Works exactly the same otherwise.
  * TODO: implement, also for vectors and point data.


### PR DESCRIPTION
# Exposing `p4est_vtk_write_cell_datav` function for users.

Following up on issue #94 

Proposed changes:
Exposed already implemented function `p4est_vtk_write_cell_datav` for writing vtk cell data using va_list instead of only variadic arguments.

Added (I hope) clear enough doxygen documentation on usage.

Useful for wrapping possibilities, since variadic arguments cannot be passed any other way than va_list.


