### PR TITLE
Exposed 'p4est_vtk_write_cell_datav' function for users

### DIFF
--- a/doc/author_krasnansky.txt
+++ b/doc/author_krasnansky.txt
@@ -1,0 +1,1 @@
+I place my contributions to p4est under FreeBSD license. Juraj Krasnansky (xkrasnanskyj@stuba.sk)

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -412,6 +412,7 @@
 #define p4est_vtk_write_file            p8est_vtk_write_file
 #define p4est_vtk_write_header          p8est_vtk_write_header
 #define p4est_vtk_write_cell_dataf      p8est_vtk_write_cell_dataf
+#define p4est_vtk_write_cell_datav      p8est_vtk_write_cell_datav
 #define p4est_vtk_write_cell_data       p8est_vtk_write_cell_data
 #define p4est_vtk_write_point_dataf     p8est_vtk_write_point_dataf
 #define p4est_vtk_write_point_data      p8est_vtk_write_point_data

--- a/src/p4est_vtk.c
+++ b/src/p4est_vtk.c
@@ -1009,27 +1009,7 @@ p4est_vtk_write_point_dataf (p4est_vtk_context_t * cont,
   return cont;
 }
 
-/** Write VTK cell data.
- *
- * This function exports custom cell data to the vtk file; it is functionally
- * the same as \b p4est_vtk_write_cell_dataf with the only difference being
- * that instead of a variable argument list, an initialized \a va_list is
- * passed as the last argument. The \a va_list is initialized from the variable
- * argument list of the calling function.
- *
- * \note This function is actually called from \b p4est_vtk_write_cell_dataf
- * and does all of the work.
- *
- * \param [in,out] cont    A vtk context created by \ref p4est_vtk_context_new.
- * \param [in] num_point_scalars Number of point scalar datasets to output.
- * \param [in] num_point_vectors Number of point vector datasets to output.
- * \param [in,out] ap      An initialized va_list used to access the
- *                         scalar/vector data.
- *
- * \return          On success, the context that has been passed in.
- *                  On failure, returns NULL and deallocates the context.
- */
-static p4est_vtk_context_t *
+p4est_vtk_context_t *
 p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
                             int write_tree, int write_level,
                             int write_rank, int wrap_rank,

--- a/src/p4est_vtk.c
+++ b/src/p4est_vtk.c
@@ -1044,6 +1044,7 @@ p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
   char                vtkCellDataString[BUFSIZ] = "";
   int                 printed = 0;
 
+  P4EST_ASSERT (num_cell_scalars >= 0 && num_cell_vectors >= 0);
   P4EST_ASSERT (cont != NULL && cont->writing);
   P4EST_ASSERT (wrap_rank >= 0);
 

