### PR TITLE
CMake: correct autobuild of libsc

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -35,7 +35,7 @@ jobs:
             ninja-build libopenmpi-dev openmpi-bin
 
     - name: CMake configure
-      run: cmake --preset default -DCMAKE_INSTALL_PREFIX=~/p4est
+      run: cmake --preset default -DCMAKE_INSTALL_PREFIX=~
 
     - name: CMake build
       run: cmake --build --preset default
@@ -47,7 +47,7 @@ jobs:
       run: ctest --preset default
 
     - name: CMake configure examples
-      run: cmake -B example/build -S example -Dmpi=yes -Dopenmp=yes -DP4EST_ROOT=~/p4est
+      run: cmake -B example/build -S example -Dmpi=yes -DP4EST_ROOT=~
 
     - name: CMake build examples
       run: cmake --build example/build
@@ -84,7 +84,7 @@ jobs:
       run: brew install open-mpi ninja
 
     - name: CMake configure
-      run: cmake --preset mac -DCMAKE_INSTALL_PREFIX=~/p4est
+      run: cmake --preset mac -DCMAKE_INSTALL_PREFIX=~
 
     - name: CMake build
       run: cmake --build build
@@ -96,7 +96,7 @@ jobs:
       run: ctest -E sort --preset default
 
     - name: CMake configure examples
-      run: cmake -B example/build -S example -Dmpi=yes -DP4EST_ROOT=~/p4est
+      run: cmake -B example/build -S example -Dmpi=yes -DP4EST_ROOT=~
 
     - name: CMake build examples
       run: cmake --build example/build
@@ -158,11 +158,11 @@ jobs:
 
     - name: CMake configure with MPI
       if: steps.check_files.outputs.files_exists == 'true'
-      run: cmake --preset default -DCMAKE_INSTALL_PREFIX=~/p4est
+      run: cmake --preset default -DCMAKE_INSTALL_PREFIX=~
 
     - name: CMake configure without MPI
       if: steps.check_files.outputs.files_exists == 'false'
-      run: cmake --preset default -Dmpi=no -DCMAKE_INSTALL_PREFIX=~/p4est
+      run: cmake --preset default -Dmpi=no -DCMAKE_INSTALL_PREFIX=~
 
     - name: CMake build
       run: cmake --build --preset default

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -18,9 +18,11 @@ on:
 jobs:
 
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: CMake build on Linux
     timeout-minutes: 15
+    env:
+      CTEST_PARALLEL_LEVEL: 2
 
     steps:
     - uses: actions/checkout@v2
@@ -33,17 +35,16 @@ jobs:
             ninja-build libopenmpi-dev openmpi-bin
 
     - name: CMake configure
-      run: cmake --preset=ninja -DCMAKE_INSTALL_PREFIX=~/p4est
+      run: cmake --preset default -DCMAKE_INSTALL_PREFIX=~/p4est
 
     - name: CMake build
-      run: cmake --build build
+      run: cmake --build --preset default
 
     - name: CMake install (for examples)
       run: cmake --install build
 
     - name: CMake self-tests
-      run: ctest --parallel 2 --output-on-failure
-      working-directory: build
+      run: ctest --preset default
 
     - name: CMake configure examples
       run: cmake -B example/build -S example -Dmpi=yes -Dopenmp=yes -DP4EST_ROOT=~/p4est
@@ -73,6 +74,7 @@ jobs:
     timeout-minutes: 20
     env:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
+      CTEST_PARALLEL_LEVEL: 3
 
     steps:
     - uses: actions/checkout@v2
@@ -82,7 +84,7 @@ jobs:
       run: brew install open-mpi ninja
 
     - name: CMake configure
-      run: cmake --preset=mac -DCMAKE_INSTALL_PREFIX=~/p4est
+      run: cmake --preset mac -DCMAKE_INSTALL_PREFIX=~/p4est
 
     - name: CMake build
       run: cmake --build build
