### PR TITLE
Introduce p4est_search_partition_gfp

### DIFF
--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -596,6 +596,21 @@ p4est_comm_is_empty_gfq (const p4est_gloidx_t *gfq, int num_procs, int p)
 }
 
 int
+p4est_comm_is_empty_gfx (const p4est_gloidx_t *gfq, const p4est_quadrant_t *gfp,
+                         int num_procs, int p)
+{
+  P4EST_ASSERT (0 <= p && p < num_procs);
+  P4EST_ASSERT (gfp != NULL);
+
+  if (gfq) {
+    return gfq[p] == gfq[p + 1];
+  }
+  else {
+    return p4est_quadrant_is_equal_piggy (&gfp[p], &gfp[p + 1]);
+  }
+}
+
+int
 p4est_comm_is_contained (p4est_t * p4est, p4est_locidx_t which_tree,
                          const p4est_quadrant_t * q, int rank)
 {

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -161,6 +161,23 @@ int                 p4est_comm_is_empty (p4est_t *p4est, int p);
 int                 p4est_comm_is_empty_gfq (const p4est_gloidx_t *gfq,
                                              int num_procs, int p);
 
+
+/** Query whether a processor has no quadrants.
+ * If gfq == NULL, the function uses p4est_quadrant_is_equal on gfp, else it
+ * compares the entries p and p+1 of gfq.
+ * \param [in] gfq          An array encoding the partition offsets in the
+ *                          global quadrant array; length \a num_procs + 1.
+ * \param [in] gfp          An array encoding the partition shape.
+ *                          Non-decreasing; length \a num_procs + 1.
+ * \param [in] num_procs    Number of processes in the partition.
+ * \param [in] p            Valid 0 < \a p < \a num_procs.
+ * \return              True if and only if processor \p is empty.
+ */
+int                 p4est_comm_is_empty_gfx (const p4est_gloidx_t *gfq,
+                                             const p4est_quadrant_t *gfp,
+                                             int num_procs, int p);
+
+
 /** Test whether a quadrant is fully contained in a rank's owned region.
  * This function may return false when \ref p4est_comm_is_owner returns true.
  * \param [in] rank    Rank whose ownership is tested.

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -152,8 +152,8 @@ void                p4est_comm_count_pertree (p4est_t * p4est,
 int                 p4est_comm_is_empty (p4est_t *p4est, int p);
 
 /** Query whether a processor has no quadrants.
- * \param [in] gfp          An array encoding the partition shape.
- *                          Non-decreasing; length \a num_procs + 1.
+ * \param [in] gfq          An array encoding the partition offsets in the
+ *                          global quadrant array; length \a num_procs + 1.
  * \param [in] num_procs    Number of processes in the partition.
  * \param [in] p            Valid 0 < \a p < \a num_procs.
  * \return              True if and only if processor \p is empty.

--- a/src/p4est_search.h
+++ b/src/p4est_search.h
@@ -452,6 +452,43 @@ void                p4est_search_partition_gfx
    p4est_search_partition_t quadrant_fn, p4est_search_partition_t point_fn,
    sc_array_t *points);
 
+/** Traverse some given global partition top-down.
+ * The partition can be that of any p4est, not necessarily known to the
+ * caller.  This is not a collective function.  It does not communicate.
+ * We proceed top-down through the partition, identically on all processors
+ * except for the results of two user-provided callbacks.  The recursion will only
+ * go down branches that are split between multiple processors.  The callback
+ * functions can be used to stop a branch recursion even for split branches.
+ * This function offers the option to search for arbitrary user-defined points
+ * analogously to \ref p4est_search_local.
+ * This function is similar to p4est_search_partition_gfx, but does not require
+ * the p4est_gloidx_t array gfq. If gfq is available, using
+ * p4est_search_partition_gfx is recommended, because it is slightly faster.
+ * \note Traversing the whole given partition will be at least O(P),
+ *       so sensible use of the callback function is advised to cut it short.
+ * \param [in] gfp          Partition position to traverse.  Length \a nmemb + 1.
+ * \param [in] nmemb        Number of processors encoded in \a gfp (plus one).
+ * \param [in] num_trees    Tree number must match the contents of \a gfp.
+ * \param [in] call_post    If true, call quadrant callback both pre and post
+ *                          point callback, in both cases before recursion (!).
+ * \param [in] user         We pass a dummy p4est to the callbacks whose only
+ *                          valid element is its user_pointer set to \a user.
+ * \param [in] quadrant_fn  This function controls the recursion,
+ *                          which only continues deeper if this
+ *                          callback returns true for a branch quadrant.
+ *                          It is allowed to set this to NULL.
+ * \param [in] point_fn     This function decides per-point whether it is
+ *                          followed down the recursion.
+ *                          Must be non-NULL if \b points are not NULL.
+ * \param [in] points       User-provided array of \b points that are
+ *                          passed to the callback \b point_fn.
+ *                          See \ref p4est_search_local for details.
+ */
+void                p4est_search_partition_gfp
+  (const p4est_quadrant_t *gfp, int nmemb, p4est_topidx_t num_trees,
+   int call_post, void *user, p4est_search_partition_t quadrant_fn,
+   p4est_search_partition_t point_fn, sc_array_t *points);
+
 /** Callback function for the top-down search through the whole forest.
  * \param [in] p4est        The forest to search.
  *                          We recurse through the trees one after another.

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -459,6 +459,7 @@
 #define p4est_comm_count_pertree        p8est_comm_count_pertree
 #define p4est_comm_is_empty             p8est_comm_is_empty
 #define p4est_comm_is_empty_gfq         p8est_comm_is_empty_gfq
+#define p4est_comm_is_empty_gfx         p8est_comm_is_empty_gfx
 #define p4est_comm_is_contained         p8est_comm_is_contained
 #define p4est_comm_is_owner             p8est_comm_is_owner
 #define p4est_comm_is_owner_gfp         p8est_comm_is_owner_gfp

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -410,6 +410,7 @@
 #define p4est_search_reorder            p8est_search_reorder
 #define p4est_search_partition          p8est_search_partition
 #define p4est_search_partition_gfx      p8est_search_partition_gfx
+#define p4est_search_partition_gfp      p8est_search_partition_gfp
 #define p4est_search_all                p8est_search_all
 #define p4est_build_new                 p8est_build_new
 #define p4est_build_init_add            p8est_build_init_add

--- a/src/p8est_communication.h
+++ b/src/p8est_communication.h
@@ -152,8 +152,8 @@ void                p8est_comm_count_pertree (p8est_t * p8est,
 int                 p8est_comm_is_empty (p8est_t *p8est, int p);
 
 /** Query whether a processor has no quadrants.
- * \param [in] gfp          An array encoding the partition shape.
- *                          Non-decreasing; length \a num_procs + 1.
+ * \param [in] gfq          An array encoding the partition offsets in the
+ *                          global quadrant array; length \a num_procs + 1.
  * \param [in] num_procs    Number of processes in the partition.
  * \param [in] p            Valid 0 < \a p < \a num_procs.
  * \return              True if and only if processor \p is empty.

--- a/src/p8est_communication.h
+++ b/src/p8est_communication.h
@@ -161,6 +161,21 @@ int                 p8est_comm_is_empty (p8est_t *p8est, int p);
 int                 p8est_comm_is_empty_gfq (const p4est_gloidx_t *gfq,
                                              int num_procs, int p);
 
+/** Query whether a processor has no quadrants.
+ * If gfq == NULL, the function uses p4est_quadrant_is_equal on gfp, else it
+ * compares the entries p and p+1 of gfq.
+ * \param [in] gfq          An array encoding the partition offsets in the
+ *                          global quadrant array; length \a num_procs + 1.
+ * \param [in] gfp          An array encoding the partition shape.
+ *                          Non-decreasing; length \a num_procs + 1.
+ * \param [in] num_procs    Number of processes in the partition.
+ * \param [in] p            Valid 0 < \a p < \a num_procs.
+ * \return              True if and only if processor \p is empty.
+ */
+int                 p8est_comm_is_empty_gfx (const p4est_gloidx_t *gfq,
+                                             const p4est_quadrant_t *gfp,
+                                             int num_procs, int p);
+
 /** Test whether a quadrant is fully contained in a rank's owned region.
  * This function may return false when \ref p8est_comm_is_owner returns true.
  * \param [in] rank    Rank whose ownership is tested.

--- a/src/p8est_search.h
+++ b/src/p8est_search.h
@@ -454,6 +454,43 @@ void                p8est_search_partition_gfx
    p8est_search_partition_t quadrant_fn, p8est_search_partition_t point_fn,
    sc_array_t *points);
 
+/** Traverse some given global partition top-down.
+ * The partition can be that of any p4est, not necessarily known to the
+ * caller.  This is not a collective function.  It does not communicate.
+ * We proceed top-down through the partition, identically on all processors
+ * except for the results of two user-provided callbacks.  The recursion will only
+ * go down branches that are split between multiple processors.  The callback
+ * functions can be used to stop a branch recursion even for split branches.
+ * This function offers the option to search for arbitrary user-defined points
+ * analogously to \ref p4est_search_local.
+ * This function is similar to p4est_search_partition_gfx, but does not require
+ * the p4est_gloidx_t array gfq. If gfq is available, using
+ * p4est_search_partition_gfx is recommended, because it is slightly faster.
+ * \note Traversing the whole given partition will be at least O(P),
+ *       so sensible use of the callback function is advised to cut it short.
+ * \param [in] gfp          Partition position to traverse.  Length \a nmemb + 1.
+ * \param [in] nmemb        Number of processors encoded in \a gfp (plus one).
+ * \param [in] num_trees    Tree number must match the contents of \a gfp.
+ * \param [in] call_post    If true, call quadrant callback both pre and post
+ *                          point callback, in both cases before recursion (!).
+ * \param [in] user         We pass a dummy p4est to the callbacks whose only
+ *                          valid element is its user_pointer set to \a user.
+ * \param [in] quadrant_fn  This function controls the recursion,
+ *                          which only continues deeper if this
+ *                          callback returns true for a branch quadrant.
+ *                          It is allowed to set this to NULL.
+ * \param [in] point_fn     This function decides per-point whether it is
+ *                          followed down the recursion.
+ *                          Must be non-NULL if \b points are not NULL.
+ * \param [in] points       User-provided array of \b points that are
+ *                          passed to the callback \b point_fn.
+ *                          See \ref p4est_search_local for details.
+ */
+void                p8est_search_partition_gfp
+  (const p4est_quadrant_t *gfp, int nmemb, p4est_topidx_t num_trees,
+   int call_post, void *user, p4est_search_partition_t quadrant_fn,
+   p4est_search_partition_t point_fn, sc_array_t *points);
+
 /** Callback function for the top-down search through the whole forest.
  * \param [in] p4est        The forest to search.
  *                          We recurse through the trees one after another.


### PR DESCRIPTION
We add p4est_search_partition_gfp as an alternative to p4est_search_partition_gfx.
The parameter gfq is no longer required as a parameter, which may avoid unnecessary communication in case gfq is not already available locally, but makes the function slightly slower.
To implement p4est_search_partition_gfp with minimal changes, we add p4est_comm_is_empty_gfx, which works like p4est_comm_is_empty_gfq for gfq != NULL and else calls p4est_quadrant_is_equal_piggy on gfp.