### PR TITLE
Fix typo in example/CMakeLists.txt and suggest change in P4ESTConfig.cmake

### DIFF
--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -3,7 +3,9 @@
 include(CMakeFindDependencyMacro)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
-find_dependency(SC)
+if( (DEFINED SC_FOUND) AND (NOT SC_FOUND) )
+  find_dependency(SC CONFIG)
+endif()
 find_dependency(ZLIB)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -8,7 +8,7 @@ include(CheckIncludeFile)
 option(mpi "use MPI" off)
 
 # --- find external libraries
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../cmake/Modules)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../cmake)
 
 if(mpi)
   find_package(MPI COMPONENTS C REQUIRED)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -20,8 +20,16 @@ endif(mpi)
 find_package(ZLIB REQUIRED)
 
 # --- find our library
-find_package(SC REQUIRED)
-find_package(P4EST REQUIRED)
+# --- try first using CONFIG mode, and if not found then use MODULE mode
+find_package(SC CONFIG)
+if(NOT SC_FOUND)
+  find_package(SC REQUIRED)
+endif()
+
+find_package(P4EST CONFIG)
+if(NOT P4EST_FOUND)
+  find_package(P4EST REQUIRED)
+endif()
 
 # --- get system capabilities
 


### PR DESCRIPTION
# Update cmake in example/CMakeLists.txt

Following up on issue #182

Proposed changes:
- fix typo in example/CMakeLists.txt
- change the way package SC and P4EST are detected by `find_package` in example/CMakeLists.txt
- propose a change to template file cmake/config.cmake.in (that serves to build P4ESTConfig.cmake)
