### PR TITLE
htonl for win32

### DIFF
--- a/src/p4est_algorithms.c
+++ b/src/p4est_algorithms.c
@@ -43,6 +43,9 @@
 #ifdef P4EST_HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
+#ifdef _WIN32
+#include <winsock.h>
+#endif
 
 #ifndef P4_TO_P8
 

--- a/src/p4est_algorithms.c
+++ b/src/p4est_algorithms.c
@@ -1577,8 +1577,8 @@ p4est_complete_or_balance_kernel (sc_array_t * inlist,
                                   sc_array_t * out,
                                   p4est_quadrant_t * first_desc,
                                   p4est_quadrant_t * last_desc,
-                                  size_t *count_in, size_t *count_out,
-                                  size_t *count_an)
+                                  size_t * count_in, size_t * count_out,
+                                  size_t * count_an)
 {
   int                 inserted;
   size_t              iz, jz;

--- a/src/p4est_algorithms.c
+++ b/src/p4est_algorithms.c
@@ -36,15 +36,15 @@
 #include <p4est_balance.h>
 #endif /* !P4_TO_P8 */
 
-/* htonl is in either of these two */
+/* htonl is in either of these three */
 #ifdef P4EST_HAVE_ARPA_NET_H
 #include <arpa/inet.h>
 #endif
 #ifdef P4EST_HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
-#ifdef _WIN32
-#include <winsock.h>
+#if defined P4EST_HAVE_WINSOCK2_H || defined _WIN32
+#include <winsock2.h>
 #endif
 
 #ifndef P4_TO_P8

--- a/src/p4est_ghost.c
+++ b/src/p4est_ghost.c
@@ -38,16 +38,15 @@
 #endif
 #include <sc_search.h>
 
-/* htonl is in either of these two */
+/* htonl is in either of these three */
 #ifdef P4EST_HAVE_ARPA_NET_H
 #include <arpa/inet.h>
 #endif
 #ifdef P4EST_HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
-/* For windows htonl resides in winsock.h */
-#ifdef _WIN32
-#include <winsock.h>
+#if defined P4EST_HAVE_WINSOCK2_H || defined _WIN32
+#include <winsock2.h>
 #endif
 
 typedef enum

--- a/src/p4est_ghost.c
+++ b/src/p4est_ghost.c
@@ -45,6 +45,10 @@
 #ifdef P4EST_HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
+/* For windows htonl resides in winsock.h */
+#ifdef _WIN32
+#include <winsock.h>
+#endif
 
 typedef enum
 {

--- a/src/p6est.c
+++ b/src/p6est.c
@@ -35,17 +35,17 @@
 #include <sc_io.h>
 #include <p6est_extended.h>
 
-/* htonl is in either of these two */
+/* htonl is in either of these three */
 #ifdef P4EST_HAVE_ARPA_NET_H
 #include <arpa/inet.h>
 #endif
 #ifdef P4EST_HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
-/* For windows htonl resides in winsock.h */
-#ifdef _WIN32
-#include <winsock.h>
+#if defined P4EST_HAVE_WINSOCK2_H || defined _WIN32
+#include <winsock2.h>
 #endif
+
 #ifdef P4EST_HAVE_ZLIB
 #include <zlib.h>
 #endif

--- a/src/p6est.c
+++ b/src/p6est.c
@@ -42,6 +42,10 @@
 #ifdef P4EST_HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
+/* For windows htonl resides in winsock.h */
+#ifdef _WIN32
+#include <winsock.h>
+#endif
 #ifdef P4EST_HAVE_ZLIB
 #include <zlib.h>
 #endif


### PR DESCRIPTION
# Title

Following up on issue # .

Proposed changes:
For windows OS 'htonl' resides in winsock.h