### PR TITLE
Use p4est_file_error_cleanup in all clean up macros

### DIFF
--- a/src/p4est_extended.h
+++ b/src/p4est_extended.h
@@ -602,7 +602,9 @@ p4est_t            *p4est_source_ext (sc_io_source_t * src,
  */
 p4est_file_context_t *p4est_file_open_read_ext (sc_MPI_Comm mpicomm,
                                                 const char *filename,
-                                                char *user_string,
+                                                char
+                                                user_string
+                                                [P4EST_NUM_USER_STRING_BYTES],
                                                 p4est_gloidx_t *
                                                 global_num_quadrants,
                                                 int *errcode);

--- a/src/p4est_io.c
+++ b/src/p4est_io.c
@@ -47,7 +47,8 @@
 #define P4EST_FILE_CHECK_OPEN(errcode, fc, user_msg, cperrcode) do {\
                                             SC_CHECK_MPI_VERBOSE (errcode, user_msg);   \
                                             *cperrcode = errcode;                       \
-                                            if (errcode) {SC_FREE (fc->file);           \
+                                            if (errcode) {                              \
+                                            p4est_file_error_cleanup (&fc->file);       \
                                             P4EST_FREE (fc);                            \
                                             p4est_file_error_code (errcode, cperrcode);\
                                             return NULL;}} while (0)
@@ -541,7 +542,7 @@ p4est_file_error_cleanup (sc_MPI_File * file)
   if ((*file)->file != sc_MPI_FILE_NULL) {
 #endif
     /* We do not use here the libsc closing function since we do not perform
-     * error checking in this functiont that is only called if we had already
+     * error checking in this function that is only called if we had already
      * an error.
      */
 #ifdef P4EST_ENABLE_MPIIO

--- a/src/p4est_io.c
+++ b/src/p4est_io.c
@@ -728,9 +728,10 @@ p4est_file_open_read (p4est_t * p4est, const char *filename,
   if (fc != NULL && p4est->global_num_quadrants != global_num_quadrants) {
     if (p4est->mpirank == 0) {
       P4EST_LERRORF (P4EST_STRING "_file_open_read: global number of "
-                     "quadrants mismatch (in file = %ld,"
-                     " by parameter = %ld)\n", global_num_quadrants,
-                     p4est->global_num_quadrants);
+                     "quadrants mismatch (in file = %lld,"
+                     " by parameter = %lld)\n",
+                     (long long) global_num_quadrants,
+                     (long long) p4est->global_num_quadrants);
     }
     p4est_file_close (fc, errcode);
     P4EST_FILE_CHECK_NULL (*errcode, fc,

--- a/src/p4est_io.h
+++ b/src/p4est_io.h
@@ -185,7 +185,7 @@ typedef struct p4est_file_context p4est_file_context_t;
  * \param [in] filename       Path to parallel file that is to be created.
  * \param [in] user_string    A user string that is written to the file header.
  *                            Only \ref P4EST_NUM_USER_STRING_BYTES
- *                            bytes without null-termination are
+ *                            bytes without nul-termination are
  *                            written to the file. If the user gives less
  *                            bytes the user_string in the file header is padded
  *                            by spaces.
@@ -220,7 +220,7 @@ p4est_file_context_t *p4est_file_open_create
  * \param [in,out] user_string  At least \ref P4EST_NUM_USER_STRING_BYTES
  *                              bytes. The user string is written
  *                              to the passed array including padding spaces
- *                              and a trailing null-termination.
+ *                              and a trailing nul-termination.
  * \param [out] errcode         An errcode that can be interpreted by \ref
  *                              p4est_file_error_string.
  * \return                      Newly allocated context to continue reading
@@ -301,7 +301,7 @@ p4est_file_context_t *p4est_file_write_header (p4est_file_context_t * fc,
  *                              \ref P4EST_ERR_IO.
  * \param [in,out] user_string  At least \ref P4EST_NUM_USER_STRING_BYTES bytes.
  *                              Filled by the padded user string and
- *                              a trailing null-termination char.
+ *                              a trailing nul-termination char.
  * \param [out] errcode         An errcode that can be interpreted by \ref
  *                              p4est_file_error_string.
  * \return                      Return the input context to continue reading
@@ -340,7 +340,7 @@ p4est_file_context_t *p4est_file_read_header (p4est_file_context_t * fc,
  *                            to sc_MPI_SUCCESS.
  * \param [in] user_string    An array of maximal \ref
  *                            P4EST_NUM_USER_STRING_BYTES bytes that
- *                            is written without the null-termination
+ *                            is written without the nul-termination
  *                            after the array-dependent metadata and before
  *                            the actual data. If the array is shorter the
  *                            written char array will be padded to the

--- a/src/p4est_io.h
+++ b/src/p4est_io.h
@@ -113,7 +113,7 @@ p4est_t            *p4est_inflate (sc_MPI_Comm mpicomm,
 
 /** p4est data file format
  * All p4est data files have 64 bytes file header section at the beginning of the file.
- * The file header section is written to the file as string without nul-termination
+ * The file header section is written to the file as string without NUL-termination
  * (called string*) and is therefore readable in a text editor.
  *
  * File Header (96 bytes):
@@ -185,7 +185,7 @@ typedef struct p4est_file_context p4est_file_context_t;
  * \param [in] filename       Path to parallel file that is to be created.
  * \param [in] user_string    A user string that is written to the file header.
  *                            Only \ref P4EST_NUM_USER_STRING_BYTES
- *                            bytes without nul-termination are
+ *                            bytes without NUL-termination are
  *                            written to the file. If the user gives less
  *                            bytes the user_string in the file header is padded
  *                            by spaces.
@@ -220,7 +220,7 @@ p4est_file_context_t *p4est_file_open_create
  * \param [in,out] user_string  At least \ref P4EST_NUM_USER_STRING_BYTES
  *                              bytes. The user string is written
  *                              to the passed array including padding spaces
- *                              and a trailing nul-termination.
+ *                              and a trailing NUL-termination.
  * \param [out] errcode         An errcode that can be interpreted by \ref
  *                              p4est_file_error_string.
  * \return                      Newly allocated context to continue reading
@@ -301,7 +301,7 @@ p4est_file_context_t *p4est_file_write_header (p4est_file_context_t * fc,
  *                              \ref P4EST_ERR_IO.
  * \param [in,out] user_string  At least \ref P4EST_NUM_USER_STRING_BYTES bytes.
  *                              Filled by the padded user string and
- *                              a trailing nul-termination char.
+ *                              a trailing NUL-termination char.
  * \param [out] errcode         An errcode that can be interpreted by \ref
  *                              p4est_file_error_string.
  * \return                      Return the input context to continue reading
@@ -340,7 +340,7 @@ p4est_file_context_t *p4est_file_read_header (p4est_file_context_t * fc,
  *                            to sc_MPI_SUCCESS.
  * \param [in] user_string    An array of maximal \ref
  *                            P4EST_NUM_USER_STRING_BYTES bytes that
- *                            is written without the nul-termination
+ *                            is written without the NUL-termination
  *                            after the array-dependent metadata and before
  *                            the actual data. If the array is shorter the
  *                            written char array will be padded to the

--- a/src/p8est_extended.h
+++ b/src/p8est_extended.h
@@ -608,7 +608,9 @@ p8est_t            *p8est_source_ext (sc_io_source_t * src,
  */
 p8est_file_context_t *p8est_file_open_read_ext (sc_MPI_Comm mpicomm,
                                                 const char *filename,
-                                                char *user_string,
+                                                char
+                                                user_string
+                                                [P8EST_NUM_USER_STRING_BYTES],
                                                 p4est_gloidx_t *
                                                 global_num_quadrants,
                                                 int *errcode);

--- a/src/p8est_io.h
+++ b/src/p8est_io.h
@@ -113,7 +113,7 @@ p8est_t            *p8est_inflate (sc_MPI_Comm mpicomm,
 
 /** p8est data file format
  * All p4est data files have 64 bytes file header section at the beginning of the file.
- * The file header section is written to the file as string without nul-termination
+ * The file header section is written to the file as string without NUL-termination
  * (called string*) and is therefore readable in a text editor.
  *
  * File Header (96 bytes):
@@ -185,7 +185,7 @@ typedef struct p8est_file_context p8est_file_context_t;
  * \param [in] filename       Path to parallel file that is to be created.
  * \param [in] user_string    A user string that is written to the file header.
  *                            Only \ref P8EST_NUM_USER_STRING_BYTES
- *                            bytes without nul-termination are
+ *                            bytes without NUL-termination are
  *                            written to the file. If the user gives less
  *                            bytes the user_string in the file header is padded
  *                            by spaces.
@@ -220,7 +220,7 @@ p8est_file_context_t *p8est_file_open_create
  * \param [in,out] user_string  At least \ref P8EST_NUM_USER_STRING_BYTES
  *                              bytes. The user string is written
  *                              to the passed array including padding spaces
- *                              and a trailing nul-termination.
+ *                              and a trailing NUL-termination.
  * \param [out] errcode         An errcode that can be interpreted by \ref
  *                              p8est_file_error_string.
  * \return                      Newly allocated context to continue reading
@@ -301,7 +301,7 @@ p8est_file_context_t *p8est_file_write_header (p8est_file_context_t * fc,
  *                              \ref P8EST_ERR_IO.
  * \param [in,out] user_string  At least \ref P8EST_NUM_USER_STRING_BYTES bytes.
  *                              Filled by the padded user string and
- *                              a trailing nul-termination char.
+ *                              a trailing NUL-termination char.
  * \param [out] errcode         An errcode that can be interpreted by \ref
  *                              p8est_file_error_string.
  * \return                      Return the input context to continue reading
@@ -341,7 +341,7 @@ p8est_file_context_t *p8est_file_read_header (p8est_file_context_t * fc,
  *                            to sc_MPI_SUCCESS.
  * \param [in] user_string    An array of maximal \ref
  *                            P8EST_NUM_USER_STRING_BYTES bytes that
- *                            is written without the nul-termination
+ *                            is written without the NUL-termination
  *                            after the array-dependent metadata and before
  *                            the actual data. If the array is shorter the
  *                            written char array will be padded to the

--- a/src/p8est_io.h
+++ b/src/p8est_io.h
@@ -185,7 +185,7 @@ typedef struct p8est_file_context p8est_file_context_t;
  * \param [in] filename       Path to parallel file that is to be created.
  * \param [in] user_string    A user string that is written to the file header.
  *                            Only \ref P8EST_NUM_USER_STRING_BYTES
- *                            bytes without null-termination are
+ *                            bytes without nul-termination are
  *                            written to the file. If the user gives less
  *                            bytes the user_string in the file header is padded
  *                            by spaces.
@@ -220,7 +220,7 @@ p8est_file_context_t *p8est_file_open_create
  * \param [in,out] user_string  At least \ref P8EST_NUM_USER_STRING_BYTES
  *                              bytes. The user string is written
  *                              to the passed array including padding spaces
- *                              and a trailing null-termination.
+ *                              and a trailing nul-termination.
  * \param [out] errcode         An errcode that can be interpreted by \ref
  *                              p8est_file_error_string.
  * \return                      Newly allocated context to continue reading
@@ -301,7 +301,7 @@ p8est_file_context_t *p8est_file_write_header (p8est_file_context_t * fc,
  *                              \ref P8EST_ERR_IO.
  * \param [in,out] user_string  At least \ref P8EST_NUM_USER_STRING_BYTES bytes.
  *                              Filled by the padded user string and
- *                              a trailing null-termination char.
+ *                              a trailing nul-termination char.
  * \param [out] errcode         An errcode that can be interpreted by \ref
  *                              p8est_file_error_string.
  * \return                      Return the input context to continue reading
@@ -341,7 +341,7 @@ p8est_file_context_t *p8est_file_read_header (p8est_file_context_t * fc,
  *                            to sc_MPI_SUCCESS.
  * \param [in] user_string    An array of maximal \ref
  *                            P8EST_NUM_USER_STRING_BYTES bytes that
- *                            is written without the null-termination
+ *                            is written without the nul-termination
  *                            after the array-dependent metadata and before
  *                            the actual data. If the array is shorter the
  *                            written char array will be padded to the


### PR DESCRIPTION
# Use p4est_file_error_cleanup in all clean up macros

Proposed changes: There was one macro that did not use `p4est_file_error_cleanup`. This caused errors if one uses OpenMPI instead of MPICH since the related place in the code had a MPICH specifc assumption. This is fixed by using `p4est_file_error_cleanup` in the respective code place.
Beside these changes this PR fixes some typos in the documentation and a compiler warning due to missing type casts.

