### PR TITLE
CI: Fix Ubuntu version

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -21,7 +21,7 @@ on:
 jobs:
 
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: CMake build on Linux
     timeout-minutes: 15
 


### PR DESCRIPTION
# CI: Fix Ubuntu version

Proposed changes:
Since Github actions is using Ubuntu 22.04 now and therefore can not install older compiler versions anymore, we fix Ubuntu 20.4 as OS to test older versions of GCC and Clang with Cmake.