@@ -91,8 +93,7 @@ jobs:
       run: cmake --install build
 
     - name: CMake self-tests
-      run: ctest -E sort --parallel 2 --output-on-failure
-      working-directory: build
+      run: ctest -E sort --preset default
 
     - name: CMake configure examples
       run: cmake -B example/build -S example -Dmpi=yes -DP4EST_ROOT=~/p4est
@@ -101,7 +102,7 @@ jobs:
       run: cmake --build example/build
 
     - name: CMake test examples
-      run: ctest --parallel 2 --output-on-failure
+      run: ctest --output-on-failure
       working-directory: example/build
 
     - name: Create package
@@ -121,7 +122,7 @@ jobs:
     name: CMake build on Windows
     timeout-minutes: 20
     env:
-      CMAKE_GENERATOR: Ninja
+      CTEST_PARALLEL_LEVEL: 2
 
     steps:
     - uses: msys2/setup-msys2@v2
@@ -157,21 +158,20 @@ jobs:
 
     - name: CMake configure with MPI
       if: steps.check_files.outputs.files_exists == 'true'
-      run: cmake --preset=ninja -DCMAKE_INSTALL_PREFIX=~/p4est
+      run: cmake --preset default -DCMAKE_INSTALL_PREFIX=~/p4est
 
     - name: CMake configure without MPI
       if: steps.check_files.outputs.files_exists == 'false'
-      run: cmake --preset=ninja -Dmpi=no -DCMAKE_INSTALL_PREFIX=~/p4est
+      run: cmake --preset default -Dmpi=no -DCMAKE_INSTALL_PREFIX=~/p4est
 
     - name: CMake build
-      run: cmake --build build
+      run: cmake --build --preset default
 
     - name: CMake install (for examples)
       run: cmake --install build
 
     - name: CMake self-tests
-      run: ctest -E loadsave2 --parallel 2 --output-on-failure
-      working-directory: build
+      run: ctest -E loadsave2 --preset default
 
     - name: Create package
       if: github.event.action == 'published'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,11 @@ endif(BUILD_TESTING)
 
 # --- packaging
 
+install(FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindSC.cmake
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindP4EST.cmake
+  DESTINATION lib/cmake/Modules)
+
 include(cmake/pkgconf.cmake)
 include(cmake/install.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,6 @@ endif()
 find_package(ZLIB)
 
 # --- libsc
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG true)
-
 if(NOT sc_external)
   find_package(SC)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,10 @@ endif()
 include(cmake/config.cmake)
 include(cmake/compilers.cmake)
 