--- a/src/p4est_vtk.h
+++ b/src/p4est_vtk.h
@@ -220,16 +220,21 @@ p4est_vtk_context_t *p4est_vtk_write_cell_dataf (p4est_vtk_context_t * cont,
  * \note This function is actually called from \b p4est_vtk_write_cell_dataf
  * and does all of the work.
  *
- * \param [in,out] cont    A vtk context created by \ref p4est_vtk_context_new.
- * \param [in] num_point_scalars Non-negative number of point scalar datasets to output.
- * \param [in] num_point_vectors Non-negative number of point vector datasets to output.
+ * \param [in,out] cont    A VTK context created by \ref p4est_vtk_context_new.
+ * \param [in] write_tree  Boolean to determine if the tree id should be output.
+ * \param [in] write_level Boolean to determine if the tree levels should be output.
+ * \param [in] write_rank  Boolean to determine if the MPI rank should be output.
+ * \param [in] wrap_rank   Number to wrap around the rank with a modulo operation.
+ *                         Can be 0 for no wrapping.
+ * \param [in] num_cell_scalars Number of cell scalar datasets to output.
+ * \param [in] num_cell_vectors Number of cell vector datasets to output.
  * \param [in,out] ap      An initialized va_list used to access the
  *                         scalar/vector data.
  *
  * \return          On success, the context that has been passed in.
  *                  On failure, returns NULL and deallocates the context.
  *
- * \note Using P4EST_ASSERT (num_cell_scalars >= 0 && num_cell_vectors >= 0) before calling this function might prove beneficial.
+ * 
  *
  */
 p4est_vtk_context_t *

--- a/src/p4est_vtk.h
+++ b/src/p4est_vtk.h
@@ -200,6 +200,45 @@ p4est_vtk_context_t *p4est_vtk_write_cell_dataf (p4est_vtk_context_t * cont,
                                                  int num_cell_scalars,
                                                  int num_cell_vectors, ...);
 
+/** Write VTK cell data.
+ *
+ * This function exports custom cell data to the vtk file; it is functionally
+ * the same as \b p4est_vtk_write_cell_dataf with the only difference being
+ * that instead of a variable argument list, an initialized \a va_list is
+ * passed as the last argument. That means \a va_start has already been called.
+ * The \a va_list is initialized from the variable
+ * argument list of the calling function. Elements of va_list are processed as "pairs" of (fieldname, fieldvalues).
+ * That means <va_list[0], va_list[1]> represents one pair, <va_list[2], va_list[3]> next one and so on.
+ * Each 'fieldname' shall be a char string containing the name of the data
+ * contained in the following 'fieldvalues'. Each of the 'fieldvalues'
+ * shall be an sc_array_t * holding double variables.
+ * The cell scalar pairs come first, followed by the cell vector pairs, followed
+ * by VTK context \a cont (same as the first argument).
+ * The number of * doubles in each sc_array must be exactly \a p4est->local_num_quadrants for
+ * scalar data and \a 3*p4est->local_num_quadrants for vector data.
+ *
+ * \note This function is actually called from \b p4est_vtk_write_cell_dataf
+ * and does all of the work.
+ *
+ * \param [in,out] cont    A vtk context created by \ref p4est_vtk_context_new.
+ * \param [in] num_point_scalars Non-negative number of point scalar datasets to output.
+ * \param [in] num_point_vectors Non-negative number of point vector datasets to output.
+ * \param [in,out] ap      An initialized va_list used to access the
+ *                         scalar/vector data.
+ *
+ * \return          On success, the context that has been passed in.
+ *                  On failure, returns NULL and deallocates the context.
+ *
+ * \note Using P4EST_ASSERT (num_cell_scalars >= 0 && num_cell_vectors >= 0) before calling this function might prove beneficial.
+ *
+ */
+p4est_vtk_context_t *
+p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
+                            int write_tree, int write_level,
+                            int write_rank, int wrap_rank,
+                            int num_cell_scalars,
+                            int num_cell_vectors, va_list ap);
+
 /** This is an alternate version of the varargs function.
  * Works exactly the same otherwise.
  * TODO: implement, also for vectors and point data.

--- a/src/p8est_vtk.h
+++ b/src/p8est_vtk.h
@@ -180,8 +180,8 @@ p8est_vtk_context_t *p8est_vtk_write_header (p8est_vtk_context_t * cont);
  * Each 'fieldname' argument shall be a char string containing the name of the data
  * contained in the following 'fieldvalues'.  Each of the 'fieldvalues'
  * arguments shall be an sc_array_t * holding double variables.  The number of
- * doubles in each sc_array must be exactly \a p4est->local_num_quadrants for
- * scalar data and \a 3*p4est->local_num_quadrants for vector data.
+ * doubles in each sc_array must be exactly \a p8est->local_num_quadrants for
+ * scalar data and \a 3*p8est->local_num_quadrants for vector data.
  *
  * \note The current p8est_vtk_context_t structure, \a cont, must be the first
  * and the last argument
@@ -198,6 +198,51 @@ p8est_vtk_context_t *p8est_vtk_write_cell_dataf (p8est_vtk_context_t * cont,
                                                  int wrap_rank,
                                                  int num_cell_scalars,
                                                  int num_cell_vectors, ...);
+
+/** Write VTK cell data.
+ *
+ * This function exports custom cell data to the vtk file; it is functionally
+ * the same as \b p8est_vtk_write_cell_dataf with the only difference being
+ * that instead of a variable argument list, an initialized \a va_list is
+ * passed as the last argument. That means \a va_start has already been called.
+ * The \a va_list is initialized from the variable
+ * argument list of the calling function. Elements of va_list are processed as "pairs" of (fieldname, fieldvalues).
+ * That means <va_list[0], va_list[1]> represents one pair, <va_list[2], va_list[3]> next one and so on.
+ * Each 'fieldname' shall be a char string containing the name of the data
+ * contained in the following 'fieldvalues'. Each of the 'fieldvalues'
+ * shall be an sc_array_t * holding double variables.
+ * The cell scalar pairs come first, followed by the cell vector pairs, followed
+ * by VTK context \a cont (same as the first argument).
+ * The number of * doubles in each sc_array must be exactly \a p8est->local_num_quadrants for
+ * scalar data and \a 3*p8est->local_num_quadrants for vector data.
+ *
+ * \note This function is actually called from \b p8est_vtk_write_cell_dataf
+ * and does all of the work.
+ *
+ * \param [in,out] cont    A VTK context created by \ref p8est_vtk_context_new.
+ * \param [in] write_tree  Boolean to determine if the tree id should be output.
+ * \param [in] write_level Boolean to determine if the tree levels should be output.
+ * \param [in] write_rank  Boolean to determine if the MPI rank should be output.
+ * \param [in] wrap_rank   Number to wrap around the rank with a modulo operation.
+ *                         Can be 0 for no wrapping.
+ * \param [in] num_cell_scalars Number of cell scalar datasets to output.
+ * \param [in] num_cell_vectors Number of cell vector datasets to output.
+ * \param [in,out] ap      An initialized va_list used to access the
+ *                         scalar/vector data.
+ *
+ * \return          On success, the context that has been passed in.
+ *                  On failure, returns NULL and deallocates the context.
+ *
+ * 
+ *
+ */
+
+p8est_vtk_context_t *
+p8est_vtk_write_cell_datav (p8est_vtk_context_t * cont,
+                            int write_tree, int write_level,
+                            int write_rank, int wrap_rank,
+                            int num_cell_scalars,
+                            int num_cell_vectors, va_list ap);
 
 /** Write VTK point data.
  *


### PR DESCRIPTION
# Exposed `p4est_vtk_write_cell_datav` function

Following up on issue #94

Proposed changes:
Exposed already implemented function `p4est_vtk_write_cell_datav` for writing vtk cell data using va_list instead of only variadic arguments.

Added (I hope) clear enough doxygen documentation on usage.

Useful for wrapping possibilities, since variadic arguments cannot be passed any other way than va_list.