### PR TITLE
Update some p6est docs

### DIFF
--- a/src/p6est.h
+++ b/src/p6est.h
@@ -174,7 +174,9 @@ typedef struct p6est
                                              never touched by p4est */
   p6est_connectivity_t *connectivity;   /**< topology of sheet, not owned. */
   p4est_t            *columns;  /**< 2D description of column layout
-                                     built from \a connectivity */
+                                     built from \a connectivity.
+                                     \note columns->p.user_data
+                                     cannot be used. */
   sc_array_t         *layers;   /**< single array that stores
                                      p2est_quadrant_t layers within columns */
   sc_mempool_t       *user_data_pool;   /**< memory allocator for user data */
@@ -330,6 +332,8 @@ p6est_t            *p6est_new (sc_MPI_Comm mpicomm,
  *
  * \return This returns a valid forest.  The user must destroy the
  * connectivity for the new p6est independently.
+ *
+ * \note p4est->p.user_data is not retained.
  */
 p6est_t            *p6est_new_from_p4est (p4est_t * p4est,
                                           double *top_vertices,

--- a/src/p6est_lnodes.h
+++ b/src/p6est_lnodes.h
@@ -37,12 +37,12 @@ SC_EXTERN_C_BEGIN;
  * for the types of hanging faces that occur in a p6est.  Please see the
  * documentation for p8est_lnodes */
 
-/* The only other differece is in the numbering of nodes, edges, and faces.
+/* The only other difference is in the numbering of nodes, edges, and faces.
  *
  * Columns of nodes are numbered contiguously: this still generates a
  * partition-unique numbering.
  *
- * Although we call a p2est_quadrant_t coordinate layer->z, the orientaton of
+ * Although we call a p2est_quadrant_t coordinate layer->z, the orientation of
  * a layer from lnodes perspective is that the vertical axis is the X axis of
  * the 3D element, the x axis of the columns is the Y axis of the 3D element,
  * and the y axis of the columns is the Z axis of the 3D element

--- a/src/p6est_lnodes.h
+++ b/src/p6est_lnodes.h
@@ -37,8 +37,7 @@ SC_EXTERN_C_BEGIN;
  * for the types of hanging faces that occur in a p6est.  Please see the
  * documentation for p8est_lnodes */
 
-/* The only other differece is in the numbering of nodes and the number of
- * faces.
+/* The only other differece is in the numbering of nodes, edges, and faces.
  *
  * Columns of nodes are numbered contiguously: this still generates a
  * partition-unique numbering.


### PR DESCRIPTION
In calls to `replace_fn` the number of out layers should be set to `4` when horizontal coarsening. See docs for `p6est_replace_t` in `src/p6est.h`.