+if(P4EST_NEED_M)
+  target_link_libraries(SC::SC INTERFACE m)
+endif()
+
 # --- p4est
 # p4est is always needed.
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,27 +1,22 @@
 {
-"version": 1,
-"cmakeMinimumRequired": {
-  "major": 3,
-  "minor": 19,
-  "patch": 0
+  "version": 2,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
 },
 
 "configurePresets": [
 {
-  "name": "_default", "hidden": true,
+  "name": "default",
   "binaryDir": "${sourceDir}/build",
+  "generator": "Ninja",
   "cacheVariables": {"CMAKE_BUILD_TYPE": "Release",
     "mpi": true,
     "openmp": true}
 },
 {
-  "name": "ninja", "inherits": "_default",
-  "displayName": "build with Ninja",
-  "description": "Ninja is a faster alternative to Make",
-  "generator": "Ninja"
-},
-{
-  "name": "mac", "inherits": "ninja",
+  "name": "mac", "inherits": "default",
   "displayName": "MacOS",
   "description": "MacOS: OpenMP not used",
   "cacheVariables": {"openmp": false}
@@ -32,19 +27,18 @@
   "description": "MacOS: OpenMP not used, using Make"
 },
 {
-  "name": "make", "inherits": "_default",
+  "name": "make", "inherits": "default",
   "displayName": "build with GNU Make",
   "generator": "Unix Makefiles"
 },
 {
-  "name": "makewin", "inherits": "_default",
+  "name": "makewin", "inherits": "default",
   "displayName": "build with GNU Make: Windows",
   "generator": "MinGW Makefiles"
 },
 {
-  "name": "intel", "inherits": "ninja",
+  "name": "intel", "inherits": "default",
   "displayName": "Intel Classic compiler: Linux/MacOS",
-  "description": "build with Intel Classic on Linux/MacOS",
   "environment": {
     "CC": "icc",
     "CXX": "icpc",
@@ -55,7 +49,6 @@
 {
   "name": "intelwin", "inherits": "intel",
   "displayName": "Intel Classic compiler: Windows",
-  "description": "build with Intel Classic on Windows",
   "environment": {
     "CC": "icl",
     "CXX": "icl"
@@ -64,12 +57,30 @@
 {
   "name": "intelnext", "inherits": "intel",
   "displayName": "Intel oneAPI LLVM",
-  "description": "build with Intel oneAPI NextGen LLVM",
   "environment": {
     "CC": "icx",
     "CXX": "icx",
     "FC": "ifx"
   }
+}
+],
+"buildPresets": [
+  {
+    "name": "default",
+    "configurePreset": "default"
+  }
+],
+"testPresets": [
+{
+  "name": "default",
+  "configurePreset": "default",
+  "output": {
+    "outputOnFailure": true,
+    "verbosity": "default"
+  },
+  "execution": {
+    "noTestsAction": "error",
+    "stopOnFailure": false}
 }
 ]
 }

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,5 +1,11 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../Modules)
+find_dependency(SC)
+find_dependency(ZLIB)
+
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 
 foreach(_comp P4EST P6EST P8EST)

--- a/cmake/GitSubmodule.cmake
+++ b/cmake/GitSubmodule.cmake
@@ -1,5 +1,5 @@
 function(git_submodule dir)
-# add a Git submodule directory to CMake, assuming the
+# get/update Git submodule directory to CMake, assuming the
 # Git submodule directory is a CMake project.
 
 find_package(Git REQUIRED)
@@ -13,7 +13,5 @@ if(NOT EXISTS ${dir}/CMakeLists.txt)
     message(SEND_ERROR "Could not retrieve Git submodule ${dir}.")
   endif()
 endif()
-
-add_subdirectory(${dir})
 
 endfunction(git_submodule)

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -8,15 +8,11 @@ configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/Config.cmake.in
 
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
-  VERSION ${${PROJECT_NAME}_VERSION}
-  COMPATIBILITY SameMinorVersion
-)
+  COMPATIBILITY SameMinorVersion)
 
 install(EXPORT ${PROJECT_NAME}Targets
-  FILE ${PROJECT_NAME}Targets.cmake
   NAMESPACE ${PROJECT_NAME}::
-  DESTINATION lib/cmake/${PROJECT_NAME}
-   )
+  DESTINATION lib/cmake/${PROJECT_NAME})
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake
@@ -25,8 +21,7 @@ install(FILES
 
 export(EXPORT ${PROJECT_NAME}Targets
   FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Targets.cmake
-  NAMESPACE ${PROJECT_NAME}::
-)
+  NAMESPACE ${PROJECT_NAME}::)
 
 # --- CPack
 

--- a/cmake/sc.cmake
+++ b/cmake/sc.cmake
@@ -1,6 +1,42 @@
 # provides imported target SC::SC
+include(ExternalProject)
 include(${CMAKE_CURRENT_LIST_DIR}/GitSubmodule.cmake)
 
 set(sc_external true CACHE BOOL "build sc library" FORCE)
 
 git_submodule("${PROJECT_SOURCE_DIR}/sc")
