### PR TITLE
Fix `p4est_save_ext` on Windows

### DIFF
--- a/INSTALL_WINDOWS
+++ b/INSTALL_WINDOWS
@@ -44,9 +44,17 @@ Instructions:
         File sc/src/sc.h line 121:
         #define __attribute__(x)
 
+        File sc/test/test_node_comm.c line 36:
+        #define srandom srand
+        #define random rand
+
         In files src/p4est_algorithms.c, p8est_algorithms.c, p6est.c
         Include definitions of htonl-function
         #define htonl(_val) ( ((uint16_t)(_val) & 0xff00) >> 8 | ((uint16_t)(_val) & 0xff) << 8 )
+
+        File test/test_balance_seeds2.c line 33:
+        #define srandom srand
+        #define random rand
 
     b. Compile the package (MPI is disabled as some changes on signals were made
         and it seems to result in the program crashing when MPI functions are used).
@@ -54,7 +62,7 @@ Instructions:
         cd p4est/
         ./bootstrap
         ./configure --disable-mpi --disable-vtk-build --without-blas
-        ./make
+        ./make LDFLAGS="-no-undefined"
         ./make install
 
   6. Build DLLs suitable for Windows.  Linking .a files to MS VS project

--- a/doc/author_schlottke-lakemper.txt
+++ b/doc/author_schlottke-lakemper.txt
@@ -1,0 +1,1 @@
+I place my contributions to p4est under the FreeBSD license. Michael Schlottke-Lakemper

--- a/src/p4est.c
+++ b/src/p4est.c
@@ -3522,6 +3522,10 @@ p4est_save_ext (const char *filename, p4est_t * p4est,
     file = fopen (filename, "ab");
     SC_CHECK_ABORT (file != NULL, "file open");
 
+    /* explicitly seek to end to avoid bad ftell return value on Windows */
+    retval = fseek(file, 0, SEEK_END);
+    SC_CHECK_ABORT (retval == 0, "file seek");
+
     /* align the start of the header */
     fpos = ftell (file);
     SC_CHECK_ABORT (fpos > 0, "first file tell");

--- a/src/p6est.c
+++ b/src/p6est.c
@@ -756,6 +756,10 @@ p6est_save_ext (const char *filename, p6est_t * p6est,
     file = fopen (filename, "ab");
     SC_CHECK_ABORT (file != NULL, "file open");
 
+    /* explicitly seek to end to avoid bad ftell return value on Windows */
+    retval = fseek(file, 0, SEEK_END);
+    SC_CHECK_ABORT (retval == 0, "file seek");
+
     /* align */
     fpos = ftell (file);
     SC_CHECK_ABORT (fpos > 0, "first file tell");


### PR DESCRIPTION
# Fix `p4est_save_ext` on Windows

Following up on issue #113.

Proposed changes:
After opening the existing files in `p4est_save_ext`/`p6est_save_ext` in "append" mode, an additional call to `fseek` ensures that the file position indicator is moved to the end of the file. On Linux/macOS this should be a no-op, since the file position indicator is already at the end of the file. On Windows, however, this fixes the issues with a zero return value from `ftell` as reported in #113.

P.S.: I realize that the contributing guidelines ask for the creation of an issue first. However, since I had a possible fix already available, I just went ahead to show a possible remedy :-)

Closes #113.