### PR TITLE
Deprecate data file format

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -58,6 +58,8 @@ set(P4EST_ENABLE_BUILD_2D true CACHE BOOL "p4est is always used")
 set(P4EST_ENABLE_BUILD_3D ${enable_p8est})
 set(P4EST_ENABLE_BUILD_P6EST ${enable_p6est})
 
+set(P4EST_ENABLE_FILE_DEPRECATED ${enable-file-deprecated})
+
 set(P4EST_ENABLE_MEMALIGN 1)
 
 if(mpi)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,6 +1,8 @@
 option(enable_p6est "build p6est" on)
 option(enable_p8est "build p8est" on)
 
+option(enable-file-deprecated "use depreacted data file format" off)
+
 option(vtk_binary "VTK binary interface" on)
 if(vtk_binary)
   set(P4EST_ENABLE_VTK_BINARY 1)

--- a/cmake/p4est_config.h.in
+++ b/cmake/p4est_config.h.in
@@ -48,6 +48,9 @@
 /* Define to 1 if we enable zlib compression for vtk binary data */
 #cmakedefine P4EST_ENABLE_VTK_COMPRESSION 1
 
+/* Define to 1 if we use depreacted data file format */
+#cmakedefine P4EST_ENABLE_FILE_DEPRECATED 1
+
 /* Define to a macro mangling the given C identifier (in lower and upper
    case), which must not contain underscores, for linking with Fortran. */
 #define P4EST_F77_FUNC(name,NAME) name ## _

--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,8 @@ P4EST_ARG_ENABLE([debug], [enable debug mode (assertions and extra checks)],
                  [DEBUG])
 P4EST_ARG_ENABLE([vtk-doubles], [use doubles for vtk file data],
                  [VTK_DOUBLES])
+P4EST_ARG_ENABLE([file-deprecated], [use depreacted data file format],
+                 [FILE_DEPRECATED])
 P4EST_ARG_DISABLE([vtk-binary], [write vtk ascii file data],
                   [VTK_BINARY])
 P4EST_ARG_DISABLE([vtk-zlib], [disable zlib compression for vtk binary data],

--- a/example/steps/p4est_step3.c
+++ b/example/steps/p4est_step3.c
@@ -54,6 +54,8 @@
 #endif
 #include <sc_options.h>
 
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
 #ifndef P4_TO_P8
 #define P4EST_DATA_FILE_EXT "p4d" /**< file extension of p4est data files */
 #else
@@ -65,11 +67,17 @@
                                                       the simulation context */
 #define STEP3_ENDIAN_CHECK 0x30415062   /* check endian; bPA0 in ASCII */
 
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
+
 /** We had 1. / 0. here to create a NaN but that is not portable. */
 static const double step3_invalid = -1.;
 
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
 /** A Boolean to decide if checkpoint files are written to disk. */
 static int          step3_checkpoint = 0;
+
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
 /* In this example we store data with each quadrant/octant. */
 
@@ -600,6 +608,8 @@ step3_write_solution (p4est_t * p4est, int timestep)
   sc_array_destroy (u_interp);
 }
 
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
 /** Write a checkpoint file of the current simulation.
  * The file can be loaded using \ref step3_restart to
  * restart the simulation.
@@ -810,6 +820,8 @@ step3_restart (const char *filename, sc_MPI_Comm mpicomm, double time_inc)
   p4est_destroy (loaded_p4est);
   p4est_connectivity_destroy (conn);
 }
+
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
 /** Approximate the divergence of (vu) on each quadrant
  *
@@ -1373,10 +1385,15 @@ step3_timestep (p4est_t * p4est, double start_time, double end_time)
 
   ctx->time_step = i - 1;
   ctx->current_time = t - dt;
+
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
   if (step3_checkpoint) {
     /* write checkpoint file */
     step3_write_checkpoint (p4est, i - 1);
   }
+
+#endif
 
   P4EST_FREE (ghost_data);
   p4est_ghost_destroy (ghost);
