### PR TITLE
Fix example link when jansson is needed by libsc in cmake.

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -38,9 +38,14 @@ if(NOT P4EST_NONEED_M)
   check_symbol_exists(sqrt math.h P4EST_NEED_M)
 endif()
 
+if(SC_HAVE_JSON)
+  include(../cmake/jansson.cmake)
+endif()
+
 target_link_libraries(SC::SC INTERFACE
 $<$<BOOL:${MPI_C_FOUND}>:MPI::MPI_C>
 $<$<BOOL:${ZLIB_FOUND}>:ZLIB::ZLIB>
+$<$<BOOL:${SC_HAVE_JSON}>:jansson::jansson>
 $<$<BOOL:${P4EST_NEED_M}>:m>
 )
 # --- get system capabilities


### PR DESCRIPTION
#  Fix example link when jansson is needed by libsc in cmake.

This was forgotten in MR #205 because examples are built in a separate sub-project.