### PR TITLE
Prev3 warning fix

### DIFF
--- a/src/p4est_mesh.c
+++ b/src/p4est_mesh.c
@@ -345,9 +345,9 @@ mesh_corner_process_inter_tree_corners (p4est_iter_corner_info_t * info,
     /* check if current side2 is among the face or edge neighbors */
     for (ignore = 0, j = 0; !ignore && j < P4EST_DIM; ++j) {
       for (k = 0; k < P4EST_DIM; ++k) {
-        if ((side1->faces[j] == side2->faces[k])
+        if ( side1->faces[j] == side2->faces[k]
 #ifdef P4_TO_P8
-            || (side1->edges[j] == side2->edges[k])
+            || side1->edges[j] == side2->edges[k]
 #endif /* P4_TO_P8 */
           ) {
           ignore = 1;

--- a/src/p4est_mesh.c
+++ b/src/p4est_mesh.c
@@ -345,9 +345,9 @@ mesh_corner_process_inter_tree_corners (p4est_iter_corner_info_t * info,
     /* check if current side2 is among the face or edge neighbors */
     for (ignore = 0, j = 0; !ignore && j < P4EST_DIM; ++j) {
       for (k = 0; k < P4EST_DIM; ++k) {
-        if ( side1->faces[j] == side2->faces[k]
+        if ( (side1->faces[j] == side2->faces[k])
 #ifdef P4_TO_P8
-            || side1->edges[j] == side2->edges[k]
+            || (side1->edges[j] == side2->edges[k])
 #endif /* P4_TO_P8 */
           ) {
           ignore = 1;

--- a/src/p4est_mesh.c
+++ b/src/p4est_mesh.c
@@ -345,9 +345,9 @@ mesh_corner_process_inter_tree_corners (p4est_iter_corner_info_t * info,
     /* check if current side2 is among the face or edge neighbors */
     for (ignore = 0, j = 0; !ignore && j < P4EST_DIM; ++j) {
       for (k = 0; k < P4EST_DIM; ++k) {
-        if ( (side1->faces[j] == side2->faces[k])
+        if ( side1->faces[j] == side2->faces[k]
 #ifdef P4_TO_P8
-            || (side1->edges[j] == side2->edges[k])
+            || side1->edges[j] == side2->edges[k]
 #endif /* P4_TO_P8 */
           ) {
           ignore = 1;

--- a/src/p4est_plex.c
+++ b/src/p4est_plex.c
@@ -380,56 +380,25 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
           int                 corner = v - vstart;
           if (hanging[P4EST_DIM - 1][corner] >= 0) {
             p4est_locidx_t      child = -1;
-            int                 dim;
+            int                 dim = -1;
 
             f = p4est_child_corner_faces[cid][corner];
-/*            
-            P4EST_ASSERT (P4EST_DIM == 3 ||f >= 0);
-#ifndef P4_TO_P8
-            dim = P4EST_DIM-1;
-            child = child_offsets[quad_to_local[qid * V + f]];
-#else
-            int                 e = p8est_child_corner_edges[cid][corner];
-            P4EST_ASSERT (e >= 0);
-            dim = 1;
-            child = child_offsets[quad_to_local[qid * V + e + P4EST_FACES]];
-#endif 
-*/
-
             P4EST_ASSERT (P4EST_DIM == 3 || f >= 0);
 
-#ifndef P4_TO_P8
-            dim = P4EST_DIM - 1;
-            int count = 1;
-            if(count == 1) 
-            {
-              printf("--------------------------------------2D---------------------------");
-              printf("%d\n",dim);
-              count++;
-            }
-#else
-            dim = 1;
-            int count = 1;
-            if(count == 1) 
-            {
-              printf("--------------------------------------3D---------------------------");
-              printf("%d\n",dim);
-              count++;
-            }
-#endif
             if (f >= 0) {
-              //dim = P4EST_DIM - 1;
               child = child_offsets[quad_to_local[qid * V + f]];
+              dim = P4EST_DIM - 1;
             }
 #ifdef P4_TO_P8
             else {
               int                 e = p8est_child_corner_edges[cid][corner];
 
+              dim = 1;
               P4EST_ASSERT (e >= 0);
-              //dim = 1;
               child = child_offsets[quad_to_local[qid * V + e + P4EST_FACES]];
             }
 #endif
+
 
             P4EST_ASSERT (dim == 1 || dim == 2);
             child += (dim == 1) ? 2 : 8;

--- a/src/p4est_plex.c
+++ b/src/p4est_plex.c
@@ -383,7 +383,7 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
             int                 dim;
 
             f = p4est_child_corner_faces[cid][corner];
-            P4EST_ASSERT (f >= 0);
+            P4EST_ASSERT (P4EST_DIM == 3 ||f >= 0);
 #ifndef P4_TO_P8
             dim = 2;
             child = child_offsets[quad_to_local[qid * V + f]];

--- a/src/p4est_plex.c
+++ b/src/p4est_plex.c
@@ -383,6 +383,7 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
             int                 dim;
 
             f = p4est_child_corner_faces[cid][corner];
+/*            
             P4EST_ASSERT (P4EST_DIM == 3 ||f >= 0);
 #ifndef P4_TO_P8
             dim = P4EST_DIM-1;
@@ -392,13 +393,32 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
             P4EST_ASSERT (e >= 0);
             dim = 1;
             child = child_offsets[quad_to_local[qid * V + e + P4EST_FACES]];
-            printf("--------------------------------------------------------------------------------------");
 #endif 
+*/
 
-/*
             P4EST_ASSERT (P4EST_DIM == 3 || f >= 0);
+
+#ifndef P4_TO_P8
+            dim = P4EST_DIM - 1;
+            int count = 1;
+            if(count == 1) 
+            {
+              printf("--------------------------------------2D---------------------------");
+              printf("%d\n",dim);
+              count++;
+            }
+#else
+            dim = 1;
+            int count = 1;
+            if(count == 1) 
+            {
+              printf("--------------------------------------3D---------------------------");
+              printf("%d\n",dim);
+              count++;
+            }
+#endif
             if (f >= 0) {
-              dim = P4EST_DIM - 1;
+              //dim = P4EST_DIM - 1;
               child = child_offsets[quad_to_local[qid * V + f]];
             }
 #ifdef P4_TO_P8
@@ -406,11 +426,11 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
               int                 e = p8est_child_corner_edges[cid][corner];
 
               P4EST_ASSERT (e >= 0);
-              dim = 1;
+              //dim = 1;
               child = child_offsets[quad_to_local[qid * V + e + P4EST_FACES]];
             }
 #endif
-*/
+
             P4EST_ASSERT (dim == 1 || dim == 2);
             child += (dim == 1) ? 2 : 8;
             quad_to_local[qid * V + v] = child;

--- a/src/p4est_plex.c
+++ b/src/p4est_plex.c
@@ -383,7 +383,17 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
             int                 dim;
 
             f = p4est_child_corner_faces[cid][corner];
-            P4EST_ASSERT (P4EST_DIM == 3 || f >= 0);
+            P4EST_ASSERT (f >= 0);
+#ifndef P4_TO_P8
+            dim = 2;
+            child = child_offsets[quad_to_local[qid * V + f]];
+#else
+            int                 e = p8est_child_corner_edges[cid][corner];
+            P4EST_ASSERT (e >= 0);
+            dim = 1;
+            child = child_offsets[quad_to_local[qid * V + e + P4EST_FACES]];
+#endif
+          /*  P4EST_ASSERT (P4EST_DIM == 3 || f >= 0);
             if (f >= 0) {
               dim = P4EST_DIM - 1;
               child = child_offsets[quad_to_local[qid * V + f]];
@@ -396,7 +406,7 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
               dim = 1;
               child = child_offsets[quad_to_local[qid * V + e + P4EST_FACES]];
             }
-#endif
+#endif*/
             P4EST_ASSERT (dim == 1 || dim == 2);
             child += (dim == 1) ? 2 : 8;
             quad_to_local[qid * V + v] = child;

--- a/src/p4est_plex.c
+++ b/src/p4est_plex.c
@@ -392,6 +392,7 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
             P4EST_ASSERT (e >= 0);
             dim = 1;
             child = child_offsets[quad_to_local[qid * V + e + P4EST_FACES]];
+            printf("--------------------------------------------------------------------------------------");
 #endif 
 
 /*

--- a/src/p4est_plex.c
+++ b/src/p4est_plex.c
@@ -383,9 +383,9 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
             int                 dim;
 
             f = p4est_child_corner_faces[cid][corner];
- /*           P4EST_ASSERT (P4EST_DIM == 3 ||f >= 0);
+            P4EST_ASSERT (P4EST_DIM == 3 ||f >= 0);
 #ifndef P4_TO_P8
-            dim = 2;
+            dim = P4EST_DIM-1;
             child = child_offsets[quad_to_local[qid * V + f]];
 #else
             int                 e = p8est_child_corner_edges[cid][corner];
@@ -393,7 +393,8 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
             dim = 1;
             child = child_offsets[quad_to_local[qid * V + e + P4EST_FACES]];
 #endif 
-*/
+
+/*
             P4EST_ASSERT (P4EST_DIM == 3 || f >= 0);
             if (f >= 0) {
               dim = P4EST_DIM - 1;
@@ -408,6 +409,7 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
               child = child_offsets[quad_to_local[qid * V + e + P4EST_FACES]];
             }
 #endif
+*/
             P4EST_ASSERT (dim == 1 || dim == 2);
             child += (dim == 1) ? 2 : 8;
             quad_to_local[qid * V + v] = child;

--- a/src/p4est_plex.c
+++ b/src/p4est_plex.c
@@ -383,7 +383,7 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
             int                 dim;
 
             f = p4est_child_corner_faces[cid][corner];
-            P4EST_ASSERT (P4EST_DIM == 3 ||f >= 0);
+ /*           P4EST_ASSERT (P4EST_DIM == 3 ||f >= 0);
 #ifndef P4_TO_P8
             dim = 2;
             child = child_offsets[quad_to_local[qid * V + f]];
@@ -392,8 +392,9 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
             P4EST_ASSERT (e >= 0);
             dim = 1;
             child = child_offsets[quad_to_local[qid * V + e + P4EST_FACES]];
-#endif
-          /*  P4EST_ASSERT (P4EST_DIM == 3 || f >= 0);
+#endif 
+*/
+            P4EST_ASSERT (P4EST_DIM == 3 || f >= 0);
             if (f >= 0) {
               dim = P4EST_DIM - 1;
               child = child_offsets[quad_to_local[qid * V + f]];
@@ -406,7 +407,7 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
               dim = 1;
               child = child_offsets[quad_to_local[qid * V + e + P4EST_FACES]];
             }
-#endif*/
+#endif
             P4EST_ASSERT (dim == 1 || dim == 2);
             child += (dim == 1) ? 2 : 8;
             quad_to_local[qid * V + v] = child;


### PR DESCRIPTION
# Fix for MacOS compiler warnings

Following up on issue # .

Proposed changes:
For the issue of uninitialized variable warning in p4est_plex.c I think it is safe to initialized the 'dim' integer to -1 because as per the assertion in the following lines, it is not allowed to have P4EST_DIM as 2 and corner faces as -1.