@@ -1397,8 +1414,10 @@ main (int argc, char **argv)
   p4est_t            *p4est;
   p4est_connectivity_t *conn;
   step3_ctx_t         ctx;
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
   sc_options_t       *opt;
   const char         *filename;
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
   /* Initialize MPI; see sc_mpi.h.
    * If configure --enable-mpi is given these are true MPI calls.
@@ -1415,6 +1434,8 @@ main (int argc, char **argv)
   P4EST_GLOBAL_PRODUCTIONF
     ("This is the p4est %dD demo example/steps/%s_step3\n",
      P4EST_DIM, P4EST_STRING);
+
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
 
   /* read command line options */
   opt = sc_options_new (argv[0]);
@@ -1437,6 +1458,8 @@ main (int argc, char **argv)
     SC_CHECK_MPI (mpiret);
     return 0;
   }
+
+  #endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
   /* Avoid write of uninitialized bytes (valgrind warning)
    * due to compiler padding.
@@ -1507,7 +1530,9 @@ main (int argc, char **argv)
   p4est_destroy (p4est);
   p4est_connectivity_destroy (conn);
 
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
   sc_options_destroy (opt);
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
   /* Verify that allocations internal to p4est and sc do not leak memory.
    * This should be called if sc_init () has been called earlier. */

--- a/example/steps/p4est_step3.c
+++ b/example/steps/p4est_step3.c
@@ -1425,7 +1425,7 @@ step3_timestep (p4est_t * p4est, double start_time, double end_time)
  * timestep; clean up, and exit.
  *
  * \param [in] mpicomm  The MPI communicator that is used to
- *                      create the corresponsing simulation
+ *                      create the corresponding simulation
  *                      p4est.
 */
 static void

--- a/example/steps/p4est_step3.c
+++ b/example/steps/p4est_step3.c
@@ -1548,20 +1548,11 @@ main (int argc, char **argv)
   filename = NULL;
 #endif
   retval = sc_options_parse (p4est_package_id, SC_LP_ERROR, opt, argc, argv);
-  usage_error = 1;
-  if (retval == -1 || retval < argc) {
-    /* usage error */
+  usage_error = (retval == -1 || retval < argc);
+  if (usage_error || help) {
     sc_options_print_usage (p4est_package_id, SC_LP_PRODUCTION, opt, NULL);
 
     /* clean up */
-    goto p4est_step3_cleanup;
-  }
-  if (help) {
-    /* help command */
-    sc_options_print_usage (p4est_package_id, SC_LP_PRODUCTION, opt, NULL);
-
-    /* clean up */
-    usage_error = 0;
     goto p4est_step3_cleanup;
   }
   sc_options_print_summary (p4est_package_id, SC_LP_PRODUCTION, opt);

--- a/src/p4est_extended.h
+++ b/src/p4est_extended.h
@@ -591,6 +591,8 @@ p4est_t            *p4est_source_ext (sc_io_source_t * src,
                                       int broadcasthead, void *user_pointer,
                                       p4est_connectivity_t ** connectivity);
 
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
 /** Open a file for reading without knowing the p4est that is associated
  * with the mesh-related data in the file (cf. \ref p4est_file_open_read).
  * For more general comments on open_read see the documentation of
@@ -621,6 +623,7 @@ p4est_file_context_t *p4est_file_read_field_ext (p4est_file_context_t * fc,
                                                  sc_array_t * quadrant_data,
                                                  char *user_string,
                                                  int *errcode);
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
 /** Create the data necessary to create a PETsc DMPLEX representation of a
  * forest, as well as the accompanying lnodes and ghost layer.  The forest

--- a/src/p4est_io.c
+++ b/src/p4est_io.c
@@ -36,6 +36,8 @@
 #include <sc_search.h>
 #include <sc.h>
 
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
 #define P4EST_FILE_COMPRESSED_QUAD_SIZE ((P4EST_DIM + 1) *\
                                         sizeof (p4est_qcoord_t))
                                         /**< size of a compressed quadrant */
@@ -165,6 +167,8 @@
                                                     p4est_file_error_cleanup (&fc->file);\
                                                     P4EST_FREE (fc);\
                                                     return NULL;}} while (0)
