### PR TITLE
Fix overread warnings

### DIFF
--- a/src/p4est_extended.h
+++ b/src/p4est_extended.h
@@ -602,9 +602,7 @@ p4est_t            *p4est_source_ext (sc_io_source_t * src,
  */
 p4est_file_context_t *p4est_file_open_read_ext (sc_MPI_Comm mpicomm,
                                                 const char *filename,
-                                                char
-                                                user_string
-                                                [P4EST_FILE_USER_STRING_BYTES],
+                                                char *user_string,
                                                 p4est_gloidx_t *
                                                 global_num_quadrants,
                                                 int *errcode);
@@ -620,9 +618,7 @@ p4est_file_context_t *p4est_file_open_read_ext (sc_MPI_Comm mpicomm,
 p4est_file_context_t *p4est_file_read_field_ext (p4est_file_context_t * fc,
                                                  p4est_gloidx_t * gfq,
                                                  sc_array_t * quadrant_data,
-                                                 char
-                                                 user_string
-                                                 [P4EST_FILE_USER_STRING_BYTES],
+                                                 char *user_string,
                                                  int *errcode);
 
 /** Create the data necessary to create a PETsc DMPLEX representation of a

--- a/src/p4est_io.c
+++ b/src/p4est_io.c
@@ -592,8 +592,7 @@ static int          p4est_file_error_code (int errcode, int *p4est_errcode);
 
 p4est_file_context_t *
 p4est_file_open_create (p4est_t * p4est, const char *filename,
-                        const char* user_string,
-                        int *errcode)
+                        const char *user_string, int *errcode)
 {
   int                 mpiret, count, count_error, mpisize;
   /* We enforce the padding of the file header. */
@@ -677,7 +676,7 @@ p4est_file_open_create (p4est_t * p4est, const char *filename,
 
 p4est_file_context_t *
 p4est_file_open_read_ext (sc_MPI_Comm mpicomm, const char *filename,
-                          char user_string[P4EST_FILE_USER_STRING_BYTES],
+                          char *user_string,
                           p4est_gloidx_t * global_num_quadrants, int *errcode)
 {
   int                 mpiret, rank;
@@ -750,8 +749,7 @@ p4est_file_open_read_ext (sc_MPI_Comm mpicomm, const char *filename,
 
 p4est_file_context_t *
 p4est_file_open_read (p4est_t * p4est, const char *filename,
-                      char user_string[P4EST_FILE_USER_STRING_BYTES],
-                      int *errcode)
+                      char *user_string, int *errcode)
 {
   p4est_gloidx_t      global_num_quadrants;
   p4est_file_context_t *fc;
@@ -795,8 +793,7 @@ p4est_file_open_read (p4est_t * p4est, const char *filename,
 p4est_file_context_t *
 p4est_file_write_header (p4est_file_context_t * fc, size_t header_size,
                          const void *header_data,
-                         const char* user_string,
-                         int *errcode)
+                         const char *user_string, int *errcode)
 {
   size_t              num_pad_bytes;
   char                header_metadata[P4EST_FILE_FIELD_HEADER_BYTES + 1],
@@ -915,9 +912,7 @@ static p4est_file_context_t *
 p4est_file_read_block_metadata (p4est_file_context_t * fc,
                                 size_t * read_data_size, size_t data_size,
                                 char block_type,
-                                char
-                                user_string[P4EST_FILE_USER_STRING_BYTES],
-                                int *errcode)
+                                char *user_string, int *errcode)
 {
   int                 mpiret, count, count_error, rank;
   int                 bytes_to_read;
@@ -1073,8 +1068,7 @@ p4est_file_read_block_metadata (p4est_file_context_t * fc,
 p4est_file_context_t *
 p4est_file_read_header (p4est_file_context_t * fc,
                         size_t header_size, void *header_data,
-                        char user_string[P4EST_FILE_USER_STRING_BYTES],
-                        int *errcode)
+                        char *user_string, int *errcode)
 {
   int                 mpiret, count, count_error, rank;
   size_t              num_pad_bytes, read_data_size;
@@ -1167,8 +1161,7 @@ p4est_file_read_header (p4est_file_context_t * fc,
 
 p4est_file_context_t *
 p4est_file_write_field (p4est_file_context_t * fc, sc_array_t * quadrant_data,
-                        const char* user_string,
-                        int *errcode)
+                        const char *user_string, int *errcode)
 {
   size_t              bytes_to_write, num_pad_bytes, array_size;
   char                array_metadata[P4EST_FILE_FIELD_HEADER_BYTES + 1],
@@ -1301,8 +1294,7 @@ p4est_file_write_field (p4est_file_context_t * fc, sc_array_t * quadrant_data,
 p4est_file_context_t *
 p4est_file_read_field_ext (p4est_file_context_t * fc, p4est_gloidx_t * gfq,
                            sc_array_t * quadrant_data,
-                           char user_string[P4EST_FILE_USER_STRING_BYTES],
-                           int *errcode)
+                           char *user_string, int *errcode)
 {
   int                 count;
   size_t              bytes_to_read, num_pad_bytes, array_size,
@@ -1411,8 +1403,7 @@ p4est_file_read_field_ext (p4est_file_context_t * fc, p4est_gloidx_t * gfq,
 
 p4est_file_context_t *
 p4est_file_read_field (p4est_file_context_t * fc, sc_array_t * quadrant_data,
-                       char user_string[P4EST_FILE_USER_STRING_BYTES],
-                       int *errcode)
+                       char *user_string, int *errcode)
 {
   int                 mpiret, mpisize, rank;
   p4est_gloidx_t     *gfq = NULL;
@@ -1465,8 +1456,7 @@ p4est_file_read_field (p4est_file_context_t * fc, sc_array_t * quadrant_data,
 
 int
 p4est_file_info (p4est_t * p4est, const char *filename,
-                 char user_string[P4EST_FILE_USER_STRING_BYTES],
-                 sc_array_t * data_sections, int *errcode)
+                 char *user_string, sc_array_t * data_sections, int *errcode)
 {
   int                 mpiret, eclass;
   int                 retval;
@@ -1784,8 +1774,7 @@ p4est_file_error_code (int errcode, int *p4est_errcode)
 }
 
 int
-p4est_file_error_string (int errclass, char string[sc_MPI_MAX_ERROR_STRING],
-                         int *resultlen)
+p4est_file_error_string (int errclass, char *string, int *resultlen)
 {
   int                 retval;
   const char         *tstr = NULL;

--- a/src/p4est_io.c
+++ b/src/p4est_io.c
@@ -592,7 +592,7 @@ static int          p4est_file_error_code (int errcode, int *p4est_errcode);
 
 p4est_file_context_t *
 p4est_file_open_create (p4est_t * p4est, const char *filename,
-                        const char user_string[P4EST_FILE_USER_STRING_BYTES],
+                        const char* user_string,
                         int *errcode)
 {
   int                 mpiret, count, count_error, mpisize;
@@ -795,7 +795,7 @@ p4est_file_open_read (p4est_t * p4est, const char *filename,
 p4est_file_context_t *
 p4est_file_write_header (p4est_file_context_t * fc, size_t header_size,
                          const void *header_data,
-                         const char user_string[P4EST_FILE_USER_STRING_BYTES],
+                         const char* user_string,
                          int *errcode)
 {
   size_t              num_pad_bytes;
@@ -1167,7 +1167,7 @@ p4est_file_read_header (p4est_file_context_t * fc,
 
 p4est_file_context_t *
 p4est_file_write_field (p4est_file_context_t * fc, sc_array_t * quadrant_data,
-                        const char user_string[P4EST_FILE_USER_STRING_BYTES],
+                        const char* user_string,
                         int *errcode)
 {
   size_t              bytes_to_write, num_pad_bytes, array_size;

--- a/src/p4est_io.h
+++ b/src/p4est_io.h
@@ -218,7 +218,7 @@ p4est_file_error_t;
  */
 p4est_file_context_t *p4est_file_open_create
   (p4est_t * p4est, const char *filename,
-   const char user_string[P4EST_FILE_USER_STRING_BYTES], int *errcode);
+   const char* user_string, int *errcode);
 
 /** Open a file for reading and read its user string on rank zero.
  * The user string is broadcasted to all ranks after reading.
@@ -290,9 +290,9 @@ p4est_file_context_t *p4est_file_open_read (p4est_t * p4est,
 p4est_file_context_t *p4est_file_write_header (p4est_file_context_t * fc,
                                                size_t header_size,
                                                const void *header_data,
-                                               const char
+                                               const char*
                                                user_string
-                                               [P4EST_FILE_USER_STRING_BYTES],
+                                               ,
                                                int *errcode);
 
 /** Read a header block from an opened file.
@@ -386,9 +386,9 @@ p4est_file_context_t *p4est_file_read_header (p4est_file_context_t * fc,
  */
 p4est_file_context_t *p4est_file_write_field (p4est_file_context_t * fc,
                                               sc_array_t * quadrant_data,
-                                              const char
+                                              const char*
                                               user_string
-                                              [P4EST_FILE_USER_STRING_BYTES],
+                                              ,
                                               int *errcode);
 
 /** Read one (more) per-quadrant data set from a parallel input file.

--- a/src/p4est_io.h
+++ b/src/p4est_io.h
@@ -218,7 +218,7 @@ p4est_file_error_t;
  */
 p4est_file_context_t *p4est_file_open_create
   (p4est_t * p4est, const char *filename,
-   const char* user_string, int *errcode);
+   const char *user_string, int *errcode);
 
 /** Open a file for reading and read its user string on rank zero.
  * The user string is broadcasted to all ranks after reading.
@@ -250,10 +250,7 @@ p4est_file_context_t *p4est_file_open_create
  */
 p4est_file_context_t *p4est_file_open_read (p4est_t * p4est,
                                             const char *filename,
-                                            char
-                                            user_string
-                                            [P4EST_FILE_USER_STRING_BYTES],
-                                            int *errcode);
+                                            char *user_string, int *errcode);
 
 /** Write a header block to an opened file.
  * This function requires an opened file context.
@@ -290,9 +287,7 @@ p4est_file_context_t *p4est_file_open_read (p4est_t * p4est,
 p4est_file_context_t *p4est_file_write_header (p4est_file_context_t * fc,
                                                size_t header_size,
                                                const void *header_data,
-                                               const char*
-                                               user_string
-                                               ,
+                                               const char *user_string,
                                                int *errcode);
 
 /** Read a header block from an opened file.
@@ -338,9 +333,7 @@ p4est_file_context_t *p4est_file_write_header (p4est_file_context_t * fc,
 p4est_file_context_t *p4est_file_read_header (p4est_file_context_t * fc,
                                               size_t header_size,
                                               void *header_data,
-                                              char
-                                              user_string
-                                              [P4EST_FILE_USER_STRING_BYTES],
+                                              char *user_string,
                                               int *errcode);
 
 /** Write one (more) per-quadrant data set to a parallel output file.
@@ -386,9 +379,7 @@ p4est_file_context_t *p4est_file_read_header (p4est_file_context_t * fc,
  */
 p4est_file_context_t *p4est_file_write_field (p4est_file_context_t * fc,
                                               sc_array_t * quadrant_data,
-                                              const char*
-                                              user_string
-                                              ,
+                                              const char *user_string,
                                               int *errcode);
 
 /** Read one (more) per-quadrant data set from a parallel input file.
@@ -441,10 +432,7 @@ p4est_file_context_t *p4est_file_write_field (p4est_file_context_t * fc,
  */
 p4est_file_context_t *p4est_file_read_field (p4est_file_context_t * fc,
                                              sc_array_t * quadrant_data,
-                                             char
-                                             user_string
-                                             [P4EST_FILE_USER_STRING_BYTES],
-                                             int *errcode);
+                                             char *user_string, int *errcode);
 
 /** A data type that encodes the metadata of one data block in a p4est data file.
  */
@@ -499,9 +487,7 @@ p4est_file_section_metadata_t;
  *                                  an error. See also errcode argument.
  */
 int                 p4est_file_info (p4est_t * p4est, const char *filename,
-                                     char
-                                     user_string
-                                     [P4EST_FILE_USER_STRING_BYTES],
+                                     char *user_string,
                                      sc_array_t * data_sections,
                                      int *errcode);
 
@@ -515,9 +501,7 @@ int                 p4est_file_info (p4est_t * p4est, const char *filename,
  *                          something else on invalid arguments.
  */
 int                 p4est_file_error_string (int errclass,
-                                             char
-                                             string[sc_MPI_MAX_ERROR_STRING],
-                                             int *resultlen);
+                                             char *string, int *resultlen);
 
 /** Close a file opened for parallel write/read and free the context.
  * \param [in,out] fc       Context previously created by \ref

--- a/src/p8est_extended.h
+++ b/src/p8est_extended.h
@@ -608,9 +608,7 @@ p8est_t            *p8est_source_ext (sc_io_source_t * src,
  */
 p8est_file_context_t *p8est_file_open_read_ext (sc_MPI_Comm mpicomm,
                                                 const char *filename,
-                                                char
-                                                user_string
-                                                [P8EST_FILE_USER_STRING_BYTES],
+                                                char *user_string,
                                                 p4est_gloidx_t *
                                                 global_num_quadrants,
                                                 int *errcode);
@@ -626,9 +624,7 @@ p8est_file_context_t *p8est_file_open_read_ext (sc_MPI_Comm mpicomm,
 p8est_file_context_t *p8est_file_read_field_ext (p8est_file_context_t * fc,
                                                  p4est_gloidx_t * gfq,
                                                  sc_array_t * quadrant_data,
-                                                 char
-                                                 user_string
-                                                 [P8EST_FILE_USER_STRING_BYTES],
+                                                 char *user_string,
                                                  int *errcode);
 
 /** Create the data necessary to create a PETsc DMPLEX representation of a

--- a/src/p8est_io.h
+++ b/src/p8est_io.h
@@ -218,7 +218,7 @@ p8est_file_error_t;
  */
 p8est_file_context_t *p8est_file_open_create
   (p8est_t * p8est, const char *filename,
-   const char* user_string, int *errcode);
+   const char *user_string, int *errcode);
 
 /** Open a file for reading and read its user string on rank zero.
  * The user string is broadcasted to all ranks after reading.
@@ -250,10 +250,7 @@ p8est_file_context_t *p8est_file_open_create
  */
 p8est_file_context_t *p8est_file_open_read (p8est_t * p8est,
                                             const char *filename,
-                                            char
-                                            user_string
-                                            [P8EST_FILE_USER_STRING_BYTES],
-                                            int *errcode);
+                                            char *user_string, int *errcode);
 
 /** Write a header block to an opened file.
  * This function requires an opened file context.
@@ -290,9 +287,7 @@ p8est_file_context_t *p8est_file_open_read (p8est_t * p8est,
 p8est_file_context_t *p8est_file_write_header (p8est_file_context_t * fc,
                                                size_t header_size,
                                                const void *header_data,
-                                               const char*
-                                               user_string
-                                               ,
+                                               const char *user_string,
                                                int *errcode);
 
 /** Read a header block from an opened file.
@@ -338,9 +333,7 @@ p8est_file_context_t *p8est_file_write_header (p8est_file_context_t * fc,
 p8est_file_context_t *p8est_file_read_header (p8est_file_context_t * fc,
                                               size_t header_size,
                                               void *header_data,
-                                              char
-                                              user_string
-                                              [P8EST_FILE_USER_STRING_BYTES],
+                                              char *user_string,
                                               int *errcode);
 
 /** Write one (more) per-quadrant data set to a parallel output file.
@@ -386,9 +379,7 @@ p8est_file_context_t *p8est_file_read_header (p8est_file_context_t * fc,
  */
 p8est_file_context_t *p8est_file_write_field (p8est_file_context_t * fc,
                                               sc_array_t * quadrant_data,
-                                              const char*
-                                              user_string
-                                              ,
+                                              const char *user_string,
                                               int *errcode);
 
 /** Read one (more) per-quadrant data set from a parallel input file.
@@ -440,10 +431,7 @@ p8est_file_context_t *p8est_file_write_field (p8est_file_context_t * fc,
  */
 p8est_file_context_t *p8est_file_read_field (p8est_file_context_t * fc,
                                              sc_array_t * quadrant_data,
-                                             char
-                                             user_string
-                                             [P8EST_FILE_USER_STRING_BYTES],
-                                             int *errcode);
+                                             char *user_string, int *errcode);
 
 /** A data type that encodes the metadata of one data block in a p4est data file.
  */
@@ -498,9 +486,7 @@ p8est_file_section_metadata_t;
  *                                  an error. See also errcode argument.
  */
 int                 p8est_file_info (p8est_t * p8est, const char *filename,
-                                     char
-                                     user_string
-                                     [P8EST_FILE_USER_STRING_BYTES],
+                                     char *user_string,
                                      sc_array_t * data_sections,
                                      int *errcode);
 
@@ -514,9 +500,7 @@ int                 p8est_file_info (p8est_t * p8est, const char *filename,
  *                          something else on invalid arguments.
  */
 int                 p8est_file_error_string (int errclass,
-                                             char
-                                             string[sc_MPI_MAX_ERROR_STRING],
-                                             int *resultlen);
+                                             char *string, int *resultlen);
 
 /** Close a file opened for parallel write/read and free the context.
  * \param [in,out] fc       Context previously created by \ref

--- a/src/p8est_io.h
+++ b/src/p8est_io.h
@@ -218,7 +218,7 @@ p8est_file_error_t;
  */
 p8est_file_context_t *p8est_file_open_create
   (p8est_t * p8est, const char *filename,
-   const char user_string[P8EST_FILE_USER_STRING_BYTES], int *errcode);
+   const char* user_string, int *errcode);
 
 /** Open a file for reading and read its user string on rank zero.
  * The user string is broadcasted to all ranks after reading.
@@ -290,9 +290,9 @@ p8est_file_context_t *p8est_file_open_read (p8est_t * p8est,
 p8est_file_context_t *p8est_file_write_header (p8est_file_context_t * fc,
                                                size_t header_size,
                                                const void *header_data,
-                                               const char
+                                               const char*
                                                user_string
-                                               [P8EST_FILE_USER_STRING_BYTES],
+                                               ,
                                                int *errcode);
 
 /** Read a header block from an opened file.
@@ -386,9 +386,9 @@ p8est_file_context_t *p8est_file_read_header (p8est_file_context_t * fc,
  */
 p8est_file_context_t *p8est_file_write_field (p8est_file_context_t * fc,
                                               sc_array_t * quadrant_data,
-                                              const char
+                                              const char*
                                               user_string
-                                              [P8EST_FILE_USER_STRING_BYTES],
+                                              ,
                                               int *errcode);
 
 /** Read one (more) per-quadrant data set from a parallel input file.


### PR DESCRIPTION
# Fix overread warnings

Proposed changes:
- For function parameters to read strings we use `char abc*` instead of char `abc[NUM]` to avoid compiler warnings classified as string overread in case of strings that are shorter than `NUM - 1`. These warnings appear because GCC 11.2 differentiates between `TYPE* abc` and `TYPE abc[]`
(cf. https://github.com/pmodels/mpich/pull/5749).
- For function parameters to write strings we do the same changes for consistency.