+
+# --- libsc externalProject
+# this keeps libsc scope totally separate from p4est, which avoids 
+# tricky to diagnose behaviors
+
+if(NOT DEFINED SC_ROOT)
+  set(SC_ROOT ${CMAKE_INSTALL_PREFIX})
+endif()
+
+if(BUILD_SHARED_LIBS)
+  set(SC_LIBRARIES ${SC_ROOT}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}sc${CMAKE_SHARED_LIBRARY_SUFFIX})
+else()
+  set(SC_LIBRARIES ${SC_ROOT}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sc${CMAKE_STATIC_LIBRARY_SUFFIX})
+endif()
+
+set(SC_INCLUDE_DIRS ${SC_ROOT}/include)
+
+ExternalProject_Add(SC
+SOURCE_DIR ${PROJECT_SOURCE_DIR}/sc
+CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${SC_ROOT} -Dmpi:BOOL=${mpi} -Dopenmp:BOOL=${openmp}
+BUILD_BYPRODUCTS ${SC_LIBRARIES}
+)
+
+# --- imported target
+
+file(MAKE_DIRECTORY ${SC_INCLUDE_DIRS})
+# avoid race condition
+
+# this GLOBAL is required to be visible via other 
+# project's FetchContent of this project
+add_library(SC::SC INTERFACE IMPORTED GLOBAL)
+target_include_directories(SC::SC INTERFACE "${SC_INCLUDE_DIRS}")
+target_link_libraries(SC::SC INTERFACE "${SC_LIBRARIES}")
+
+add_dependencies(SC::SC SC)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -30,6 +30,15 @@ if(ZLIB_FOUND)
   target_link_libraries(SC::SC INTERFACE ZLIB::ZLIB)
 endif()
 
+check_symbol_exists(sqrt math.h P4EST_NONEED_M)
+if(NOT P4EST_NONEED_M)
+  set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} m)
+  check_symbol_exists(sqrt math.h P4EST_NEED_M)
+endif()
+
+if(P4EST_NEED_M)
+  target_link_libraries(SC::SC INTERFACE m)
+endif()
 
 # --- get system capabilities
 check_include_file(arpa/inet.h P4EST_HAVE_ARPA_INET_H)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -5,8 +5,6 @@ include(CTest)
 include(CheckIncludeFile)
 include(CheckSymbolExists)
 
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../cmake/Modules)
-
 option(mpi "use MPI" off)
 
 # --- find external libraries
@@ -19,10 +17,19 @@ endif(mpi)
 
 # --- find our library
 
-find_package(P4EST COMPONENTS P8EST PATHS ${PROJECT_SOURCE_DIR}/../build)
-if(NOT P4EST_FOUND)
-  find_package(P4EST REQUIRED PATHS ${PROJECT_SOURCE_DIR}/../build)
+if(NOT P4EST_ROOT AND NOT DEFINED ENV{P4EST_ROOT})
+  set(P4EST_ROOT ${PROJECT_SOURCE_DIR}/../build)
 endif()
+
+find_package(P4EST COMPONENTS P8EST)
+if(NOT P4EST_FOUND)
+  find_package(P4EST REQUIRED)
+endif()
+
+if(ZLIB_FOUND)
+  target_link_libraries(SC::SC INTERFACE ZLIB::ZLIB)
+endif()
+
 
 # --- get system capabilities
 check_include_file(arpa/inet.h P4EST_HAVE_ARPA_INET_H)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -17,14 +17,7 @@ if(mpi)
   endif()
 endif(mpi)
 
-find_package(ZLIB REQUIRED)
-
 # --- find our library
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG true)
-
-# SC could have been installed with p4est,
-# or SC could be installed by itself
-find_package(SC HINTS ${P4EST_ROOT} PATHS ${PROJECT_SOURCE_DIR}/../build REQUIRED)
 
 find_package(P4EST COMPONENTS P8EST PATHS ${PROJECT_SOURCE_DIR}/../build)
 if(NOT P4EST_FOUND)


### PR DESCRIPTION
previously I directly added libsc to p4est CMake project. This created undesired mixing of project scopes, such that libsc did not install correctly when built with p4est. This PR eliminates that problem and clarifies linking by keeping libsc scope totally separate from p4est in CMake.