### PR TITLE
Add function to check if p4est has been initialized

### DIFF
--- a/src/p4est_base.c
+++ b/src/p4est_base.c
@@ -25,7 +25,7 @@
 #include <p4est_base.h>
 
 int                 p4est_package_id = -1;
-int                 p4est_is_initialized_ = 0;
+int                 p4est_initialized = 0;
 
 void
 p4est_init (sc_log_handler_t log_handler, int log_threshold)
@@ -47,13 +47,13 @@ p4est_init (sc_log_handler_t log_handler, int log_threshold)
   P4EST_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "LDFLAGS", P4EST_LDFLAGS);
   P4EST_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "LIBS", P4EST_LIBS);
 
-  p4est_is_initialized_ = 1;
+  p4est_initialized = 1;
 }
 
 int
 p4est_is_initialized (void)
 {
-  return p4est_is_initialized_;
+  return p4est_initialized;
 }
 
 #ifndef __cplusplus

--- a/src/p4est_base.c
+++ b/src/p4est_base.c
@@ -25,6 +25,7 @@
 #include <p4est_base.h>
 
 int                 p4est_package_id = -1;
+int                 p4est_is_initialized_ = 0;
 
 void
 p4est_init (sc_log_handler_t log_handler, int log_threshold)
@@ -45,6 +46,14 @@ p4est_init (sc_log_handler_t log_handler, int log_threshold)
   P4EST_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "CFLAGS", P4EST_CFLAGS);
   P4EST_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "LDFLAGS", P4EST_LDFLAGS);
   P4EST_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "LIBS", P4EST_LIBS);
+
+  p4est_is_initialized_ = 1;
+}
+
+int
+p4est_is_initialized (void)
+{
+  return p4est_is_initialized_;
 }
 
 #ifndef __cplusplus

--- a/src/p4est_base.h
+++ b/src/p4est_base.h
@@ -345,6 +345,13 @@ p4est_log_indent_pop ()
 void                p4est_init (sc_log_handler_t log_handler,
                                 int log_threshold);
 
+/** Return whether p4est has been initialized or not.
+ *
+ * \return          Returns `1` if p4est has been initialized with a call to
+ *                  `p4est_init`, and `0` otherwise.
+ */
+int                 p4est_is_initialized (void);
+
 /** Compute hash value for two p4est_topidx_t integers.
  * \param [in] tt     Array of (at least) two values.
  * \return            An unsigned hash value.

--- a/src/p4est_base.h
+++ b/src/p4est_base.h
@@ -346,9 +346,15 @@ void                p4est_init (sc_log_handler_t log_handler,
                                 int log_threshold);
 
 /** Return whether p4est has been initialized or not.
+ * Keep in mind that \ref p4est_init is an optional function
+ * but it helps with proper parallel logging.
  *
- * \return          Returns `1` if p4est has been initialized with a call to
- *                  `p4est_init`, and `0` otherwise.
+ * Currently there is no inverse to \ref p4est_init, and no way to deinit it.
+ * This is ok since initialization generally does no harm.
+ * Just do not call libsc's finalize function while p4est is still in use.
+ *
+ * \return          True if p4est has been initialized with a call to
+ *                  \ref p4est_init and false otherwise.
  */
 int                 p4est_is_initialized (void);
 


### PR DESCRIPTION
This adds the first part of the functionality as discussed in #178, i.e., the ability to check if p4est has already been initialized through a function `p4est_is_initialized`.

I'm not sure if this needs anything else - or if this is even the right target branch for the next release - but I just thought I'd get the discussion started by opening a PR to iterate on.

cc @ranocha 