+
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
 sc_array_t         *
 p4est_deflate_quadrants (p4est_t * p4est, sc_array_t ** data)
@@ -433,6 +437,8 @@ p4est_inflate_null (sc_MPI_Comm mpicomm, p4est_connectivity_t * connectivity,
 
   return ret_p4est;
 }
+
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
 
 /* Avoid redefinition in p4est_to_p8est.h */
 #ifdef P4_TO_P8
@@ -2290,3 +2296,5 @@ p4est_file_close (p4est_file_context_t * fc, int *errcode)
   p4est_file_error_code (*errcode, errcode);
   return 0;
 }
+
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */

--- a/src/p4est_io.h
+++ b/src/p4est_io.h
@@ -39,6 +39,15 @@
 
 SC_EXTERN_C_BEGIN;
 
+/** This parallel data file format is deprecated since we plan to release an
+ * updated version of it soon. You can still use \ref p4est_load and \ref
+ * p4est_save to read and write a p4est including the connectivity and
+ * quadrant data. However, you can not read and write external mesh associated
+ * data using a p4est function if you do not use the p4est_file functions.
+ * If you still want to use the p4est_file functions you can configure
+ * with --enable-file-deprecated or use the variable enable-file-deprecated
+ * in CMake.
+*/
 #ifdef P4EST_ENABLE_FILE_DEPRECATED
 
 #define P4EST_FILE_MAGIC_NUMBER "p4data0" /**< magic string for p4est data files */

--- a/src/p4est_io.h
+++ b/src/p4est_io.h
@@ -39,6 +39,8 @@
 
 SC_EXTERN_C_BEGIN;
 
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
 #define P4EST_FILE_MAGIC_NUMBER "p4data0" /**< magic string for p4est data files */
 #define P4EST_FILE_METADATA_BYTES 96 /**< number of file metadata bytes */
 #define P4EST_FILE_MAGIC_BYTES 8 /**< number of bytes of the magic number */
@@ -60,6 +62,8 @@ SC_EXTERN_C_BEGIN;
 #define P4EST_FILE_MAX_GLOBAL_QUAD 9999999999999999 /**< maximal number of global quadrants */
 #define P4EST_FILE_MAX_BLOCK_SIZE 9999999999999 /**< maximal number of block bytes */
 #define P4EST_FILE_MAX_FIELD_ENTRY_SIZE 9999999999999 /**< maximal number of bytes per field entry */
+
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
 /** Extract processor local quadrants' x y level data.
  * Optionally extracts the quadrant data as well into a separate array.
@@ -130,6 +134,8 @@ p4est_t            *p4est_inflate_null (sc_MPI_Comm mpicomm,
                                         sc_array_t * quadrants,
                                         sc_array_t * data,
                                         void *user_pointer);
+
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
 
 /** p4est data file format
  * All p4est data files have 64 bytes file header section at the beginning of the file.
@@ -729,6 +735,8 @@ p4est_file_context_t *p4est_file_read_connectivity (p4est_file_context_t * fc,
  */
 int                 p4est_file_close (p4est_file_context_t * fc,
                                       int *errcode);
+
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
 SC_EXTERN_C_END;
 

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -63,6 +63,9 @@
 #define P4EST_LAST_OFFSET               P8EST_LAST_OFFSET
 #define P4EST_QUADRANT_INIT             P8EST_QUADRANT_INIT
 #define P4EST_LEAF_IS_FIRST_IN_TREE     P8EST_LEAF_IS_FIRST_IN_TREE
+
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
 #define P4EST_FILE_MAGIC_NUMBER         P8EST_FILE_MAGIC_NUMBER
 #define P4EST_FILE_METADATA_BYTES       P8EST_FILE_METADATA_BYTES
 #define P4EST_FILE_MAGIC_BYTES          P8EST_FILE_MAGIC_BYTES
