### PR TITLE
Develop

### DIFF
--- a/doc/author_ghosh.txt
+++ b/doc/author_ghosh.txt
@@ -1,0 +1,2 @@
+I place my contributions to p4est under the FreeBSD license. 
+Gautam Ghosh (ghosh@ins.uni-bonn.de)

--- a/src/p4est_mesh.c
+++ b/src/p4est_mesh.c
@@ -345,9 +345,9 @@ mesh_corner_process_inter_tree_corners (p4est_iter_corner_info_t * info,
     /* check if current side2 is among the face or edge neighbors */
     for (ignore = 0, j = 0; !ignore && j < P4EST_DIM; ++j) {
       for (k = 0; k < P4EST_DIM; ++k) {
-        if ((side1->faces[j] == side2->faces[k])
+        if (side1->faces[j] == side2->faces[k]
 #ifdef P4_TO_P8
-            || (side1->edges[j] == side2->edges[k])
+            || side1->edges[j] == side2->edges[k]
 #endif /* P4_TO_P8 */
           ) {
           ignore = 1;

--- a/src/p4est_nodes.c
+++ b/src/p4est_nodes.c
@@ -454,7 +454,7 @@ p4est_nodes_foreach (void **item, const void *u)
   const p4est_locidx_t *new_node_number =
     (const p4est_locidx_t *) internal_data->user_data;
 
-  *item = (void *) (long) new_node_number[(long) *item];
+  *item = (void *) (size_t) new_node_number[(size_t) * item];
 
   return 1;
 }

--- a/src/p4est_plex.c
+++ b/src/p4est_plex.c
@@ -380,7 +380,7 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
           int                 corner = v - vstart;
           if (hanging[P4EST_DIM - 1][corner] >= 0) {
             p4est_locidx_t      child = -1;
-            int                 dim;
+            int                 dim = 1;
 
             f = p4est_child_corner_faces[cid][corner];
             P4EST_ASSERT (P4EST_DIM == 3 || f >= 0);
@@ -393,7 +393,6 @@ parent_to_child (p4est_quadrant_t * q, p4est_topidx_t t, p4est_locidx_t qid,
               int                 e = p8est_child_corner_edges[cid][corner];
 
               P4EST_ASSERT (e >= 0);
-              dim = 1;
               child = child_offsets[quad_to_local[qid * V + e + P4EST_FACES]];
             }
 #endif


### PR DESCRIPTION
# Title Fixes for CMake build warnings

Following up on issue # .

Proposed changes:
1. Remove redundant brackets.
2. Always type cast void* to size_t, intptr_t or uintptr_t on 32-bit and 64-bit machines.
3. Integer dim can be initialized to 1
