### PR TITLE
Fix EOF detection in `p4est_connectivity_getline_upper` on Windows

### DIFF
--- a/doc/author_schlottke-lakemper.txt
+++ b/doc/author_schlottke-lakemper.txt
@@ -1,0 +1,1 @@
+I place my contributions to p4est under the FreeBSD license. Michael Schlottke-Lakemper

--- a/src/p4est_connectivity.c
+++ b/src/p4est_connectivity.c
@@ -4596,11 +4596,11 @@ p4est_connectivity_getline_upper (FILE * stream)
 
   for (;;) {
     c = fgetc (stream);
-    c = toupper (c);
     if (c == EOF && linep == line) {
       P4EST_FREE (linep);
       return NULL;
     }
+    c = toupper (c);
 
     if (--len == 0) {
       char               *linen;


### PR DESCRIPTION
# Fix EOF detection in `p4est_connectivity_getline_upper` on Windows

We have noted that `p4est_connectivity_getline_upper` sometimes fails on Windows (not always - it seems to depend on the actual C library version used). The problem is rooted in the following lines:
https://github.com/cburstedde/p4est/blob/3a78fd2d3a45d27a96db108e042838d0da12591c/src/p4est_connectivity.c#L4598-L4603

After reading the next character from the stream with `fgetc`, it is converted to uppercase using `toupper` and then checked for the `EOF` (end of file) marker. This is OK on Linux (and presumably macOS), since
> If c is a lowercase letter, toupper() returns its uppercase equivalent, if an uppercase representation exists in the current locale.  Otherwise, it returns c.

([ref](https://man7.org/linux/man-pages/man3/toupper.3.html)). Thus, if `c` is actually `EOF` (typically represented as `-1`), there is no uppercase representation and it remains unchanged.

However, on Windows the documentation [says](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/toupper-toupper-towupper-toupper-l-towupper-l?view=msvc-160#return-value)
> In order for `toupper` to give the expected results, `__isascii` and `islower` must both return nonzero.

Thus, *implicitly* it says: If it is not an ASCII character, anything can happen! And indeed: In some cases
```c
toupper(-1) == -1 == EOF
```
but in other cases (in my case when invoking `libp4est` from Julia),
```c
toupper(-1) == 159 != EOF
```
and thus the reading loop in `p4est_connectivity_getline_upper` never terminates.

Proposed changes:
Move the conversion `toupper` to after the check for `EOC`, which will make this work no matter on which platform this is running.
