### PR TITLE
Function for uniform global first quadrant array

### DIFF
--- a/src/p4est.c
+++ b/src/p4est.c
@@ -3839,9 +3839,8 @@ p4est_load_mpi (const char *filename, sc_MPI_Comm mpicomm, size_t data_size,
       SC_CHECK_ABORT (!retval, "seek over ignored partition");
       retval = sc_io_source_read (src, &u64int, sizeof (uint64_t), NULL);
       SC_CHECK_ABORT (!retval, "read quadrant count");
-      for (i = 1; i <= num_procs; ++i) {
-        gfq[i] = p4est_partition_cut_uint64 (u64int, i, num_procs);
-      }
+      p4est_comm_global_first_quadrant ((p4est_gloidx_t) u64int, num_procs,
+                                        gfq);
     }
   }
   if (broadcasthead) {
@@ -4150,9 +4149,8 @@ p4est_source_ext (sc_io_source_t * src, sc_MPI_Comm mpicomm, size_t data_size,
       SC_CHECK_ABORT (!retval, "seek over ignored partition");
       retval = sc_io_source_read (src, &u64int, sizeof (uint64_t), NULL);
       SC_CHECK_ABORT (!retval, "read quadrant count");
-      for (i = 1; i <= num_procs; ++i) {
-        gfq[i] = p4est_partition_cut_uint64 (u64int, i, num_procs);
-      }
+      p4est_comm_global_first_quadrant ((p4est_gloidx_t) u64int, num_procs,
+                                        gfq);
     }
   }
   if (broadcasthead) {

--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -403,10 +403,8 @@ p4est_comm_global_first_quadrant (p4est_gloidx_t global_num_quadrants,
 
   gfq[0] = 0;
   for (i = 1; i < mpisize; ++i) {
-    gfq[i] = p4est_partition_cut_gloidx ((uint64_t)
-                                         global_num_quadrants, i, mpisize);
+    gfq[i] = p4est_partition_cut_gloidx (global_num_quadrants, i, mpisize);
   }
-
   gfq[mpisize] = global_num_quadrants;
 }
 

--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -398,16 +398,14 @@ p4est_comm_global_first_quadrant (p4est_gloidx_t global_num_quadrants,
   int                 i;
 
   P4EST_ASSERT (gfq != NULL);
+  P4EST_ASSERT (mpisize >= 0);
+  P4EST_ASSERT (global_num_quadrants >= 0);
 
   gfq[0] = 0;
   for (i = 1; i < mpisize; ++i) {
-    gfq[i] =
-      (p4est_gloidx_t) (((double) i * (long double) global_num_quadrants) /
-                        ((double) mpisize));
-    P4EST_ASSERT (gfq[i] ==
-                  (p4est_gloidx_t) p4est_partition_cut_uint64 ((uint64_t)
-                                                               global_num_quadrants,
-                                                               i, mpisize));
+    gfq[i] = (p4est_gloidx_t) p4est_partition_cut_uint64 ((uint64_t)
+                                                          global_num_quadrants,
+                                                          i, mpisize);
   }
 
   gfq[mpisize] = global_num_quadrants;

--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -398,7 +398,7 @@ p4est_comm_global_first_quadrant (p4est_gloidx_t global_num_quadrants,
   int                 i;
 
   P4EST_ASSERT (gfq != NULL);
-  P4EST_ASSERT (mpisize >= 0);
+  P4EST_ASSERT (mpisize >= 1);
   P4EST_ASSERT (global_num_quadrants >= 0);
 
   gfq[0] = 0;

--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -396,16 +396,20 @@ p4est_comm_global_first_quadrant (p4est_gloidx_t global_num_quadrants,
                                   int mpisize, p4est_gloidx_t * gfq)
 {
   int                 i;
-  p4est_gloidx_t      quotient;
 
   P4EST_ASSERT (gfq != NULL);
 
-  quotient = global_num_quadrants / ((p4est_gloidx_t) mpisize);
-
   gfq[0] = 0;
   for (i = 1; i < mpisize; ++i) {
-    gfq[i] = ((p4est_gloidx_t) i) * quotient;
+    gfq[i] =
+      (p4est_gloidx_t) (((double) i * (long double) global_num_quadrants) /
+                        ((double) mpisize));
+    P4EST_ASSERT (gfq[i] ==
+                  (p4est_gloidx_t) p4est_partition_cut_uint64 ((uint64_t)
+                                                               global_num_quadrants,
+                                                               i, mpisize));
   }
+
   gfq[mpisize] = global_num_quadrants;
 }
 

--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -392,6 +392,24 @@ p4est_comm_global_partition (p4est_t * p4est, p4est_quadrant_t * first_quad)
 }
 
 void
+p4est_comm_global_first_quadrant (p4est_gloidx_t global_num_quadrants,
+                                  int mpisize, p4est_gloidx_t * gfq)
+{
+  int                 i;
+  p4est_gloidx_t      quotient;
+
+  P4EST_ASSERT (gfq != NULL);
+
+  quotient = global_num_quadrants / ((p4est_gloidx_t) mpisize);
+
+  gfq[0] = 0;
+  for (i = 1; i < mpisize; ++i) {
+    gfq[i] = ((p4est_gloidx_t) i) * quotient;
+  }
+  gfq[mpisize] = global_num_quadrants;
+}
+
+void
 p4est_comm_count_pertree (p4est_t * p4est, p4est_gloidx_t * pertree)
 {
   const int           num_procs = p4est->mpisize;

--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -403,9 +403,8 @@ p4est_comm_global_first_quadrant (p4est_gloidx_t global_num_quadrants,
 
   gfq[0] = 0;
   for (i = 1; i < mpisize; ++i) {
-    gfq[i] = (p4est_gloidx_t) p4est_partition_cut_uint64 ((uint64_t)
-                                                          global_num_quadrants,
-                                                          i, mpisize);
+    gfq[i] = p4est_partition_cut_gloidx ((uint64_t)
+                                         global_num_quadrants, i, mpisize);
   }
 
   gfq[mpisize] = global_num_quadrants;

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -120,6 +120,21 @@ void                p4est_comm_global_partition (p4est_t * p4est,
                                                  p4est_quadrant_t *
                                                  first_quad);
 
+/** Calculate the global fist quadrant array for a uniform partition.
+ * 
+ * \param [in] global_num_quadrants   The global number of quadrants.
+ * \param [in] mpisize                The number of MPI ranks.
+ * \param [in,out] gfq                At least allocated mpisize + 1
+ *                                    p4est_gloidx_t. This array is
+ *                                    filled with the global first
+ *                                    quadrant array assuming a
+ *                                    uniform partition.
+ */
+void                p4est_comm_global_first_quadrant (p4est_gloidx_t
+                                                      global_num_quadrants,
+                                                      int mpisize,
+                                                      p4est_gloidx_t * gfq);
+
 /** Compute and distribute the cumulative number of quadrants per tree.
  * \param [in] p4est    This p4est needs to have correct values for
  *                      global_first_quadrant and global_first_position.

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -121,7 +121,7 @@ void                p4est_comm_global_partition (p4est_t * p4est,
                                                  first_quad);
 
 /** Calculate the global fist quadrant array for a uniform partition.
- * 
+ *
  * \param [in] global_num_quadrants   The global number of quadrants.
  * \param [in] mpisize                The number of MPI ranks.
  * \param [in,out] gfq                At least allocated mpisize + 1

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -392,6 +392,7 @@
 #define p4est_comm_parallel_env_reduce_ext p8est_comm_parallel_env_reduce_ext
 #define p4est_comm_count_quadrants      p8est_comm_count_quadrants
 #define p4est_comm_global_partition     p8est_comm_global_partition
+#define p4est_comm_global_first_quadrant p8est_comm_global_first_quadrant
 #define p4est_comm_count_pertree        p8est_comm_count_pertree
 #define p4est_comm_is_empty             p8est_comm_is_empty
 #define p4est_comm_is_contained         p8est_comm_is_contained

--- a/src/p8est_communication.h
+++ b/src/p8est_communication.h
@@ -120,6 +120,21 @@ void                p8est_comm_global_partition (p8est_t * p8est,
                                                  p8est_quadrant_t *
                                                  first_quad);
 
+/** Calculate the global fist quadrant array for a uniform partition.
+ * 
+ * \param [in] global_num_quadrants   The global number of quadrants.
+ * \param [in] mpisize                The number of MPI ranks.
+ * \param [in,out] gfq                At least allocated mpisize + 1
+ *                                    p4est_gloidx_t. This array is
+ *                                    filled with the global first
+ *                                    quadrant array assuming a
+ *                                    uniform partition.
+ */
+void                p8est_comm_global_first_quadrant (p4est_gloidx_t
+                                                      global_num_quadrants,
+                                                      int mpisize,
+                                                      p4est_gloidx_t * gfq);
+
 /** Compute and distribute the cumulative number of quadrants per tree.
  * \param [in] p8est    This p8est needs to have correct values for
  *                      global_first_quadrant and global_first_position.

--- a/src/p8est_communication.h
+++ b/src/p8est_communication.h
@@ -121,7 +121,7 @@ void                p8est_comm_global_partition (p8est_t * p8est,
                                                  first_quad);
 
 /** Calculate the global fist quadrant array for a uniform partition.
- * 
+ *
  * \param [in] global_num_quadrants   The global number of quadrants.
  * \param [in] mpisize                The number of MPI ranks.
  * \param [in,out] gfq                At least allocated mpisize + 1


### PR DESCRIPTION
# Function for uniform global first quadrant array

Proposed changes:
Implement a function to compute the global first quadrant array for a uniform partition. This function is used in the respective places in p4est. This PR is a preparation for the parallel I/O PR since this function is required for the upcoming code.