### PR TITLE
cmake:example: don't try to run test in CI

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -67,9 +67,6 @@ jobs:
     - name: CMake build examples
       run: cmake --build example/build --parallel
 
-    - name: CMake test examples
-      run: ctest --test-dir example/build --output-on-failure
-
     - name: Create package
       if: github.event.action == 'published'
       run: cpack --config build/CPackConfig.cmake
@@ -134,9 +131,6 @@ jobs:
     - name: CMake build examples
       run: cmake --build example/build --parallel
 
-    - name: CMake test examples
-      run: ctest --test-dir example/build --output-on-failure
-
     - name: Create package
       if: github.event.action == 'published'
       run: cpack --config build/CPackConfig.cmake
@@ -190,9 +184,6 @@ jobs:
 
     - name: CMake build examples
       run: cmake --build example/build --parallel
-
-    - name: CMake test examples
-      run: ctest --test-dir example/build --output-on-failure
 
     - name: Create package
       if: github.event.action == 'published'

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.13...3.24)
 project(p4estExamples LANGUAGES C)
 
-include(CTest)
 include(CheckSymbolExists)
 include(CheckIncludeFile)
 
@@ -72,36 +71,34 @@ endif()
 
 
 # --- helper functions
+# it is not intended to run examples as tests
 
 function(p4est_example name files arg1 arg2)
 
 add_executable(${name} ${files})
 target_link_libraries(${name} PRIVATE P4EST::P4EST SC::SC)
 
-if(0) # it is not intended to run examples as tests
 if(mpi)
   add_test(NAME ${name} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${Ncpu} $<TARGET_FILE:${name}> ${arg1} ${arg2})
 else()
   add_test(NAME ${name} COMMAND ${name} ${arg1} ${arg2})
 endif()
 set_property(TEST ${name} PROPERTY LABELS p8est)
-endif()
 
 endfunction(p4est_example)
+
 
 function(p8est_example name files arg1 arg2)
 
 add_executable(${name} ${files})
 target_link_libraries(${name} PRIVATE P4EST::P4EST SC::SC)
 
-if(0) # it is not intended to run examples as tests
 if(mpi)
   add_test(NAME ${name} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${Ncpu} $<TARGET_FILE:${name}> ${arg1} ${arg2})
 else()
   add_test(NAME ${name} COMMAND ${name} ${arg1} ${arg2})
 endif()
 set_property(TEST ${name} PROPERTY LABELS p8est)
-endif()
 
 endfunction(p8est_example)
 


### PR DESCRIPTION
The examples were not intended to be run in the CI