### PR TITLE
Fix accidentally enlarged ghost layer in p4est_ghost_expand

### DIFF
--- a/src/p4est_ghost.c
+++ b/src/p4est_ghost.c
@@ -3762,10 +3762,9 @@ p4est_ghost_expand_internal (p4est_t * p4est, p4est_lnodes_t * lnodes,
       sc_array_uniq (buf, p4est_quadrant_compare_piggy);
     }
 
+    sc_array_resize (ghost_layer, (size_t) (old_num_ghosts + num_new_ghosts));
     if (num_new_ghosts) {
       /* update the ghost layer */
-      sc_array_resize (ghost_layer,
-                       (size_t) (old_num_ghosts + num_new_ghosts));
       sc_array_sort (ghost_layer, p4est_quadrant_compare_piggy);
       sc_array_uniq (ghost_layer, p4est_quadrant_compare_piggy);
 


### PR DESCRIPTION
Following up on issue #98.

Proposed changes: fix bug where the ghost layer accidentally wasn't resized correctly if none of the proposed new ghost quadrants was actually new.