### PR TITLE
Vtk cell data memory leak

### DIFF
--- a/src/p4est_vtk.c
+++ b/src/p4est_vtk.c
@@ -1104,7 +1104,6 @@ p4est_vtk_write_cell_data (p4est_vtk_context_t * cont,
   p4est_topidx_t      jt;
   p4est_locidx_t      il;
 
-  p4est_vtk_context_t *list_end;
   char                vtkCellDataString[BUFSIZ] = "";
   int                 printed = 0;
 

--- a/src/p4est_vtk.c
+++ b/src/p4est_vtk.c
@@ -1195,7 +1195,6 @@ p4est_vtk_write_cell_data (p4est_vtk_context_t * cont,
 
 #ifndef P4EST_VTK_ASCII
   locidx_data = P4EST_ALLOC (p4est_locidx_t, Ncells);
-  uint8_data = P4EST_ALLOC (uint8_t, Ncells);
 #endif
 
   if (write_tree) {
@@ -1231,7 +1230,6 @@ p4est_vtk_write_cell_data (p4est_vtk_context_t * cont,
 
       P4EST_FREE (names);
       P4EST_FREE (locidx_data);
-      P4EST_FREE (uint8_data);
 
       return NULL;
     }
@@ -1241,6 +1239,10 @@ p4est_vtk_write_cell_data (p4est_vtk_context_t * cont,
   }
 
   if (write_level) {
+#ifndef P4EST_VTK_ASCII  
+  uint8_data = P4EST_ALLOC (uint8_t, Ncells);
+#endif
+
     fprintf (cont->vtufile, "        <DataArray type=\"%s\" Name=\"level\""
              " format=\"%s\">\n", "UInt8", P4EST_VTK_FORMAT_STRING);
 #ifdef P4EST_VTK_ASCII
@@ -1311,13 +1313,12 @@ p4est_vtk_write_cell_data (p4est_vtk_context_t * cont,
                                      sizeof (*locidx_data) * Ncells);
     fprintf (cont->vtufile, "\n");
 
-    P4EST_FREE (locidx_data);
-
     if (retval) {
       P4EST_LERROR (P4EST_STRING "_vtk: Error encoding types\n");
       p4est_vtk_context_destroy (cont);
 
       P4EST_FREE (names);
+      P4EST_FREE (locidx_data);
 
       return NULL;
     }
@@ -1331,9 +1332,14 @@ p4est_vtk_write_cell_data (p4est_vtk_context_t * cont,
     p4est_vtk_context_destroy (cont);
 
     P4EST_FREE (names);
+    P4EST_FREE (locidx_data);
 
     return NULL;
   }
+
+#ifndef P4EST_VTK_ASCII
+  P4EST_FREE (locidx_data);
+#endif
 
   all = 0;
   for (i = 0; i < num_cell_scalars; ++all, ++i) {

--- a/src/p4est_vtk.c
+++ b/src/p4est_vtk.c
@@ -820,7 +820,6 @@ p4est_vtk_write_header (p4est_vtk_context_t * cont)
  * argument list of the calling function.
  *
  * \note This function is actually called from \b p4est_vtk_write_point_dataf
- * and does all of the work.
  *
  * \param [in,out] cont    A vtk context created by \ref p4est_vtk_context_new.
  * \param [in] num_point_scalars Number of point scalar datasets to output.
@@ -1016,7 +1015,73 @@ p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
                             int num_cell_scalars,
                             int num_cell_vectors, va_list ap)
 {
-  const int           mpirank = cont->p4est->mpirank;
+  int                  i;
+  const char         **names;
+  sc_array_t         **values;
+  p4est_vtk_context_t *list_end = NULL, *retContext = NULL;
+
+  P4EST_ASSERT (num_cell_scalars >= 0 && num_cell_vectors >= 0);
+  P4EST_ASSERT (cont != NULL && cont->writing);
+  P4EST_ASSERT (wrap_rank >= 0);
+
+  names = P4EST_ALLOC (const char *, num_cell_scalars + num_cell_vectors);
+  values = P4EST_ALLOC (sc_array_t *, num_cell_scalars + num_cell_vectors);  
+
+  for (i = 0; i < num_cell_scalars + num_cell_vectors; ++i)
+  {
+    names[i] = va_arg(ap, const char *);
+    values[i] = va_arg(ap, sc_array_t *);
+  }
+
+  /* Check for pointer variable marking the end of variable data input. */
+  list_end = va_arg (ap, p4est_vtk_context_t *);
+  SC_CHECK_ABORT (list_end == cont,
+                  P4EST_STRING "_vtk Error: the end of variable data must be"
+                  " specified by passing, as the last argument, the current "
+                  P4EST_STRING "_vtk_context_t pointer.  See " P4EST_STRING
+                  "_vtk.h for more information.");
+
+  retContext = p4est_vtk_write_cell_data(cont, write_tree, write_level, write_rank, wrap_rank, num_cell_scalars, num_cell_vectors, names, values);
+
+  P4EST_FREE(values);
+  P4EST_FREE(names);
+
+  return retContext;
+}
+
+p4est_vtk_context_t *
+p4est_vtk_write_cell_dataf (p4est_vtk_context_t * cont,
+                            int write_tree, int write_level,
+                            int write_rank, int wrap_rank,
+                            int num_cell_scalars, int num_cell_vectors, ...)
+{
+  va_list             ap;
+
+  P4EST_ASSERT (cont != NULL && cont->writing);
+  P4EST_ASSERT (num_cell_scalars >= 0 && num_cell_vectors >= 0);
+
+  va_start (ap, num_cell_vectors);
+  cont = p4est_vtk_write_cell_datav (cont,
+                                     write_tree, write_level,
+                                     write_rank, wrap_rank,
+                                     num_cell_scalars, num_cell_vectors, ap);
+  va_end (ap);
+
+  return cont;
+}
+
+p4est_vtk_context_t *
+p4est_vtk_write_cell_data (p4est_vtk_context_t * cont,
+                                                int write_tree,
+                                                int write_level,
+                                                int write_rank,
+                                                int wrap_rank,
+                                                int num_cell_scalars,
+                                                int num_cell_vectors,
+                                                const char *fieldnames[],
+                                                sc_array_t * values[])
+{
+ const int           mpirank = cont->p4est->mpirank;
   int                 retval;
   int                 i, all = 0;
   int                 scalar_strlen, vector_strlen;
@@ -1027,7 +1092,6 @@ p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
   const p4est_locidx_t Ncells = cont->p4est->local_num_quadrants;
   char                cell_scalars[BUFSIZ], cell_vectors[BUFSIZ];
   const char         *name, **names;
-  sc_array_t        **values;
   size_t              num_quads, zz;
   sc_array_t         *quadrants;
   p4est_quadrant_t   *quad;
@@ -1054,20 +1118,18 @@ p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
        || num_cell_scalars || num_cell_vectors))
     return cont;
 
-  values = P4EST_ALLOC (sc_array_t *, num_cell_scalars + num_cell_vectors);
   names = P4EST_ALLOC (const char *, num_cell_scalars + num_cell_vectors);
 
   /* Gather cell data. */
   scalar_strlen = 0;
   cell_scalars[0] = '\0';
   for (i = 0; i < num_cell_scalars; ++all, ++i) {
-    name = names[all] = va_arg (ap, const char *);
+    name = names[all] = fieldnames[all];
     retval = snprintf (cell_scalars + scalar_strlen, BUFSIZ - scalar_strlen,
                        "%s%s", i == 0 ? "" : ",", name);
     SC_CHECK_ABORT (retval > 0,
                     P4EST_STRING "_vtk: Error collecting cell scalars");
     scalar_strlen += retval;
-    values[all] = va_arg (ap, sc_array_t *);
 
     /* Validate input. */
     SC_CHECK_ABORT (values[all]->elem_size == sizeof (double),
@@ -1085,13 +1147,12 @@ p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
   vector_strlen = 0;
   cell_vectors[0] = '\0';
   for (i = 0; i < num_cell_vectors; ++all, ++i) {
-    name = names[all] = va_arg (ap, const char *);
+    name = names[all] = fieldnames[all];
     retval = snprintf (cell_vectors + vector_strlen, BUFSIZ - vector_strlen,
                        "%s%s", i == 0 ? "" : ",", name);
     SC_CHECK_ABORT (retval > 0,
                     P4EST_STRING "_vtk: Error collecting cell vectors");
-    vector_strlen += retval;
-    values[all] = va_arg (ap, sc_array_t *);
+    vector_strlen += retval;    
 
     /* Validate input. */
     SC_CHECK_ABORT (values[all]->elem_size == sizeof (double),
@@ -1105,14 +1166,6 @@ p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
                     " vector data must contain exactly"
                     " 3 * p4est->local_num_quadrants doubles.");
   }
-
-  /* Check for pointer variable marking the end of variable data input. */
-  list_end = va_arg (ap, p4est_vtk_context_t *);
-  SC_CHECK_ABORT (list_end == cont,
-                  P4EST_STRING "_vtk Error: the end of variable data must be"
-                  " specified by passing, as the last argument, the current "
-                  P4EST_STRING "_vtk_context_t pointer.  See " P4EST_STRING
-                  "_vtk.h for more information.");
 
   if (write_tree)
     printed +=
@@ -1177,7 +1230,6 @@ p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
       P4EST_LERROR (P4EST_STRING "_vtk: Error encoding types\n");
       p4est_vtk_context_destroy (cont);
 
-      P4EST_FREE (values);
       P4EST_FREE (names);
       P4EST_FREE (locidx_data);
       P4EST_FREE (uint8_data);
@@ -1228,7 +1280,6 @@ p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
       P4EST_LERROR (P4EST_STRING "_vtk: Error encoding types\n");
       p4est_vtk_context_destroy (cont);
 
-      P4EST_FREE (values);
       P4EST_FREE (names);
       P4EST_FREE (locidx_data);
 
@@ -1267,7 +1318,6 @@ p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
       P4EST_LERROR (P4EST_STRING "_vtk: Error encoding types\n");
       p4est_vtk_context_destroy (cont);
 
-      P4EST_FREE (values);
       P4EST_FREE (names);
 
       return NULL;
@@ -1281,7 +1331,6 @@ p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
                    cont->vtufilename);
     p4est_vtk_context_destroy (cont);
 
-    P4EST_FREE (values);
     P4EST_FREE (names);
 
     return NULL;
@@ -1301,8 +1350,6 @@ p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
   }
 
   fprintf (cont->vtufile, "      </CellData>\n");
-
-  P4EST_FREE (values);
 
   if (ferror (cont->vtufile)) {
     P4EST_LERRORF (P4EST_STRING "_vtk: Error writing %s\n",
@@ -1359,27 +1406,6 @@ p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
   }
 
   P4EST_FREE (names);
-
-  return cont;
-}
-
-p4est_vtk_context_t *
-p4est_vtk_write_cell_dataf (p4est_vtk_context_t * cont,
-                            int write_tree, int write_level,
-                            int write_rank, int wrap_rank,
-                            int num_cell_scalars, int num_cell_vectors, ...)
-{
-  va_list             ap;
-
-  P4EST_ASSERT (cont != NULL && cont->writing);
-  P4EST_ASSERT (num_cell_scalars >= 0 && num_cell_vectors >= 0);
-
-  va_start (ap, num_cell_vectors);
-  cont = p4est_vtk_write_cell_datav (cont,
-                                     write_tree, write_level,
-                                     write_rank, wrap_rank,
-                                     num_cell_scalars, num_cell_vectors, ap);
-  va_end (ap);
 
   return cont;
 }

--- a/src/p4est_vtk.h
+++ b/src/p4est_vtk.h
@@ -157,6 +157,46 @@ void                p4est_vtk_context_destroy (p4est_vtk_context_t * context);
  */
 p4est_vtk_context_t *p4est_vtk_write_header (p4est_vtk_context_t * cont);
 
+ /** Write VTK cell data.
+ *
+ * There are options to have this function write
+ * the tree id, quadrant level, or MPI rank without explicit input data.
+ *
+ * Writing a VTK file is split into a few routines.
+ * This allows there to be an arbitrary number of
+ * fields.
+ *
+ * \param [in,out] cont    A VTK context created by \ref p4est_vtk_context_new.
+ * \param [in] write_tree  Boolean to determine if the tree id should be output.
+ * \param [in] write_level Boolean to determine if the tree levels should be output.
+ * \param [in] write_rank  Boolean to determine if the MPI rank should be output.
+ * \param [in] wrap_rank   Number to wrap around the rank with a modulo operation.
+ *                         Can be 0 for no wrapping.
+ * \param [in] num_cell_scalars Number of cell scalar datasets to output.
+ * \param [in] num_cell_vectors Number of cell vector datasets to output.
+ *
+ * \param [in] fieldnames Array of char strings containing the name of the data
+ * \param [in] values Array of pointers to sc_array_t holding variables of type double.
+ *
+ * The number of doubles in each sc_array must be exactly \a p4est->local_num_quadrants for
+ * scalar data and \a 3*p4est->local_num_quadrants for vector data. The cell scalar data come
+ * first, followed by the cell vector data.
+ *
+ *
+ * \return          On success, the context that has been passed in.
+ *                  On failure, returns NULL and deallocates the context.
+ * TODO: implement also for point data.
+ */
+p4est_vtk_context_t *p4est_vtk_write_cell_data (p4est_vtk_context_t * cont,
+                                                int write_tree,
+                                                int write_level,
+                                                int write_rank,
+                                                int wrap_rank,
+                                                int num_cell_scalars,
+                                                int num_cell_vectors,
+                                                const char *fieldnames[],
+                                                sc_array_t * values[]);
+
 /** Write VTK cell data.
  *
  * There are options to have this function write
@@ -206,19 +246,16 @@ p4est_vtk_context_t *p4est_vtk_write_cell_dataf (p4est_vtk_context_t * cont,
  * the same as \b p4est_vtk_write_cell_dataf with the only difference being
  * that instead of a variable argument list, an initialized \a va_list is
  * passed as the last argument. That means \a va_start has already been called.
- *
- * The \a va_list is initialized from the variable argument list of the calling
- * function. Elements of va_list are processed as "pairs" of (fieldname,
- * fieldvalues).  That means <va_list[0], va_list[1]> represents one pair,
- * <va_list[2], va_list[3]> next one and so on.
+ * The \a va_list is initialized from the variable
+ * argument list of the calling function. Elements of va_list are processed as "pairs" of (fieldname, fieldvalues).
+ * That means <va_list[0], va_list[1]> represents one pair, <va_list[2], va_list[3]> next one and so on.
  * Each 'fieldname' shall be a char string containing the name of the data
  * contained in the following 'fieldvalues'. Each of the 'fieldvalues'
- * shall be an `sc_array_t *` holding double variables.
+ * shall be an sc_array_t * holding double variables.
  * The cell scalar pairs come first, followed by the cell vector pairs, followed
  * by VTK context \a cont (same as the first argument).
- * The number of sizeof (double) entries in each sc_array must be exactly \a
- * p4est->local_num_quadrants for scalar data and \a
- * 3*p4est->local_num_quadrants for vector data.
+ * The number of * doubles in each sc_array must be exactly \a p4est->local_num_quadrants for
+ * scalar data and \a 3*p4est->local_num_quadrants for vector data.
  *
  * \note This function is actually called from \b p4est_vtk_write_cell_dataf
  * and does all of the work.
@@ -236,25 +273,14 @@ p4est_vtk_context_t *p4est_vtk_write_cell_dataf (p4est_vtk_context_t * cont,
  *
  * \return          On success, the context that has been passed in.
  *                  On failure, returns NULL and deallocates the context.
+ *
  */
-p4est_vtk_context_t *p4est_vtk_write_cell_datav
-  (p4est_vtk_context_t * cont,
-   int write_tree, int write_level, int write_rank, int wrap_rank,
-   int num_cell_scalars, int num_cell_vectors, va_list ap);
-
-/** This is an alternate version of the varargs function.
- * Works exactly the same otherwise.
- * TODO: implement, also for vectors and point data.
- */
-p4est_vtk_context_t *p4est_vtk_write_cell_data (p4est_vtk_context_t * cont,
-                                                int write_tree,
-                                                int write_level,
-                                                int write_rank,
-                                                int wrap_rank,
-                                                int num_cell_scalars,
-                                                int num_cell_vectors,
-                                                const char *filenames[],
-                                                sc_array_t * values[]);
+p4est_vtk_context_t *
+p4est_vtk_write_cell_datav (p4est_vtk_context_t * cont,
+                            int write_tree, int write_level,
+                            int write_rank, int wrap_rank,
+                            int num_cell_scalars,
+                            int num_cell_vectors, va_list ap);
 
 /** Write VTK point data.
  *

--- a/src/p8est_vtk.h
+++ b/src/p8est_vtk.h
@@ -156,6 +156,46 @@ void                p8est_vtk_context_destroy (p8est_vtk_context_t * context);
  */
 p8est_vtk_context_t *p8est_vtk_write_header (p8est_vtk_context_t * cont);
 
+ /** Write VTK cell data.
+ *
+ * There are options to have this function write
+ * the tree id, quadrant level, or MPI rank without explicit input data.
+ *
+ * Writing a VTK file is split into a few routines.
+ * This allows there to be an arbitrary number of
+ * fields.
+ *
+ * \param [in,out] cont    A VTK context created by \ref p8est_vtk_context_new.
+ * \param [in] write_tree  Boolean to determine if the tree id should be output.
+ * \param [in] write_level Boolean to determine if the tree levels should be output.
+ * \param [in] write_rank  Boolean to determine if the MPI rank should be output.
+ * \param [in] wrap_rank   Number to wrap around the rank with a modulo operation.
+ *                         Can be 0 for no wrapping.
+ * \param [in] num_cell_scalars Number of cell scalar datasets to output.
+ * \param [in] num_cell_vectors Number of cell vector datasets to output.
+ *
+ * \param [in] fieldnames Array of char strings containing the name of the data
+ * \param [in] values Array of pointers to sc_array_t holding variables of type double.
+ *
+ * The number of doubles in each sc_array must be exactly \a p8est->local_num_quadrants for
+ * scalar data and \a 3*p8est->local_num_quadrants for vector data.
+ * The cell scalar data come first, followed by the cell vector data.
+ *
+ *
+ * \return          On success, the context that has been passed in.
+ *                  On failure, returns NULL and deallocates the context.
+ * TODO: implement also for point data.
+ */
+p8est_vtk_context_t *p8est_vtk_write_cell_data (p8est_vtk_context_t * cont,
+                                                int write_tree,
+                                                int write_level,
+                                                int write_rank,
+                                                int wrap_rank,
+                                                int num_cell_scalars,
+                                                int num_cell_vectors,
+                                                const char *fieldnames[],
+                                                sc_array_t * values[]);
+
 /** Write VTK cell data.
  *
  * There are options to have this function write
@@ -205,19 +245,16 @@ p8est_vtk_context_t *p8est_vtk_write_cell_dataf (p8est_vtk_context_t * cont,
  * the same as \b p8est_vtk_write_cell_dataf with the only difference being
  * that instead of a variable argument list, an initialized \a va_list is
  * passed as the last argument. That means \a va_start has already been called.
- *
- * The \a va_list is initialized from the variable argument list of the calling
- * function. Elements of va_list are processed as "pairs" of (fieldname,
- * fieldvalues).  That means <va_list[0], va_list[1]> represents one pair,
- * <va_list[2], va_list[3]> next one and so on.
+ * The \a va_list is initialized from the variable
+ * argument list of the calling function. Elements of va_list are processed as "pairs" of (fieldname, fieldvalues).
+ * That means <va_list[0], va_list[1]> represents one pair, <va_list[2], va_list[3]> next one and so on.
  * Each 'fieldname' shall be a char string containing the name of the data
  * contained in the following 'fieldvalues'. Each of the 'fieldvalues'
- * shall be an `sc_array_t *` holding double variables.
+ * shall be an sc_array_t * holding double variables.
  * The cell scalar pairs come first, followed by the cell vector pairs, followed
  * by VTK context \a cont (same as the first argument).
- * The number of sizeof (double) entries in each sc_array must be exactly \a
- * p8est->local_num_quadrants for scalar data and \a
- * 3*p8est->local_num_quadrants for vector data.
+ * The number of * doubles in each sc_array must be exactly \a p8est->local_num_quadrants for
+ * scalar data and \a 3*p8est->local_num_quadrants for vector data.
  *
  * \note This function is actually called from \b p8est_vtk_write_cell_dataf
  * and does all of the work.
@@ -235,11 +272,17 @@ p8est_vtk_context_t *p8est_vtk_write_cell_dataf (p8est_vtk_context_t * cont,
  *
  * \return          On success, the context that has been passed in.
  *                  On failure, returns NULL and deallocates the context.
+ *
+ * 
+ *
  */
-p8est_vtk_context_t *p8est_vtk_write_cell_datav
-  (p8est_vtk_context_t * cont,
-   int write_tree, int write_level, int write_rank, int wrap_rank,
-   int num_cell_scalars, int num_cell_vectors, va_list ap);
+
+p8est_vtk_context_t *
+p8est_vtk_write_cell_datav (p8est_vtk_context_t * cont,
+                            int write_tree, int write_level,
+                            int write_rank, int wrap_rank,
+                            int num_cell_scalars,
+                            int num_cell_vectors, va_list ap);
 
 /** Write VTK point data.
  *


### PR DESCRIPTION
# Memory leak during writing cell data

Following up on issue #105  .
Leak happened every time you did not write out level and/or rank, since deallocation of always allocated variables during normal execution happened inside of `if` statements.

Proposed changes:
No longer always allocating uint8_data, since only `if (write_level)` statements uses it. Now this array is allocated and deallocated inside of this statement.

Variable `locidx_data` is always deallocated right after the `if (write_rank)` statement. Of course proper deallocations in case something goes wrong are in place.

This PR is a little 'hacky' since it is directly influenced by my previous one and both of them are editing the same piece of code.

