### PR TITLE
CI:CMake: add GCC-12, work with CMake 3.26 runner default

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -89,8 +89,7 @@ jobs:
       with:
         name: linux_cmake_log
         path: |
-          ./build/CMakeFiles/CMakeOutput.log
-          ./build/CMakeFiles/CMakeError.log
+          ./build/CMakeFiles/CMakeConfigureLog.yaml
           ./build/Testing/Temporary/LastTest.log
 
   mac:
@@ -100,7 +99,7 @@ jobs:
 
     strategy:
       matrix:
-        cc: [clang, gcc]
+        cc: [clang, gcc-12]
         shared: [true, false]
 
     env:
@@ -157,8 +156,7 @@ jobs:
       with:
         name: mac_cmake_log
         path: |
-          ./build/CMakeFiles/CMakeOutput.log
-          ./build/CMakeFiles/CMakeError.log
+          ./build/CMakeFiles/CMakeConfigureLog.yaml
           ./build/Testing/Temporary/LastTest.log
 
   windows:
@@ -215,6 +213,5 @@ jobs:
       with:
         name: windows_cmake_log
         path: |
-          ./build/CMakeFiles/CMakeOutput.log
-          ./build/CMakeFiles/CMakeError.log
+          ./build/CMakeFiles/CMakeConfigureLog.yaml
           ./build/Testing/Temporary/LastTest.log

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -18,16 +18,19 @@ on:
   release:
     types: [published]
 
+env:
+  CTEST_NO_TESTS_ACTION: "error"
+
 jobs:
 
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: CMake build on Linux
     timeout-minutes: 15
 
     strategy:
       matrix:
-        cc: [clang-7, clang-8, clang-9, clang-10, gcc-7, gcc-8, gcc-9, gcc-10, gcc-11]
+        cc: [gcc-9, gcc-10, gcc-11, gcc-12]
         shared: [true, false]
 
     env:
@@ -41,8 +44,7 @@ jobs:
       run: |
         sudo apt-get update -yq
         sudo apt-get install -yq --no-install-recommends \
-            zlib1g-dev libmpich-dev mpich \
-            ${{ matrix.cc }}
+            zlib1g-dev libmpich-dev mpich
 
     - name: CMake configure
       run: |


### PR DESCRIPTION
Just like https://github.com/cburstedde/libsc/pull/113

For GitHub Actions CI:

* GCC 12 is now also available
* CMake 3.26 is now used, which does not have CMake{Error,Output}.log anymore, replaced by CMakeConfigureLog.yaml
* CTEST_NO_TESTS_ACTION: "error" is in case something is amiss in the CMakeLists.txt that accidentally disabled all tests, this environment variable fails CTest if no tests are enabled.

As I had done previously in libsc CMake CI, to make the CI tests run faster, I only test with GCC 9-12 