@@ -76,6 +79,8 @@
 #define P4EST_FILE_MAX_GLOBAL_QUAD      P8EST_FILE_MAX_GLOBAL_QUAD
 #define P4EST_FILE_MAX_BLOCK_SIZE       P8EST_FILE_MAX_BLOCK_SIZE
 #define P4EST_FILE_MAX_FIELD_ENTRY_SIZE P8EST_FILE_MAX_FIELD_ENTRY_SIZE
+
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
 /* redefine enums */
 #define P4EST_CONNECT_SELF              P8EST_CONNECT_SELF
@@ -91,6 +96,9 @@
 #define P4EST_WRAP_NONE                 P8EST_WRAP_NONE
 #define P4EST_WRAP_REFINE               P8EST_WRAP_REFINE
 #define P4EST_WRAP_COARSEN              P8EST_WRAP_COARSEN
+
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
 #define P4EST_FILE_ERR_SUCCESS          P8EST_FILE_ERR_SUCCESS
 #define P4EST_FILE_ERR_FILE             P8EST_FILE_ERR_FILE
 #define P4EST_FILE_ERR_NOT_SAME         P8EST_FILE_ERR_NOT_SAME
@@ -112,6 +120,8 @@
 #define P4EST_FILE_ERR_COUNT            P8EST_FILE_ERR_COUNT
 #define P4EST_FILE_ERR_UNKNOWN          P8EST_FILE_ERR_UNKNOWN
 #define P4EST_FILE_ERR_LASTCODE         P8EST_FILE_ERR_LASTCODE
+
+#endif
 
 /* redefine types */
 #ifdef P4EST_BACKWARD_DEALII
@@ -281,8 +291,13 @@
 #define p4est_save_ext                  p8est_save_ext
 #define p4est_load_ext                  p8est_load_ext
 #define p4est_source_ext                p8est_source_ext
+
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
 #define p4est_file_open_read_ext        p8est_file_open_read_ext
 #define p4est_file_read_field_ext       p8est_file_read_field_ext
+
+#endif
 
 /* functions in p4est_iterate */
 #define p4est_iterate                   p8est_iterate
@@ -469,6 +484,9 @@
 #define p4est_deflate_quadrants         p8est_deflate_quadrants
 #define p4est_inflate                   p8est_inflate
 #define p4est_inflate_null              p8est_inflate_null
+
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
 #define p4est_file_open_create          p8est_file_open_create
 #define p4est_file_open_append          p8est_file_open_append
 #define p4est_file_open_read            p8est_file_open_read
@@ -483,6 +501,8 @@
 #define p4est_file_write_connectivity   p8est_file_write_connectivity
 #define p4est_file_read_connectivity    p8est_file_read_connectivity
 #define p4est_file_close                p8est_file_close
+
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
 /* functions in p4est_geometry */
 #define p4est_geometry_destroy          p8est_geometry_destroy

--- a/src/p8est_extended.h
+++ b/src/p8est_extended.h
@@ -597,6 +597,8 @@ p8est_t            *p8est_source_ext (sc_io_source_t * src,
                                       int broadcasthead, void *user_pointer,
                                       p8est_connectivity_t ** connectivity);
 
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
 /** Open a file for reading without knowing the p4est that is associated
  * with the mesh-related data in the file (cf. \ref p8est_file_open_read).
  * For more general comments on open_read see the documentation of
@@ -627,6 +629,8 @@ p8est_file_context_t *p8est_file_read_field_ext (p8est_file_context_t * fc,
                                                  sc_array_t * quadrant_data,
                                                  char *user_string,
                                                  int *errcode);
+
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
 /** Create the data necessary to create a PETsc DMPLEX representation of a
  * forest, as well as the accompanying lnodes and ghost layer.  The forest

--- a/src/p8est_io.h
+++ b/src/p8est_io.h
@@ -39,6 +39,8 @@
 
 SC_EXTERN_C_BEGIN;
 
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
 #define P8EST_FILE_MAGIC_NUMBER "p8data0" /**< magic string for p8est data files */
 #define P8EST_FILE_METADATA_BYTES 96 /**< number of file metadata bytes */
 #define P8EST_FILE_MAGIC_BYTES 8 /**< number of bytes of the magic number without \n */
