### PR TITLE
Fix -Wstrict-prototypes

### DIFF
--- a/doc/author_prj-.txt
+++ b/doc/author_prj-.txt
@@ -1,0 +1,1 @@
+I place my contributions to p4est under the FreeBSD license. prj- (https://github.com/prj-)

--- a/src/p4est_base.h
+++ b/src/p4est_base.h
@@ -322,13 +322,13 @@ void                P4EST_LERRORF (const char *fmt, ...)
 extern int          p4est_package_id;
 
 static inline void
-p4est_log_indent_push ()
+p4est_log_indent_push (void)
 {
   sc_log_indent_push_count (p4est_package_id, 1);
 }
 
 static inline void
-p4est_log_indent_pop ()
+p4est_log_indent_pop (void)
 {
   sc_log_indent_pop_count (p4est_package_id, 1);
 }

--- a/src/p4est_connectivity.h
+++ b/src/p4est_connectivity.h
@@ -530,7 +530,7 @@ p4est_connectivity_t *p4est_connectivity_new_disk (int periodic_a,
  * 0  2  4  6  8
  *  1  3  5  7  9
  */
-p4est_connectivity_t *p4est_connectivity_new_icosahedron ();
+p4est_connectivity_t *p4est_connectivity_new_icosahedron (void);
 
 /** Create a connectivity structure that builds a 2d spherical shell.
  * \ref p8est_connectivity_new_shell


### PR DESCRIPTION
```warning: a function declaration without a prototype is deprecated in all versions of C```
