### PR TITLE
Add generic neighbor transformations and use them to fix periodic coordinates for plex

### DIFF
--- a/src/p4est_bits.h
+++ b/src/p4est_bits.h
@@ -723,6 +723,33 @@ void                p4est_quadrant_predecessor (const p4est_quadrant_t *
 void                p4est_quadrant_srand (const p4est_quadrant_t * q,
                                           sc_rand_state_t * rstate);
 
+/** Transform a quadrant from self's coordinate system to neighbor's coordinate system.
+ *
+ * \param [in]  nt            A neighbor transform.
+ * \param [in]  self_quad     Input quadrant in self coordinates.
+ * \param [out] neigh_coords  Quad transformed into neighbor coordinates.
+ *
+ * \note This transform gives meaningful results when \a self_quad is inside
+ * the tree root or touches the interface between the two trees in the
+ * transform.
+ */
+void                p4est_neighbor_transform_quadrant
+  (const p4est_neighbor_transform_t * nt,
+   const p4est_quadrant_t * self_quad, p4est_quadrant_t * neigh_quad);
+
+/** Transform a quadrant from a neighbors's coordinate system to self's coordinate system.
+ *
+ * \param [in]  nt            A neighbor transform.
+ * \param [in]  neigh_coords  Input quadrant in neighbor coordinates.
+ * \param [out] self_coords   Quad transformed into self coordinates.
+ *
+ * \note This transform gives meaningful results when \a neigh_quad is inside
+ * the tree root or touches the interface between the two trees in the
+ * transform.
+ */
+void                p4est_neighbor_transform_quadrant_reverse
+  (const p4est_neighbor_transform_t * nt,
+   const p4est_quadrant_t * neigh_quad, p4est_quadrant_t * self_quad);
 SC_EXTERN_C_END;
 
 #endif /* !P4EST_BITS_H */

--- a/src/p4est_bits.h
+++ b/src/p4est_bits.h
@@ -88,6 +88,18 @@ int                 p4est_quadrant_is_equal_piggy (const p4est_quadrant_t *
  */
 int                 p4est_quadrant_compare (const void *v1, const void *v2);
 
+/** Compare two sets of coordintes in their Morton ordering.
+ * Coordinates are signed, but the sorted order will treat them
+ * as unsigned, with negative coordinates being greater than
+ * positive coordinates because of their representation in twos-complement.
+ * \param [in] v1, v2    Two sets of 2d coordinates.
+ * \return Returns < 0 if \a v1 < \a v2,
+ *                   0 if \a v1 == \a v2,
+ *                 > 0 if \a v1 > \a v2
+ */
+int                 p4est_coordinates_compare (const p4est_qcoord_t v1[],
+                                               const p4est_qcoord_t v2[]);
+
 /** Compare two quadrants in their Morton ordering, with equivalence if the
  * two quadrants overlap.
  * \return Returns < 0 if \a v1 < \a v2 and \a v1 and \a v2 do not overlap,
@@ -617,6 +629,21 @@ void                p4est_nearest_common_ancestor_D (const p4est_quadrant_t *
 void                p4est_quadrant_transform_face (const p4est_quadrant_t * q,
                                                    p4est_quadrant_t * r,
                                                    const int ftransform[]);
+
+/** Transforms coordinates across a face between trees.
+ * \param [in]  coords_in   Input coordinates.
+ * \param [out] coords_out  Output coordinates.
+ * \param [in] ftransform   This array holds 9 integers.
+ *             [0,2]        The coordinate axis sequence of the origin face.
+ *             [3,5]        The coordinate axis sequence of the target face.
+ *             [6,8]        Edge reverse flag for axis 0; face code for 1.
+ *             [1,4,7]      0 (unused for compatibility with 3D).
+ */
+void                p4est_coordinates_transform_face (const p4est_qcoord_t
+                                                      coords_in[],
+                                                      p4est_qcoord_t
+                                                      coords_out[],
+                                                      const int ftransform[]);
 
 /** Checks if a quadrant touches a corner (diagonally inside or outside).
  */

--- a/src/p4est_connectivity.h
+++ b/src/p4est_connectivity.h
@@ -87,6 +87,7 @@ SC_EXTERN_C_BEGIN;
 typedef enum
 {
   /* make sure to have different values 2D and 3D */
+  P4EST_CONNECT_SELF = 20,
   P4EST_CONNECT_FACE = 21,
   P4EST_CONNECT_CORNER = 22,
   P4EST_CONNECT_FULL = P4EST_CONNECT_CORNER
@@ -200,6 +201,61 @@ typedef struct
   sc_array_t          corner_transforms;
 }
 p4est_corner_info_t;
+
+/** Generic interface for transformations beteen a tree and any of its neighbors */
+typedef struct
+{
+  p4est_connect_type_t neighbor_type; /**< type of connection to neighbor*/
+  p4est_topidx_t      neighbor;   /**< neighbor tree index */
+  int8_t              index_self; /**< index of interface from self's
+                                       perspective */
+  int8_t              index_neighbor; /**< index of interface from neighbor's
+                                           perspective */
+  int8_t              perm[P4EST_DIM]; /**< permutation of dimensions when
+                                            transforming self coords to
+                                            neighbor coords */
+  int8_t              sign[P4EST_DIM]; /**< sign changes when transforming self
+                                            coords to neighbor coords */
+  p4est_qcoord_t      origin_self[P4EST_DIM]; /** point on the interface from
+                                                  self's perspective */
+  p4est_qcoord_t      origin_neighbor[P4EST_DIM]; /** point on the interface
+                                                      from neighbor's
+                                                      perspective */
+}
+p4est_neighbor_transform_t;
+
+/* *INDENT-OFF* */
+
+/** Transform from self's coordinate system to neighbor's coordinate system.
+ *
+ * \param [in]  nt            A neighbor transform.
+ * \param [in]  self_coords   Input quadrant coordinates in self coordinates.
+ * \param [out] neigh_coords  Coordinates transformed into neighbor coordinates.
+ */
+void                p4est_neighbor_transform_coordinates
+                      (const p4est_neighbor_transform_t * nt,
+                       const p4est_qcoord_t self_coords[P4EST_DIM],
+                       p4est_qcoord_t neigh_coords[P4EST_DIM]);
+
+/** Transform from neighbor's coordinate system to self's coordinate system.
+ *
+ * \param [in]  nt            A neighbor transform.
+ * \param [in]  neigh_coords  Input quadrant coordinates in self coordinates.
+ * \param [out] self_coords   Coordinates transformed into neighbor coordinates.
+ */
+void                p4est_neighbor_transform_coordinates_reverse
+                      (const p4est_neighbor_transform_t * nt,
+                       const p4est_qcoord_t neigh_coords[P4EST_DIM],
+                       p4est_qcoord_t self_coords[P4EST_DIM]);
+
+void                p4est_connectivity_get_neighbor_transforms
+                      (p4est_connectivity_t *conn,
+                       p4est_topidx_t tree_id,
+                       p4est_connect_type_t boundary_type,
+                       int boundary_index,
+                       sc_array_t *neighbor_transform_array);
+
+/* *INDENT-ON* */
 
 /** Store the corner numbers 0..4 for each tree face. */
 extern const int    p4est_face_corners[4][2];

--- a/src/p4est_plex.c
+++ b/src/p4est_plex.c
@@ -1053,7 +1053,8 @@ p4est_get_plex_data_int (p4est_t * p4est, p4est_ghost_t * ghost,
       quadrant_get_local_coordinates (p4est, t, q, fc, q_node_coords);
       for (int v = 0; v < V; v++) {
         double             *v_coords =
-          sc_array_index (node_coords, (size_t) quad_to_local[qid * V + v]);
+          (double *) sc_array_index (node_coords,
+                                     (size_t) quad_to_local[qid * V + v]);
 
         for (int d = 0; d < 3; d++) {
           v_coords[d] = q_node_coords[v][d];
@@ -1076,7 +1077,8 @@ p4est_get_plex_data_int (p4est_t * p4est, p4est_ghost_t * ghost,
         quadrant_get_local_coordinates (p4est, t, q, fc, q_node_coords);
         for (int v = 0; v < V; v++) {
           double             *v_coords =
-            sc_array_index (node_coords, (size_t) quad_to_local[qid * V + v]);
+            (double *) sc_array_index (node_coords,
+                                       (size_t) quad_to_local[qid * V + v]);
 
           for (int d = 0; d < 3; d++) {
             v_coords[d] = q_node_coords[v][d];

--- a/src/p4est_plex.c
+++ b/src/p4est_plex.c
@@ -100,6 +100,190 @@ p4est_gloidx_pair_compare (const void *a, const void *b)
 }
 
 static void
+p4est_coordinates_canonicalize (p4est_t * p4est,
+                                p4est_locidx_t tree_id,
+                                const p4est_qcoord_t these_coords[],
+                                p4est_locidx_t * neigh_tree_id,
+                                p4est_qcoord_t neigh_coords[])
+{
+  int                 face_code, n_outside;
+  p4est_connect_type_t neigh_type;
+  int                 neigh_index;
+  sc_array_t          neigh_transforms;
+
+  *neigh_tree_id = tree_id;
+  face_code = 0;
+  n_outside = 0;
+  for (int d = 0; d < P4EST_DIM; d++) {
+    neigh_coords[d] = these_coords[d];
+    P4EST_ASSERT (0 <= these_coords[d] && these_coords[d] <= P4EST_ROOT_LEN);
+    face_code |= (these_coords[d] == 0) ? (1 << (2 * d)) : 0;
+    face_code |= (these_coords[d] == P4EST_ROOT_LEN) ? (1 << (2 * d + 1)) : 0;
+    n_outside += (these_coords[d] == 0 || these_coords[d] == P4EST_ROOT_LEN);
+  }
+  switch (n_outside) {
+  case 0:
+    return;
+  case 1:
+    neigh_type = P4EST_CONNECT_FACE;
+    neigh_index = SC_LOG2_8 (face_code);
+    break;
+#ifdef P4_TO_P8
+  case 2:
+    neigh_type = P8EST_CONNECT_EDGE;
+    neigh_index = -1;
+    for (int e = 0; e < P8EST_EDGES; e++) {
+      if ((face_code & (1 << p8est_edge_faces[e][0])) &&
+          (face_code & (1 << p8est_edge_faces[e][1]))) {
+        neigh_index = e;
+        break;
+      }
+    }
+    P4EST_ASSERT (neigh_index >= 0);
+    break;
+#endif
+  case P4EST_DIM:
+    neigh_type = P4EST_CONNECT_CORNER;
+    neigh_index = 0;
+    for (int d = 0; d < P4EST_DIM; d++) {
+      neigh_index += (face_code & (1 << (2 * d + 1))) ? (1 << d) : 0;
+    }
+    break;
+  default:
+    SC_ABORT_NOT_REACHED ();
+  }
+  sc_array_init (&neigh_transforms, sizeof (p4est_neighbor_transform_t));
+  p4est_connectivity_get_neighbor_transforms (p4est->connectivity, tree_id,
+                                              neigh_type, neigh_index,
+                                              &neigh_transforms);
+  /* skip the first neighbor which is self */
+  for (size_t iz = 1; iz < neigh_transforms.elem_count; iz++) {
+    p4est_neighbor_transform_t *nt =
+      (p4est_neighbor_transform_t *) sc_array_index (&neigh_transforms, iz);
+    p4est_qcoord_t      trans_coords[P4EST_DIM];
+
+    if (nt->neighbor > *neigh_tree_id) {
+      continue;
+    }
+    p4est_neighbor_transform_coordinates (nt, these_coords, trans_coords);
+    if (nt->neighbor < *neigh_tree_id
+        || p4est_coordinates_compare (trans_coords, neigh_coords) < 0) {
+      *neigh_tree_id = nt->neighbor;
+      for (int d = 0; d < P4EST_DIM; d++) {
+        neigh_coords[d] = trans_coords[d];
+      }
+    }
+  }
+  sc_array_reset (&neigh_transforms);
+}
+
+/* Given a quadrant, local or ghost, and its
+
+   - face code and
+   - quad_to_local map,
+
+   compute the vertex coordinates at the center of each
+   local interface.  The vertex coordinates can be ambiguous
+   on a periodic or mesh with disconnected vertices, so
+   this function canonicalizes the results so that all
+   quadrants that share a node will agree on its coordinates.
+
+   We even compute the coordinates of mesh points that are not vertices (at
+   their centers), because the mesh point may be a parent to a vertex,
+   and that vertex will inherit its coordinates
+*/
+static void
+quadrant_get_local_coordinates (p4est_t * p4est, p4est_locidx_t tree_id,
+                                p4est_quadrant_t * quad,
+                                p4est_lnodes_code_t face_code,
+                                double coords[][3])
+{
+#ifndef P4_TO_P8
+  int                 dim_limits[3] = { 0, 4, 8 };
+#else
+  int                 dim_limits[4] = { 0, 6, 18, 26 };
+#endif
+  int                 has_hanging, hanging[3][12];
+  p4est_quadrant_t    p;
+  /* initialize each local dof with (tree_id, qcoord) coordinates */
+  p4est_qcoord_t      h = P4EST_QUADRANT_LEN (quad->level), H;
+
+  P4EST_QUADRANT_INIT (&p);
+#ifndef P4_TO_P8
+  has_hanging = p4est_lnodes_decode (face_code, &hanging[0][0]);
+#else
+  has_hanging =
+    p8est_lnodes_decode (face_code, &hanging[0][0], &hanging[1][0]);
+#endif
+  has_hanging |= lnodes_decode2 (face_code, &hanging[P4EST_DIM - 1][0]);
+  H = h;
+  if (has_hanging) {
+    p4est_quadrant_parent (quad, &p);
+    H = P4EST_QUADRANT_LEN (p.level);
+  }
+
+  /* compute the coordinates in this tree */
+  for (int dim = 0; dim < P4EST_DIM; dim++) {
+    int                 vstart = dim_limits[P4EST_DIM - dim - 1];
+    int                 vend = dim_limits[P4EST_DIM - dim];
+    const int          *vhanging = &(hanging[P4EST_DIM - dim - 1][0]);
+
+    for (int v = 0; v < vend - vstart; v++) {
+      p4est_qcoord_t      these_coords[3];
+      p4est_qcoord_t      neigh_coords[3];
+      p4est_quadrant_t   *q = (has_hanging && (vhanging[v] >= 0)) ? &p : quad;
+      p4est_qcoord_t      vh = (has_hanging && (vhanging[v] >= 0)) ? H : h;
+      p4est_locidx_t      neigh_tree_id;
+
+      these_coords[0] = q->x;
+      these_coords[1] = q->y;
+#ifdef P4_TO_P8
+      these_coords[2] = q->z;
+#endif
+
+      switch (dim) {
+      case 0:                  /* corners */
+        for (int d = 0; d < P4EST_DIM; d++) {
+          these_coords[d] += (v & (1 << d)) ? vh : 0;
+        }
+        break;
+      case (P4EST_DIM - 1):    /* faces */
+        for (int d = 0; d < P4EST_DIM; d++) {
+          these_coords[d] += (d == v / 2) ? ((v & 1) * vh) : vh / 2;
+        }
+        break;
+#ifdef P4_TO_P8
+      case 1:                  /* edges */
+        {
+          int                 lo_dir[3] = { 1, 0, 0 };
+          for (int d = 0; d < P4EST_DIM; d++) {
+            these_coords[d] += (d == v / 4) ? vh / 2 :
+              vh * ((d == lo_dir[v / 4]) ? (v & 1) : ((v & 2) >> 1));
+          }
+        }
+        break;
+#endif
+      default:
+        SC_ABORT_NOT_REACHED ();
+      }
+      for (int d = 0; d < P4EST_DIM; d++) {
+        P4EST_ASSERT (0 <= these_coords[d]
+                      && these_coords[d] <= P4EST_ROOT_LEN);
+      }
+      p4est_coordinates_canonicalize (p4est, tree_id, these_coords,
+                                      &neigh_tree_id, neigh_coords);
+      p4est_qcoord_to_vertex (p4est->connectivity, neigh_tree_id,
+                              neigh_coords[0], neigh_coords[1],
+#ifdef P4_TO_P8
+                              neigh_coords[2],
+#endif
+                              &coords[v + vstart][0]);
+    }
+  }
+
+}
+
+static void
 mark_parent (p4est_locidx_t qid, int ctype_int, p4est_lnodes_code_t * F,
              p4est_locidx_t * quad_to_local, int8_t * is_parent,
              int8_t * node_dim)
@@ -560,6 +744,7 @@ p4est_get_plex_data_int (p4est_t * p4est, p4est_ghost_t * ghost,
   p4est_locidx_t      qid;
   int                 v, V = lnodes->vnodes;
   sc_array_t         *is_parent, *node_dim;
+  sc_array_t         *node_coords;
   int                 ctype_int = p4est_connect_type_int (P4EST_CONNECT_FULL);
   p4est_locidx_t      num_global, num_global_plus_children, last_global,
     *child_offsets;
@@ -845,6 +1030,57 @@ p4est_get_plex_data_int (p4est_t * p4est, p4est_ghost_t * ghost,
         }
         else {
           *dim = 0;
+        }
+      }
+    }
+  }
+
+  /* loop over quads:
+   * - compute coordinates for each node
+   */
+  node_coords = sc_array_new_size (3 * sizeof (double), num_global);
+  for (qid = 0, t = flt; t <= llt; t++) {
+    p4est_tree_t       *tree = p4est_tree_array_index (p4est->trees, t);
+    sc_array_t         *quadrants = &(tree->quadrants);
+    p4est_locidx_t      num_quads = (p4est_locidx_t) quadrants->elem_count;
+
+    for (p4est_locidx_t il = 0; il < num_quads; il++, qid++) {
+      p4est_quadrant_t   *q =
+        p4est_quadrant_array_index (quadrants, (size_t) il);
+      p4est_lnodes_code_t fc = F[qid];
+      double              q_node_coords[P4EST_INSUL][3];
+
+      quadrant_get_local_coordinates (p4est, t, q, fc, q_node_coords);
+      for (int v = 0; v < V; v++) {
+        double             *v_coords =
+          sc_array_index (node_coords, (size_t) quad_to_local[qid * V + v]);
+
+        for (int d = 0; d < 3; d++) {
+          v_coords[d] = q_node_coords[v][d];
+        }
+      }
+    }
+  }
+  if (overlap) {
+    for (t = 0; t < p4est->connectivity->num_trees; t++) {
+      p4est_locidx_t      il, istart = ghost->tree_offsets[t];
+      p4est_locidx_t      iend = ghost->tree_offsets[t + 1];
+
+      for (il = istart; il < iend; il++) {
+        p4est_quadrant_t   *q =
+          p4est_quadrant_array_index (&ghost->ghosts, (size_t) il);
+        p4est_locidx_t      qid = il + Klocal;
+        p4est_lnodes_code_t fc = F[qid];
+        double              q_node_coords[P4EST_INSUL][3];
+
+        quadrant_get_local_coordinates (p4est, t, q, fc, q_node_coords);
+        for (int v = 0; v < V; v++) {
+          double             *v_coords =
+            sc_array_index (node_coords, (size_t) quad_to_local[qid * V + v]);
+
+          for (int d = 0; d < 3; d++) {
+            v_coords[d] = q_node_coords[v][d];
+          }
         }
       }
     }
@@ -1402,175 +1638,28 @@ p4est_get_plex_data_int (p4est_t * p4est, p4est_ghost_t * ghost,
     }
 #endif
     /* compute coordinates */
-    for (qid = 0, t = flt; t <= llt; t++) {
-      p4est_tree_t       *tree = p4est_tree_array_index (p4est->trees, t);
-      sc_array_t         *quadrants = &(tree->quadrants);
-      p4est_locidx_t      num_quads = (p4est_locidx_t) quadrants->elem_count;
+    for (p4est_locidx_t v = 0;
+         v < dim_offsets[ctype_int + 1] - dim_offsets[ctype_int]; v++) {
+      p4est_locidx_t      lid = plex_to_local[v + dim_offsets[ctype_int]] - K;
+      p4est_locidx_t      parent;
+      const double       *n_coords;
+      double             *v_coords = &coords[v * 3];
 
-      for (il = 0; il < num_quads; il++, qid++) {
-        p4est_quadrant_t   *q =
-          p4est_quadrant_array_index (quadrants, (size_t) il);
-        p4est_qcoord_t      h = P4EST_QUADRANT_LEN (q->level);
-        int                 vstart, vend;
+      P4EST_ASSERT (lid >= 0);
 
-        vstart = dim_limits[P4EST_DIM - 1];
-        vend = dim_limits[P4EST_DIM];
-        for (v = vstart; v < vend; v++) {
-          int                 corner = v - vstart;
-          p4est_locidx_t      vid =
-            local_to_plex[quad_to_local[qid * V + v] + K] -
-            dim_offsets[P4EST_DIM];
-          p4est_locidx_t      vid2 =
-            (quad_to_local_orig !=
-             NULL) ? (local_to_plex[quad_to_local_orig[qid * V + v] + K] -
-                      dim_offsets[P4EST_DIM]) : vid;
-          double              vcoord[3];
-
-          p4est_qcoord_to_vertex (p4est->connectivity, t,
-                                  q->x + ((corner & 1) ? h : 0),
-                                  q->y + ((corner & 2) ? h : 0),
-#ifdef P4_TO_P8
-                                  q->z + ((corner & 4) ? h : 0),
-#endif
-                                  vcoord);
-          coords[3 * vid + 0] = vcoord[0];
-          coords[3 * vid + 1] = vcoord[1];
-          coords[3 * vid + 2] = vcoord[2];
-
-          if (vid2 != vid) {
-            p4est_quadrant_t    p;
-
-            p4est_quadrant_parent (q, &p);
-            p4est_qcoord_to_vertex (p4est->connectivity, t,
-                                    p.x + ((corner & 1) ? (2 * h) : 0),
-                                    p.y + ((corner & 2) ? (2 * h) : 0),
-#ifdef P4_TO_P8
-                                    p.z + ((corner & 4) ? (2 * h) : 0),
-#endif
-                                    vcoord);
-            coords[3 * vid2 + 0] = vcoord[0];
-            coords[3 * vid2 + 1] = vcoord[1];
-            coords[3 * vid2 + 2] = vcoord[2];
-          }
-        }
+      parent = *((p4est_locidx_t *) sc_array_index (child_to_parent, lid));
+      if (parent >= 0) {
+        n_coords = (double *) sc_array_index (node_coords, parent);
+      }
+      else {
+        n_coords = (double *) sc_array_index (node_coords, lid);
+      }
+      for (int d = 0; d < 3; d++) {
+        v_coords[d] = n_coords[d];
       }
     }
-    /* interpolate children coordinates from parent vertices */
-    for (il = 0; il < num_global; il++) {
-      p4est_locidx_t      pid, nid;
-      int8_t              isp;
 
-      nid = il + K;
-      pid = local_to_plex[nid];
-      isp = *((int8_t *) sc_array_index (is_parent, il));
-      if (isp) {
-        p4est_locidx_t      cvert = child_offsets[il + 1] - 1, poff, vid;
-        int8_t              pdim;
-        p4est_locidx_t     *pcones;
-
-        pdim = *((int8_t *) sc_array_index (node_dim, (size_t) il));
-        poff =
-          dim_cone_offsets[P4EST_DIM - pdim] + 2 * pdim * (pid -
-                                                           dim_offsets
-                                                           [P4EST_DIM -
-                                                            pdim]);
-        pcones = &cones[poff];
-        vid = local_to_plex[cvert + K] - dim_offsets[P4EST_DIM];
-        if (pdim == 1) {
-          p4est_locidx_t      pvid[2];
-
-          pvid[0] = pcones[0] - dim_offsets[P4EST_DIM];
-          pvid[1] = pcones[1] - dim_offsets[P4EST_DIM];
-          coords[3 * vid + 0] =
-            0.5 * (coords[3 * pvid[0] + 0] + coords[3 * pvid[1] + 0]);
-          coords[3 * vid + 1] =
-            0.5 * (coords[3 * pvid[0] + 1] + coords[3 * pvid[1] + 1]);
-          coords[3 * vid + 2] =
-            0.5 * (coords[3 * pvid[0] + 2] + coords[3 * pvid[1] + 2]);
-        }
-#ifdef P4_TO_P8
-        else {
-          int                 j, k;
-
-          coords[3 * vid + 0] = 0.;
-          coords[3 * vid + 1] = 0.;
-          coords[3 * vid + 2] = 0.;
-
-          for (j = 0; j < 4; j++) {
-            p4est_locidx_t      coff, *ccones;
-            p4est_locidx_t      pvid[2];
-
-            coff =
-              dim_cone_offsets[P4EST_DIM - 1] + 2 * (pcones[j] -
-                                                     dim_offsets[P4EST_DIM -
-                                                                 1]);
-            ccones = &cones[coff];
-
-            pvid[0] = ccones[0] - dim_offsets[P4EST_DIM];
-            pvid[1] = ccones[1] - dim_offsets[P4EST_DIM];
-            for (k = 0; k < 3; k++) {
-              coords[3 * vid + k] +=
-                0.125 * (coords[3 * pvid[0] + k] + coords[3 * pvid[1] + k]);
-            }
-          }
-        }
-#endif
-      }
-    }
-    if (overlap) {
-      for (t = 0; t < p4est->connectivity->num_trees; t++) {
-        p4est_locidx_t      il, istart = ghost->tree_offsets[t];
-        p4est_locidx_t      iend = ghost->tree_offsets[t + 1];
-
-        for (il = istart; il < iend; il++, qid++) {
-          p4est_quadrant_t   *q =
-            p4est_quadrant_array_index (&ghost->ghosts, (size_t) il);
-          p4est_qcoord_t      h = P4EST_QUADRANT_LEN (q->level);
-          int                 vstart, vend;
-
-          vstart = dim_limits[P4EST_DIM - 1];
-          vend = dim_limits[P4EST_DIM];
-          for (v = vstart; v < vend; v++) {
-            int                 corner = v - vstart;
-            p4est_locidx_t      vid =
-              local_to_plex[quad_to_local[qid * V + v] + K] -
-              dim_offsets[P4EST_DIM];
-            p4est_locidx_t      vid2 =
-              (quad_to_local_orig !=
-               NULL) ? (local_to_plex[quad_to_local_orig[qid * V + v] + K] -
-                        dim_offsets[P4EST_DIM]) : vid;
-            double              vcoord[3];
-
-            p4est_qcoord_to_vertex (p4est->connectivity, t,
-                                    q->x + ((corner & 1) ? h : 0),
-                                    q->y + ((corner & 2) ? h : 0),
-#ifdef P4_TO_P8
-                                    q->z + ((corner & 4) ? h : 0),
-#endif
-                                    vcoord);
-            coords[3 * vid + 0] = vcoord[0];
-            coords[3 * vid + 1] = vcoord[1];
-            coords[3 * vid + 2] = vcoord[2];
-
-            if (vid2 != vid) {
-              p4est_quadrant_t    p;
-
-              p4est_quadrant_parent (q, &p);
-              p4est_qcoord_to_vertex (p4est->connectivity, t,
-                                      p.x + ((corner & 1) ? (2 * h) : 0),
-                                      p.y + ((corner & 2) ? (2 * h) : 0),
-#ifdef P4_TO_P8
-                                      p.z + ((corner & 4) ? (2 * h) : 0),
-#endif
-                                      vcoord);
-              coords[3 * vid2 + 0] = vcoord[0];
-              coords[3 * vid2 + 1] = vcoord[1];
-              coords[3 * vid2 + 2] = vcoord[2];
-            }
-          }
-        }
-      }
-    }
+    sc_array_destroy (node_coords);
 
     /* cleanup */
     P4EST_FREE (quad_to_local);

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -65,6 +65,7 @@
 #define P4EST_LEAF_IS_FIRST_IN_TREE     P8EST_LEAF_IS_FIRST_IN_TREE
 
 /* redefine enums */
+#define P4EST_CONNECT_SELF              P8EST_CONNECT_SELF
 #define P4EST_CONNECT_FACE              P8EST_CONNECT_FACE
 #define P4EST_CONNECT_CORNER            P8EST_CONNECT_CORNER
 #define P4EST_CONNECT_FULL              P8EST_CONNECT_FULL
@@ -87,6 +88,7 @@
 #define p4est_connectivity_t            p8est_connectivity_t
 #define p4est_corner_transform_t        p8est_corner_transform_t
 #define p4est_corner_info_t             p8est_corner_info_t
+#define p4est_neighbor_transform_t      p8est_neighbor_transform_t
 #define p4est_geometry_t                p8est_geometry_t
 #define p4est_t                         p8est_t
 #define p4est_tree_t                    p8est_tree_t
@@ -165,6 +167,12 @@
 #define p4est_expand_face_transform     p8est_expand_face_transform
 #define p4est_find_face_transform       p8est_find_face_transform
 #define p4est_find_corner_transform     p8est_find_corner_transform
+#define p4est_neighbor_transform_coordinates \
+        p8est_neighbor_transform_coordinates
+#define p4est_neighbor_transform_coordinates_reverse \
+        p8est_neighbor_transform_coordinates_reverse
+#define p4est_connectivity_get_neighbor_transforms \
+        p8est_connectivity_get_neighbor_transforms
 #define p4est_corner_array_index        p8est_corner_array_index
 #define p4est_connectivity_reorder      p8est_connectivity_reorder
 #define p4est_connectivity_reorder_newid                \
@@ -324,6 +332,10 @@
 #define p4est_quadrant_successor        p8est_quadrant_successor
 #define p4est_quadrant_predecessor      p8est_quadrant_predecessor
 #define p4est_quadrant_srand            p8est_quadrant_srand
+#define p4est_neighbor_transform_quadrant       \
+        p8est_neighbor_transform_quadrant
+#define p4est_neighbor_transform_quadrant_reverse    \
+        p8est_neighbor_transform_quadrant_reverse
 
 /* functions in p4est_search */
 #define p4est_find_partition            p8est_find_partition

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -254,6 +254,7 @@
 #define p4est_quadrant_overlaps         p8est_quadrant_overlaps
 #define p4est_quadrant_is_equal_piggy   p8est_quadrant_is_equal_piggy
 #define p4est_quadrant_compare          p8est_quadrant_compare
+#define p4est_coordinates_compare       p8est_coordinates_compare
 #define p4est_quadrant_disjoint         p8est_quadrant_disjoint
 #define p4est_quadrant_compare_piggy    p8est_quadrant_compare_piggy
 #define p4est_quadrant_compare_local_num p8est_quadrant_compare_local_num
@@ -312,6 +313,8 @@
 #define p4est_quadrant_corner_descendant p8est_quadrant_corner_descendant
 #define p4est_nearest_common_ancestor   p8est_nearest_common_ancestor
 #define p4est_nearest_common_ancestor_D p8est_nearest_common_ancestor_D
+#define p4est_coordinates_transform_face        \
+        p8est_coordinates_transform_face
 #define p4est_quadrant_transform_face   p8est_quadrant_transform_face
 #define p4est_quadrant_touches_corner   p8est_quadrant_touches_corner
 #define p4est_quadrant_transform_corner p8est_quadrant_transform_corner

--- a/src/p6est.c
+++ b/src/p6est.c
@@ -162,8 +162,8 @@ p6est_connectivity_memory_used (p6est_connectivity_t * conn)
 {
   return
     p4est_connectivity_memory_used (conn->conn4) +
-    conn->top_vertices == NULL ? 0 :
-    (conn->conn4->num_vertices * 3 * sizeof (double));
+    ((conn->top_vertices == NULL) ? 0 :
+     (conn->conn4->num_vertices * 3 * sizeof (double)));
 }
 
 int
@@ -289,7 +289,7 @@ p6est_connectivity_save (const char *filename, p6est_connectivity_t * conn)
 }
 
 p6est_connectivity_t *
-p6est_connectivity_load (const char *filename, size_t * bytes)
+p6est_connectivity_load (const char *filename, size_t *bytes)
 {
   int                 retval;
   size_t              bytes_in;
@@ -761,7 +761,7 @@ p6est_save_ext (const char *filename, p6est_t * p6est,
     SC_CHECK_ABORT (file != NULL, "file open");
 
     /* explicitly seek to end to avoid bad ftell return value on Windows */
-    retval = fseek(file, 0, SEEK_END);
+    retval = fseek (file, 0, SEEK_END);
     SC_CHECK_ABORT (retval == 0, "file seek");
 
     /* align */

--- a/src/p8est_bits.c
+++ b/src/p8est_bits.c
@@ -370,6 +370,60 @@ p8est_quadrant_touches_edge (const p4est_quadrant_t * q, int edge, int inside)
 }
 
 void
+p8est_coordinates_transform_edge (const p4est_qcoord_t coords_in[],
+                                  p4est_qcoord_t coords_out[],
+                                  const p8est_edge_info_t * ei,
+                                  const p8est_edge_transform_t * et)
+{
+  int                 iaxis;
+  p4est_qcoord_t      my_xyz, *target_xyz[3];
+
+  iaxis = (int) ei->iedge / 4;
+  P4EST_ASSERT (0 <= et->naxis[0] && et->naxis[0] < 3);
+  P4EST_ASSERT (0 <= et->naxis[1] && et->naxis[1] < 3);
+  P4EST_ASSERT (0 <= et->naxis[2] && et->naxis[2] < 3);
+  P4EST_ASSERT (et->naxis[0] != et->naxis[1] &&
+                et->naxis[0] != et->naxis[2] && et->naxis[1] != et->naxis[2]);
+  P4EST_ASSERT (0 <= et->nflip && et->nflip < 2);
+  P4EST_ASSERT (coords_in != coords_out);
+
+  for (int d = 0; d < P4EST_DIM; d++) {
+    target_xyz[d] = &coords_out[d];
+  }
+
+  /* transform coordinate axis parallel to edge */
+  my_xyz = coords_in[iaxis];
+  if (!et->nflip) {
+    *target_xyz[et->naxis[0]] = my_xyz;
+  }
+  else {
+    *target_xyz[et->naxis[0]] = P4EST_ROOT_LEN - my_xyz;
+  }
+
+  /* create the other two coordinates */
+  switch (et->corners) {
+  case 0:
+    *target_xyz[et->naxis[1]] = 0;
+    *target_xyz[et->naxis[2]] = 0;
+    break;
+  case 1:
+    *target_xyz[et->naxis[1]] = P4EST_ROOT_LEN;
+    *target_xyz[et->naxis[2]] = 0;
+    break;
+  case 2:
+    *target_xyz[et->naxis[1]] = 0;
+    *target_xyz[et->naxis[2]] = P4EST_ROOT_LEN;
+    break;
+  case 3:
+    *target_xyz[et->naxis[1]] = P4EST_ROOT_LEN;
+    *target_xyz[et->naxis[2]] = P4EST_ROOT_LEN;
+    break;
+  default:
+    SC_ABORT_NOT_REACHED ();
+  }
+}
+
+void
 p8est_quadrant_transform_edge (const p4est_quadrant_t * q,
                                p4est_quadrant_t * r,
                                const p8est_edge_info_t * ei,

--- a/src/p8est_bits.h
+++ b/src/p8est_bits.h
@@ -88,6 +88,18 @@ int                 p8est_quadrant_is_equal_piggy (const p8est_quadrant_t *
  */
 int                 p8est_quadrant_compare (const void *v1, const void *v2);
 
+/** Compare two sets of coordintes in their Morton ordering.
+ * Coordinates are signed, but the sorted order will treat them
+ * as unsigned, with negative coordinates being greater than
+ * positive coordinates because of their representation in twos-complement.
+ * \param [in] v1, v2    Two sets of 3d coordinates.
+ * \return Returns < 0 if \a v1 < \a v2,
+ *                   0 if \a v1 == \a v2,
+ *                 > 0 if \a v1 > \a v2
+ */
+int                 p8est_coordinates_compare (const p4est_qcoord_t v1[],
+                                               const p4est_qcoord_t v2[]);
+
 /** Compare two quadrants in their Morton ordering, with equivalence if the
  * two quadrants overlap.
  * \return Returns < 0 if \a v1 < \a v2 and \a v1 and \v2 do not overlap,
@@ -677,6 +689,20 @@ void                p8est_quadrant_transform_face (const p8est_quadrant_t * q,
                                                    p8est_quadrant_t * r,
                                                    const int ftransform[]);
 
+/** Transforms coordinates across a face between trees.
+ * \param [in]  coords_in   Input coordinates.
+ * \param [out] coords_out  Output coordinates.
+ * \param [in] ftransform   This array holds 9 integers.
+ *             [0]..[2]     The coordinate axis sequence of the origin face.
+ *             [3]..[5]     The coordinate axis sequence of the target face.
+ *             [6]..[8]     Edge reverse flag for axes 0, 1; face code for 2.
+ */
+void                p8est_coordinates_transform_face (const p4est_qcoord_t
+                                                      coords_in[],
+                                                      p4est_qcoord_t
+                                                      coords_out[],
+                                                      const int ftransform[]);
+
 /** Checks if a quadrant touches an edge (diagonally inside or outside).
  */
 int                 p8est_quadrant_touches_edge (const p8est_quadrant_t * q,
@@ -685,8 +711,8 @@ int                 p8est_quadrant_touches_edge (const p8est_quadrant_t * q,
 /** Transforms a quadrant across an edge between trees.
  * \param [in]     q          Input quadrant.
  * \param [in,out] r          Quadrant whose Morton index will be filled.
- * \param [in]     edge       Edge index of the originating quadrant.
- * \param [in]     ei         Edge information computed previously.
+ * \param [in]     ei         Edge info from p8est_find_edge_transform().
+ * \param [in]     et         One of ei's transformations.
  * \param [in]     inside     The quadrant will be placed inside or outside.
  */
 void                p8est_quadrant_transform_edge (const p8est_quadrant_t * q,
@@ -696,6 +722,23 @@ void                p8est_quadrant_transform_edge (const p8est_quadrant_t * q,
                                                    const
                                                    p8est_edge_transform_t *
                                                    et, int inside);
+
+/** Transforms coordinates on an edge between trees.
+ * \param [in]     coords_in  Input coordinates.
+ * \param [out]    coords_out Output coordinates.
+ * \param [in]     ei         Edge info from p8est_find_edge_transform().
+ * \param [in]     et         One of ei's transformations.
+ */
+void                p8est_coordinates_transform_edge (const p4est_qcoord_t
+                                                      coords_in[],
+                                                      p4est_qcoord_t
+                                                      coords_out[],
+                                                      const
+                                                      p8est_edge_info_t *
+                                                      ei,
+                                                      const
+                                                      p8est_edge_transform_t *
+                                                      et);
 
 /** Shifts a quadrant until it touches the specified edge from the inside.
  * If this shift is meant to recreate the effects of \a q on balancing across

--- a/src/p8est_bits.h
+++ b/src/p8est_bits.h
@@ -843,6 +843,33 @@ void                p8est_quadrant_predecessor (const p8est_quadrant_t *
 void                p8est_quadrant_srand (const p8est_quadrant_t * q,
                                           sc_rand_state_t * rstate);
 
+/** Transform a quadrant from self's coordinate system to neighbor's coordinate system.
+ *
+ * \param [in]  nt            A neighbor transform.
+ * \param [in]  self_quad     Input quadrant in self coordinates.
+ * \param [out] neigh_coords  Quad transformed into neighbor coordinates.
+ *
+ * \note This transform gives meaningful results when \a self_quad is inside
+ * the tree root or touches the interface between the two trees in the
+ * transform.
+ */
+void                p8est_neighbor_transform_quadrant
+  (const p8est_neighbor_transform_t * nt,
+   const p8est_quadrant_t * self_quad, p8est_quadrant_t * neigh_quad);
+
+/** Transform a quadrant from a neighbors's coordinate system to self's coordinate system.
+ *
+ * \param [in]  nt            A neighbor transform.
+ * \param [in]  neigh_coords  Input quadrant in neighbor coordinates.
+ * \param [out] self_coords   Quad transformed into self coordinates.
+ *
+ * \note This transform gives meaningful results when \a neigh_quad is inside
+ * the tree root or touches the interface between the two trees in the
+ * transform.
+ */
+void                p4est_neighbor_transform_quadrant_reverse
+  (const p8est_neighbor_transform_t * nt,
+   const p8est_quadrant_t * neigh_quad, p8est_quadrant_t * self_quad);
 SC_EXTERN_C_END;
 
 #endif /* !P8EST_BITS_H */

--- a/src/p8est_connectivity.c
+++ b/src/p8est_connectivity.c
@@ -24,6 +24,7 @@
 
 #include <p4est_to_p8est.h>
 #include <p8est_connectivity.h>
+#include <p8est.h>
 
 /* *INDENT-OFF* */
 const int           p8est_face_corners[6][4] =

--- a/src/p8est_connectivity.h
+++ b/src/p8est_connectivity.h
@@ -89,6 +89,7 @@ SC_EXTERN_C_BEGIN;
 typedef enum
 {
   /* make sure to have different values 2D and 3D */
+  P8EST_CONNECT_SELF = 30,
   P8EST_CONNECT_FACE = 31,
   P8EST_CONNECT_EDGE = 32,
   P8EST_CONNECT_CORNER = 33,
@@ -244,6 +245,61 @@ typedef struct
   sc_array_t          corner_transforms;
 }
 p8est_corner_info_t;
+
+/** Generic interface for transformations beteen a tree and any of its neighbors */
+typedef struct
+{
+  p8est_connect_type_t neighbor_type; /**< type of connection to neighbor*/
+  p4est_topidx_t      neighbor;   /**< neighbor tree index */
+  int8_t              index_self; /**< index of interface from self's
+                                       perspective */
+  int8_t              index_neighbor; /**< index of interface from neighbor's
+                                           perspective */
+  int8_t              perm[P8EST_DIM]; /**< permutation of dimensions when
+                                            transforming self coords to
+                                            neighbor coords */
+  int8_t              sign[P8EST_DIM]; /**< sign changes when transforming self
+                                            coords to neighbor coords */
+  p4est_qcoord_t      origin_self[P8EST_DIM]; /** point on the interface from
+                                                  self's perspective */
+  p4est_qcoord_t      origin_neighbor[P8EST_DIM]; /** point on the interface
+                                                      from neighbor's
+                                                      perspective */
+}
+p8est_neighbor_transform_t;
+
+/* *INDENT-OFF* */
+
+/** Transform from self's coordinate system to neighbor's coordinate system.
+ *
+ * \param [in]  nt            A neighbor transform.
+ * \param [in]  self_coords   Input quadrant coordinates in self coordinates.
+ * \param [out] neigh_coords  Coordinates transformed into neighbor coordinates.
+ */
+void                p8est_neighbor_transform_coordinates
+                      (const p8est_neighbor_transform_t * nt,
+                       const p4est_qcoord_t self_coords[P8EST_DIM],
+                       p4est_qcoord_t neigh_coords[P8EST_DIM]);
+
+/** Transform from neighbor's coordinate system to self's coordinate system.
+ *
+ * \param [in]  nt            A neighbor transform.
+ * \param [in]  neigh_coords  Input quadrant coordinates in self coordinates.
+ * \param [out] self_coords   Coordinates transformed into neighbor coordinates.
+ */
+void                p8est_neighbor_transform_coordinates_reverse
+                      (const p8est_neighbor_transform_t * nt,
+                       const p4est_qcoord_t neigh_coords[P8EST_DIM],
+                       p4est_qcoord_t self_coords[P8EST_DIM]);
+
+void                p8est_connectivity_get_neighbor_transforms
+                      (p8est_connectivity_t *conn,
+                       p4est_topidx_t tree_id,
+                       p8est_connect_type_t boundary_type,
+                       int boundary_index,
+                       sc_array_t *neighbor_transform_array);
+
+/* *INDENT-ON* */
 
 /** Store the corner numbers 0..7 for each tree face. */
 extern const int    p8est_face_corners[6][4];

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -15,7 +15,7 @@ p4est_test_programs += \
         test/p4est_test_mesh_bijective test/p4est_test_conn_transformation \
         test/p4est_test_iterate test/p4est_test_lnodes \
         test/p4est_test_search test/p4est_test_brick \
-	test/p4est_test_complete_subtree \
+        test/p4est_test_complete_subtree \
         test/p4est_test_partition_corr \
         test/p4est_test_conn_complete test/p4est_test_balance_seeds \
         test/p4est_test_wrap test/p4est_test_replace test/p4est_test_join \
@@ -23,6 +23,7 @@ p4est_test_programs += \
         test/p4est_test_connrefine \
         test/p4est_test_subcomm \
         test/p4est_test_nodes \
+        test/p4est_test_neighbor_transform \
         test/p4est_test_version
 if P4EST_WITH_METIS
 p4est_test_programs += \
@@ -47,6 +48,7 @@ p4est_test_programs += \
         test/p8est_test_connrefine \
         test/p8est_test_subcomm \
         test/p8est_test_nodes \
+        test/p8est_test_neighbor_transform \
         test/p8est_test_version
 if P4EST_WITH_METIS
 p4est_test_programs += \
@@ -99,6 +101,7 @@ test_p4est_test_plex_SOURCES = test/test_plex2.c
 test_p4est_test_connrefine_SOURCES = test/test_connrefine2.c
 test_p4est_test_subcomm_SOURCES = test/test_subcomm2.c
 test_p4est_test_nodes_SOURCES = test/test_nodes2.c
+test_p4est_test_neighbor_transform_SOURCES = test/test_neighbor_transform2.c
 test_p4est_test_version_SOURCES = test/test_version.c
 if P4EST_WITH_METIS
 test_p4est_test_reorder_SOURCES = test/test_reorder2.c
@@ -138,6 +141,7 @@ test_p8est_test_plex_SOURCES = test/test_plex3.c
 test_p8est_test_connrefine_SOURCES = test/test_connrefine3.c
 test_p8est_test_subcomm_SOURCES = test/test_subcomm3.c
 test_p8est_test_nodes_SOURCES = test/test_nodes3.c
+test_p8est_test_neighbor_transform_SOURCES = test/test_neighbor_transform3.c
 test_p8est_test_version_SOURCES = test/test_version.c
 if P4EST_WITH_METIS
 test_p8est_test_reorder_SOURCES = test/test_reorder3.c

--- a/test/test_neighbor_transform2.c
+++ b/test/test_neighbor_transform2.c
@@ -1,0 +1,534 @@
+/*
+  This file is part of p4est.
+  p4est is a C library to manage a collection (a forest) of multiple
+  connected adaptive quadtrees or octrees in parallel.
+
+  Copyright (C) 2010 The University of Texas System
+  Additional copyright (C) 2011 individual authors
+  Written by Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac
+
+  p4est is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  p4est is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with p4est; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#ifndef P4_TO_P8
+#include <p4est_connectivity.h>
+#include <p4est_bits.h>
+#else
+#include <p8est_connectivity.h>
+#include <p8est_bits.h>
+#endif
+
+static void
+quad_coords (const p4est_quadrant_t * quad, p4est_qcoord_t coords[P4EST_DIM],
+             int corner)
+{
+  p4est_qcoord_t      h = P4EST_QUADRANT_LEN (quad->level);
+
+  coords[0] = quad->x;
+  coords[1] = quad->y;
+#ifdef P4_TO_P8
+  coords[2] = quad->z;
+#endif
+  for (int d = 0; d < P4EST_DIM; d++) {
+    coords[d] += (corner & (1 << d)) ? h : 0;
+  }
+}
+
+static int
+coords_equal (const p4est_qcoord_t A[], p4est_qcoord_t B[])
+{
+  for (int d = 0; d < P4EST_DIM; d++) {
+    if (A[d] != B[d]) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static void
+test_find_self_transform (sc_array_t * neigh_transforms, int t, int found[])
+{
+  for (size_t iz = 0; iz < neigh_transforms->elem_count; iz++) {
+    p4est_neighbor_transform_t *nt =
+      (p4est_neighbor_transform_t *) sc_array_index (neigh_transforms, iz);
+
+    if (found[iz])
+      continue;
+    if (nt->neighbor_type == P4EST_CONNECT_SELF) {
+      P4EST_ASSERT (nt->neighbor == t);
+      P4EST_ASSERT (nt->index_self == 0);
+      P4EST_ASSERT (nt->index_neighbor == 0);
+      for (int d = 0; d < P4EST_DIM; d++) {
+        P4EST_ASSERT (nt->origin_self[d] == nt->origin_neighbor[d]);
+        P4EST_ASSERT (nt->perm[d] == d);
+        P4EST_ASSERT (nt->sign[d] == 1);
+      }
+
+      for (uint64_t id = 0; id < (1 << (P4EST_DIM * 2)); id++) {
+        p4est_quadrant_t    self_q, neigh_q;
+        p4est_quadrant_set_morton (&self_q, 2, id);
+
+        /* test forward transform */
+        P4EST_QUADRANT_INIT (&neigh_q);
+        p4est_neighbor_transform_quadrant (nt, &self_q, &neigh_q);
+        P4EST_ASSERT (p4est_quadrant_compare (&self_q, &neigh_q) == 0);
+
+        /* test reverse transform */
+        P4EST_QUADRANT_INIT (&self_q);
+        p4est_neighbor_transform_quadrant_reverse (nt, &neigh_q, &self_q);
+        P4EST_ASSERT (p4est_quadrant_compare (&self_q, &neigh_q) == 0);
+
+        for (int c = 0; c < P4EST_CHILDREN; c++) {
+          p4est_qcoord_t      self_coords[P4EST_DIM];
+          p4est_qcoord_t      neigh_coords[P4EST_DIM];
+
+          quad_coords (&self_q, self_coords, c);
+
+          for (int d = 0; d < P4EST_DIM; d++) {
+            neigh_coords[d] = -1;
+          }
+          p4est_neighbor_transform_coordinates (nt, self_coords,
+                                                neigh_coords);
+          P4EST_ASSERT (coords_equal (self_coords, neigh_coords));
+
+          for (int d = 0; d < P4EST_DIM; d++) {
+            self_coords[d] = -1;
+          }
+          p4est_neighbor_transform_coordinates_reverse (nt, neigh_coords,
+                                                        self_coords);
+          P4EST_ASSERT (coords_equal (self_coords, neigh_coords));
+        }
+      }
+      P4EST_GLOBAL_LDEBUG ("Self transformation ok\n");
+      found[iz] = 1;
+      return;
+    }
+  }
+}
+
+static void
+test_find_face_transform (sc_array_t * neigh_transforms, int j, int ntree,
+                          const int ftransform[9], int found[])
+{
+  for (size_t iz = 0; iz < neigh_transforms->elem_count; iz++) {
+    p4est_neighbor_transform_t *nt =
+      (p4est_neighbor_transform_t *) sc_array_index (neigh_transforms, iz);
+
+    if (found[iz])
+      continue;
+    if (nt->neighbor_type == P4EST_CONNECT_FACE && nt->index_self == j) {
+      P4EST_ASSERT (nt->neighbor == ntree);
+      P4EST_ASSERT (0 <= nt->index_neighbor
+                    && nt->index_neighbor < P4EST_FACES);
+
+      for (uint64_t id = 0; id < (1 << (P4EST_DIM * 2)); id++) {
+        p4est_quadrant_t    self_quad[2];
+        int                 fs[2];
+
+        fs[0] = j;
+        fs[1] = j ^ 1;
+
+        /* only test quadrants that touch face j */
+        p4est_quadrant_set_morton (&self_quad[0], 2, id);
+        p4est_quadrant_face_neighbor (&self_quad[0], j, &self_quad[1]);
+        if (p4est_quadrant_is_inside_root (&self_quad[1])) {
+          continue;
+        }
+
+        for (int s = 0; s < 2; s++) {
+          p4est_quadrant_t    neigh_quad, neigh_quad_f, self_quad_rev;
+
+          /* compare neighbor transform and face transform */
+          p4est_quadrant_transform_face (&self_quad[s], &neigh_quad_f,
+                                         ftransform);
+          p4est_neighbor_transform_quadrant (nt, &self_quad[s], &neigh_quad);
+          P4EST_ASSERT (p4est_quadrant_compare (&neigh_quad, &neigh_quad_f) ==
+                        0);
+
+          /* reverse is a left inverse */
+          p4est_neighbor_transform_quadrant_reverse (nt, &neigh_quad,
+                                                     &self_quad_rev);
+          P4EST_ASSERT (p4est_quadrant_compare (&self_quad[s], &self_quad_rev)
+                        == 0);
+
+          for (int fc = 0; fc < P4EST_CHILDREN / 2; fc++) {
+            p4est_qcoord_t      self_coords[P4EST_DIM];
+            p4est_qcoord_t      neigh_coords[P4EST_DIM];
+            p4est_qcoord_t      neigh_coords_f[P4EST_DIM];
+            p4est_qcoord_t      self_coords_rev[P4EST_DIM];
+            int                 c = p4est_face_corners[fs[s]][fc];
+
+            quad_coords (&self_quad[s], self_coords, c);
+            p4est_coordinates_transform_face (self_coords, neigh_coords_f,
+                                              ftransform);
+            p4est_neighbor_transform_coordinates (nt, self_coords,
+                                                  neigh_coords);
+            P4EST_ASSERT (coords_equal (neigh_coords_f, neigh_coords));
+
+            p4est_neighbor_transform_coordinates_reverse (nt, neigh_coords,
+                                                          self_coords_rev);
+            P4EST_ASSERT (coords_equal (self_coords, self_coords_rev));
+          }
+        }
+
+      }
+      P4EST_GLOBAL_LDEBUGF ("Face transformation across %d ok\n", j);
+      found[iz] = 1;
+      return;
+    }
+  }
+}
+
+static void
+test_self_transform (p4est_connectivity_t * conn, p4est_topidx_t t, int j,
+                     sc_array_t * neigh_transforms)
+{
+  int                 found = 0;
+
+  P4EST_ASSERT (neigh_transforms->elem_count == 1);
+  test_find_self_transform (neigh_transforms, t, &found);
+  P4EST_ASSERT (found);
+}
+
+static void
+test_face_transform (p4est_connectivity_t * conn, p4est_topidx_t t, int j,
+                     sc_array_t * neigh_transforms)
+{
+  int                *found =
+    P4EST_ALLOC_ZERO (int, neigh_transforms->elem_count);
+  p4est_topidx_t      ntree;
+  int                 ftransform[9];
+
+  P4EST_ASSERT (neigh_transforms->elem_count == 1
+                || neigh_transforms->elem_count == 2);
+  test_find_self_transform (neigh_transforms, t, found);
+  ntree = p4est_find_face_transform (conn, t, j, ftransform);
+  if (ntree >= 0) {
+    test_find_face_transform (neigh_transforms, j, ntree, ftransform, found);
+  }
+  for (size_t iz = 0; iz < neigh_transforms->elem_count; iz++) {
+    P4EST_ASSERT (found[iz]);
+  }
+  P4EST_FREE (found);
+}
+
+#ifdef P4_TO_P8
+static void
+test_find_edge_transform (sc_array_t * neigh_transforms, p4est_topidx_t t,
+                          int j, p8est_edge_info_t * ei,
+                          p8est_edge_transform_t * et, int found[])
+{
+  for (size_t iz = 0; iz < neigh_transforms->elem_count; iz++) {
+    p4est_neighbor_transform_t *nt =
+      (p4est_neighbor_transform_t *) sc_array_index (neigh_transforms, iz);
+
+    if (found[iz])
+      continue;
+    if (nt->neighbor_type == P8EST_CONNECT_EDGE && nt->index_self == j) {
+      P4EST_ASSERT (nt->neighbor == et->ntree);
+      P4EST_ASSERT (nt->index_neighbor == et->nedge);
+
+      for (uint64_t id = 0; id < (1 << (P4EST_DIM * 2)); id++) {
+        p4est_quadrant_t    self_quad[2];
+        int                 es[2];
+
+        es[0] = j;
+        es[1] = j ^ 3;
+
+        /* only test quadrants that touch face j */
+        p4est_quadrant_set_morton (&self_quad[0], 2, id);
+        p8est_quadrant_edge_neighbor (&self_quad[0], j, &self_quad[1]);
+        if (!p8est_quadrant_is_outside_edge (&self_quad[1])) {
+          continue;
+        }
+
+        for (int s = 0; s < 2; s++) {
+          p4est_quadrant_t    neigh_quad, neigh_quad_e, self_quad_rev;
+
+          /* compare neighbor transform and face transform */
+          p8est_quadrant_transform_edge (&self_quad[s], &neigh_quad_e, ei, et,
+                                         s);
+          p4est_neighbor_transform_quadrant (nt, &self_quad[s], &neigh_quad);
+          P4EST_ASSERT (p4est_quadrant_compare (&neigh_quad, &neigh_quad_e) ==
+                        0);
+
+          /* reverse is a left inverse */
+          p4est_neighbor_transform_quadrant_reverse (nt, &neigh_quad,
+                                                     &self_quad_rev);
+          P4EST_ASSERT (p4est_quadrant_compare (&self_quad[s], &self_quad_rev)
+                        == 0);
+
+          for (int ec = 0; ec < 2; ec++) {
+            p4est_qcoord_t      self_coords[P4EST_DIM];
+            p4est_qcoord_t      neigh_coords[P4EST_DIM];
+            p4est_qcoord_t      neigh_coords_e[P4EST_DIM];
+            p4est_qcoord_t      self_coords_rev[P4EST_DIM];
+            int                 c = p8est_edge_corners[es[s]][ec];
+
+            quad_coords (&self_quad[s], self_coords, c);
+            p8est_coordinates_transform_edge (self_coords, neigh_coords_e, ei,
+                                              et);
+            p4est_neighbor_transform_coordinates (nt, self_coords,
+                                                  neigh_coords);
+            P4EST_ASSERT (coords_equal (neigh_coords_e, neigh_coords));
+
+            p4est_neighbor_transform_coordinates_reverse (nt, neigh_coords,
+                                                          self_coords_rev);
+            P4EST_ASSERT (coords_equal (self_coords, self_coords_rev));
+          }
+        }
+
+      }
+      P4EST_GLOBAL_LDEBUGF ("Edge transformation across %d to %d ok\n", j,
+                            et->ntree);
+      found[iz] = 1;
+      return;
+    }
+  }
+}
+
+static void
+test_find_all_edge_transforms (p4est_connectivity_t * conn, p4est_topidx_t t,
+                               int j, sc_array_t * neigh_transforms,
+                               int found[])
+{
+  p8est_edge_info_t   ei;
+  sc_array_t         *eta = &ei.edge_transforms;
+
+  sc_array_init (eta, sizeof (p8est_edge_transform_t));
+  p8est_find_edge_transform (conn, t, j, &ei);
+  for (size_t iz = 0; iz < eta->elem_count; iz++) {
+    p8est_edge_transform_t *et =
+      (p8est_edge_transform_t *) sc_array_index (eta, iz);
+
+    test_find_edge_transform (neigh_transforms, t, j, &ei, et, found);
+  }
+  sc_array_reset (eta);
+}
+
+static void
+test_edge_transform (p4est_connectivity_t * conn, p4est_topidx_t t, int j,
+                     sc_array_t * neigh_transforms)
+{
+  int                *found =
+    P4EST_ALLOC_ZERO (int, neigh_transforms->elem_count);
+
+  P4EST_ASSERT (neigh_transforms->elem_count >= 1);
+  test_find_self_transform (neigh_transforms, t, found);
+  for (int ef = 0; ef < 2; ef++) {
+    int                 f = p8est_edge_faces[j][ef];
+    int                 ftransform[9];
+    p4est_topidx_t      ntree;
+
+    ntree = p4est_find_face_transform (conn, t, f, ftransform);
+    if (ntree >= 0) {
+      test_find_face_transform (neigh_transforms, f, ntree, ftransform,
+                                found);
+    }
+  }
+  test_find_all_edge_transforms (conn, t, j, neigh_transforms, found);
+  for (size_t iz = 0; iz < neigh_transforms->elem_count; iz++) {
+    P4EST_ASSERT (found[iz]);
+  }
+  P4EST_FREE (found);
+}
+#endif
+
+static void
+test_find_corner_transform (sc_array_t * neigh_transforms, p4est_topidx_t t,
+                            int j, p4est_corner_transform_t * ct, int found[])
+{
+  for (size_t iz = 0; iz < neigh_transforms->elem_count; iz++) {
+    p4est_neighbor_transform_t *nt =
+      (p4est_neighbor_transform_t *) sc_array_index (neigh_transforms, iz);
+
+    if (found[iz])
+      continue;
+    if (nt->neighbor_type == P4EST_CONNECT_CORNER && nt->index_self == j) {
+      p4est_quadrant_t    root, self_quad[2];
+      int                 cs[2], ncs[2];
+
+      cs[0] = j;
+      cs[1] = j ^ (P4EST_CHILDREN - 1);
+      ncs[0] = (ct->ncorner) ^ (P4EST_CHILDREN - 1);
+      ncs[1] = ct->ncorner;
+      p4est_qcoord_t      self_coords[P4EST_DIM];
+      p4est_qcoord_t      neigh_coords_c[P4EST_DIM];
+      p4est_qcoord_t      neigh_coords[P4EST_DIM];
+      p4est_qcoord_t      self_coords_rev[P4EST_DIM];
+
+      P4EST_ASSERT (nt->neighbor == ct->ntree);
+      P4EST_ASSERT (nt->index_neighbor == ct->ncorner);
+
+      memset (&root, 0, sizeof (root));
+      p4est_quadrant_corner_descendant (&root, &self_quad[0], j, 2);
+      p4est_quadrant_corner_neighbor (&self_quad[0], j, &self_quad[1]);
+      for (int s = 0; s < 2; s++) {
+        p4est_quadrant_t    neigh_quad_c, neigh_quad, self_quad_rev;
+
+        neigh_quad_c = self_quad[s];
+        p4est_quadrant_transform_corner (&neigh_quad_c, ct->ncorner, s);
+        p4est_neighbor_transform_quadrant (nt, &self_quad[s], &neigh_quad);
+        P4EST_ASSERT (p4est_quadrant_compare (&neigh_quad_c, &neigh_quad) ==
+                      0);
+
+        p4est_neighbor_transform_quadrant_reverse (nt, &neigh_quad,
+                                                   &self_quad_rev);
+        P4EST_ASSERT (p4est_quadrant_compare (&self_quad[s], &self_quad_rev)
+                      == 0);
+
+        quad_coords (&self_quad[s], self_coords, cs[s]);
+        quad_coords (&neigh_quad, neigh_coords_c, ncs[s]);
+        p4est_neighbor_transform_coordinates (nt, self_coords, neigh_coords);
+        P4EST_ASSERT (coords_equal (neigh_coords_c, neigh_coords));
+
+        p4est_neighbor_transform_coordinates_reverse (nt, neigh_coords,
+                                                      self_coords_rev);
+        P4EST_ASSERT (coords_equal (self_coords, self_coords_rev));
+      }
+      P4EST_GLOBAL_LDEBUGF ("Corner transformation across %d to %d ok\n", j,
+                            ct->ntree);
+      found[iz] = 1;
+      return;
+    }
+  }
+}
+
+static void
+test_corner_transform (p4est_connectivity_t * conn, p4est_topidx_t t, int j,
+                       sc_array_t * neigh_transforms)
+{
+  int                *found =
+    P4EST_ALLOC_ZERO (int, neigh_transforms->elem_count);
+  p4est_corner_info_t ci;
+  sc_array_t         *cta = &ci.corner_transforms;;
+
+  P4EST_ASSERT (neigh_transforms->elem_count >= 1);
+  test_find_self_transform (neigh_transforms, t, found);
+  for (int cf = 0; cf < P4EST_DIM; cf++) {
+    int                 f = p4est_corner_faces[j][cf];
+    int                 ftransform[9];
+    p4est_topidx_t      ntree;
+
+    ntree = p4est_find_face_transform (conn, t, f, ftransform);
+    if (ntree >= 0) {
+      test_find_face_transform (neigh_transforms, f, ntree, ftransform,
+                                found);
+    }
+  }
+#ifdef P4_TO_P8
+  for (int ce = 0; ce < P4EST_DIM; ce++) {
+    int                 e = p8est_corner_edges[j][ce];
+
+    test_find_all_edge_transforms (conn, t, e, neigh_transforms, found);
+  }
+#endif
+  sc_array_init (cta, sizeof (p4est_corner_transform_t));
+  p4est_find_corner_transform (conn, t, j, &ci);
+  for (size_t iz = 0; iz < cta->elem_count; iz++) {
+    p4est_corner_transform_t *ct =
+      (p4est_corner_transform_t *) sc_array_index (cta, iz);
+
+    test_find_corner_transform (neigh_transforms, t, j, ct, found);
+  }
+  sc_array_reset (cta);
+  for (size_t iz = 0; iz < neigh_transforms->elem_count; iz++) {
+    P4EST_ASSERT (found[iz]);
+  }
+  P4EST_FREE (found);
+}
+
+int
+main (int argc, char **argv)
+{
+  sc_MPI_Init (&argc, &argv);
+  sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_DEBUG);
+  p4est_init (NULL, SC_LP_DEBUG);
+#ifndef P4_TO_P8
+#define N_NAMES 13
+  const char         *names[N_NAMES] =
+    { "brick23", "corner", "cubed", "disk", "icosahedron", "moebius",
+    "periodic", "pillow", "rotwrap", "star", "shell2d", "disk2d", "unit"
+  };
+  const p4est_connect_type_t neigh_types[3] =
+    { P4EST_CONNECT_SELF, P4EST_CONNECT_FACE, P4EST_CONNECT_CORNER };
+  const char         *neigh_type_names[3] = { "self", "face", "corner" };
+  const int           neigh_sizes[3] = { 1, P4EST_FACES, P4EST_CHILDREN };
+#else
+#define N_NAMES 9
+  const char         *names[] =
+    { "brick235", "periodic", "rotcubes", "rotwrap", "shell", "sphere",
+    "twocubes", "twowrap", "unit"
+  };
+  const p4est_connect_type_t neigh_types[4] =
+    { P4EST_CONNECT_SELF, P4EST_CONNECT_FACE, P8EST_CONNECT_EDGE,
+    P4EST_CONNECT_CORNER
+  };
+  const char         *neigh_type_names[4] =
+    { "self", "face", "edge", "corner" };
+  const int           neigh_sizes[4] =
+    { 1, P4EST_FACES, P8EST_EDGES, P4EST_CHILDREN };
+#endif
+
+  for (int i = 0; i < N_NAMES; i++) {
+    p4est_connectivity_t *conn = p4est_connectivity_new_byname (names[i]);
+    P4EST_ASSERT (conn != NULL);
+
+    for (p4est_topidx_t t = 0; t < conn->num_trees; t++) {
+      for (int n = 0; n <= P4EST_DIM; n++) {
+        p4est_connect_type_t neigh_type = neigh_types[n];
+
+        for (int j = 0; j < neigh_sizes[n]; j++) {
+          sc_array_t          neigh_transforms;
+
+          P4EST_GLOBAL_LDEBUGF ("Testing connectivity %s, tree %d, %s %d\n",
+                                names[i], t, neigh_type_names[n], j);
+          p4est_log_indent_push ();
+
+          sc_array_init (&neigh_transforms,
+                         sizeof (p4est_neighbor_transform_t));
+          p4est_connectivity_get_neighbor_transforms (conn, t, neigh_type, j,
+                                                      &neigh_transforms);
+
+          switch (n) {
+          case 0:
+            test_self_transform (conn, t, j, &neigh_transforms);
+            break;
+          case 1:
+            test_face_transform (conn, t, j, &neigh_transforms);
+            break;
+#ifdef P4_TO_P8
+          case 2:
+            test_edge_transform (conn, t, j, &neigh_transforms);
+            break;
+#endif
+          case P4EST_DIM:
+            test_corner_transform (conn, t, j, &neigh_transforms);
+            break;
+          default:
+            SC_ABORT_NOT_REACHED ();
+          }
+
+          sc_array_reset (&neigh_transforms);
+          p4est_log_indent_pop ();
+        }
+      }
+    }
+
+    p4est_connectivity_destroy (conn);
+  }
+  sc_MPI_Finalize ();
+  return 0;
+}

--- a/test/test_neighbor_transform3.c
+++ b/test/test_neighbor_transform3.c
@@ -1,0 +1,26 @@
+/*
+  This file is part of p4est.
+  p4est is a C library to manage a collection (a forest) of multiple
+  connected adaptive quadtrees or octrees in parallel.
+
+  Copyright (C) 2010 The University of Texas System
+  Additional copyright (C) 2011 individual authors
+  Written by Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac
+
+  p4est is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  p4est is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with p4est; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#include <p4est_to_p8est.h>
+#include "test_neighbor_transform2.c"


### PR DESCRIPTION
There are four parts to this PR

# 1. Small compiler warning / indent fixes for p6est

Self-explanatory.

# 2. Add operations on pure coordinates

- `p4est_coordinates_compare()`
- `p4est_coordinates_transform_face()`
- `p8est_coordinates_transform_edge()`

From the commit messages:

> It is insufficient just to transform nodes because nodes are restricted to being at valid quadrant corners, so not all coordinates can be represented by nodes.
>
> Likewise, the coordinates can be sorted in Morton order even without a level attached, which is useful for canonicalizing points between trees, so we add this capability.

# 3. Add generic neighbor transformations

- typedef `p4est_neighbor_transform_t`
- `p4est_connectivity_get_neighbor_transforms()`
- `p4est_neighbor_transform_coordinates()` and `p4est_neighbor_transform_coordinates_reverse()`
- `p4est_neighbor_transform_quadrant()` and `p4est_neighbor_transform_quadrant_reverse()`

From the commit messages:

> Add a neighbor transform that generalizes all other inter-tree transformation objects.
>
> - This makes it much easier to write loops over all trees that touch a {face, edge, corner}
> - The data structure, while not as compressed as the others, is more interpretable: each transformation is clearly composed from shifts, permutations, and sign changes.
> - A test is added to make sure the generic neighbor transformation does the same thing as the individual transformations for every interface of every named connectivity.

# 4. Fix vertex coordinates calculations in `p4est_get_plex_data()`

From the commit messages:

> Guarantee that all cells agree about the coordinates of a vertex in plex data
>
> Use newly added neighbor transformations to canonicalize the (tree, qcoords) of each vertex and then apply qcoords_to_vertex to determine the coordinates.
> A periodic connectivity is added test_plex2.c to exercise this capability.