@@ -60,6 +62,8 @@ SC_EXTERN_C_BEGIN;
 #define P8EST_FILE_MAX_GLOBAL_QUAD 9999999999999999 /**< maximal number of global quadrants */
 #define P8EST_FILE_MAX_BLOCK_SIZE 9999999999999 /**< maximal number of block bytes */
 #define P8EST_FILE_MAX_FIELD_ENTRY_SIZE 9999999999999 /**< maximal number of bytes per field entry */
+
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
 /** Extract processor local quadrants' x y z level data.
  * Optionally extracts the quadrant data as well into a separate array.
@@ -130,6 +134,8 @@ p8est_t            *p8est_inflate_null (sc_MPI_Comm mpicomm,
                                         sc_array_t * quadrants,
                                         sc_array_t * data,
                                         void *user_pointer);
+
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
 
 /** p8est data file format
  * All p4est data files have 64 bytes file header section at the beginning of the file.
@@ -730,6 +736,8 @@ p8est_file_context_t *p8est_file_read_connectivity (p8est_file_context_t * fc,
  */
 int                 p8est_file_close (p8est_file_context_t * fc,
                                       int *errcode);
+
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
 SC_EXTERN_C_END;
 

--- a/src/p8est_io.h
+++ b/src/p8est_io.h
@@ -39,6 +39,15 @@
 
 SC_EXTERN_C_BEGIN;
 
+/** This parallel data file format is deprecated since we plan to release an
+ * updated version of it soon. You can still use \ref p8est_load and \ref
+ * p8est_save to read and write a p8est including the connectivity and
+ * quadrant data. However, you can not read and write external mesh associated
+ * data using a p8est function if you do not use the p4est_file functions.
+ * If you still want to use the p8est_file functions you can configure
+ * with --enable-file-deprecated or use the variable enable-file-deprecated
+ * in CMake.
+*/
 #ifdef P4EST_ENABLE_FILE_DEPRECATED
 
 #define P8EST_FILE_MAGIC_NUMBER "p8data0" /**< magic string for p8est data files */

--- a/test/test_io2.c
+++ b/test/test_io2.c
@@ -33,6 +33,8 @@
 #endif
 #include <sc_options.h>
 
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
 #ifndef P4_TO_P8
 #define P4EST_DATA_FILE_EXT "p4d" /**< file extension of p4est data files */
 #else
@@ -202,9 +204,13 @@ typedef struct compressed_quadrant
 }
 compressed_quadrant_t;
 
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
+
 int
 main (int argc, char **argv)
 {
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
   sc_MPI_Comm         mpicomm;
   int                 mpiret, errcode;
   int                 rank, size;
@@ -634,6 +640,8 @@ main (int argc, char **argv)
 
   mpiret = sc_MPI_Finalize ();
   SC_CHECK_MPI (mpiret);
+
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
   return 0;
 }


### PR DESCRIPTION
# Deprecate data file format

Proposed changes: Since we are planning to release an updated parallel data file format for p4est, we deprecate the old one to clarify that it will be replaced soon. The old data file format and all corresponding functionality like the simulation restart in `p{4,8}est_step3` can be activated by `--enable-file-deprecated` as configure flag for autotools or via the variable `enable-file-deprecated` in CMake.

The `p{4,8}est_{load,save}` functionality is unaffected and besides the functions for the data file format `p{4,8}est_file_*` including its tests and the restart functionality in `p{4,8}est_step3` nothing is changed and in particular no other existing functionality of p4est breaks.