### PR TITLE
Add json support in cmake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,14 @@ if(NOT sc_external)
 endif()
 if(NOT TARGET SC::SC)
   include(cmake/sc.cmake)
+
+  # here we make sure SC_HAVE_JSON is defined:
+  # - when sc_external is true, we use the same logic as in libsc to find library jansson
+  # - when libsc is found via find_package (CONFIG mode), this variable is already defined
+  #   in SCConfig.cmake
+  include(cmake/jansson.cmake)
 endif()
+
 
 # --- configure p4est
 
@@ -45,8 +52,10 @@ include(cmake/compilers.cmake)
 target_link_libraries(SC::SC INTERFACE
 $<$<BOOL:${MPI_C_FOUND}>:MPI::MPI_C>
 $<$<BOOL:${ZLIB_FOUND}>:ZLIB::ZLIB>
+$<$<BOOL:${SC_HAVE_JSON}>:jansson::jansson>
 $<$<BOOL:${P4EST_NEED_M}>:m>
 )
+
 # --- p4est
 # p4est is always needed.
 

--- a/cmake/jansson.cmake
+++ b/cmake/jansson.cmake
@@ -1,0 +1,41 @@
+# optional json library :
+# 1. try cmake find_package in config mode
+# 2. try pkg-config
+
+find_package(jansson CONFIG)
+
+if(jansson_FOUND)
+
+  message(STATUS "jansson library found via find_package")
+
+else()
+
+  # make sure cmake macro pkg_check_modules is available
+  find_package(PkgConfig)
+
+  if (PKG_CONFIG_FOUND)
+    pkg_check_modules(LIBSC_JANSSON QUIET IMPORTED_TARGET jansson)
+
+    if (LIBSC_JANSSON_FOUND)
+      message(STATUS "jansson library found via pkg-config")
+      add_library(jansson::jansson ALIAS PkgConfig::LIBSC_JANSSON)
+      set(jansson_FOUND 1)
+    else()
+      set(jansson_FOUND 0)
+    endif()
+  else()
+    message(NOTICE "pkg-config executable is not available.")
+    set(jansson_FOUND 0)
+  endif()
+
+endif()
+
+if( NOT jansson_FOUND )
+  message(NOTICE "libjansson was not found")
+endif()
+
+if (jansson_FOUND)
+  set(SC_HAVE_JSON 1)
+else()
+  set(SC_HAVE_JSON 0)
+endif()


### PR DESCRIPTION
# Add json support in cmake build system

This commit closely follow json support in libsc cmake build system.

This commit is currently harmless, it does almost nothing if libsc version is older than the merge which introduced json support in libsc.

I suggest to merge current MR, right before updating libsc git submodule.


