### PR TITLE
Update points example

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -857,7 +857,8 @@ WARN_LOGFILE           =
 
 INPUT                  = @top_srcdir@/src \
                          @top_srcdir@/doc/mainpage.dox \
-                         @top_srcdir@/doc/examples.dox
+                         @top_srcdir@/doc/examples.dox \
+                         @top_srcdir@/doc/example_points.dox
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/example_points.dox
+++ b/doc/example_points.dox
@@ -1,0 +1,78 @@
+/*
+  This file is part of p4est.
+  p4est is a C library to manage a collection (a forest) of multiple
+  connected adaptive quadtrees or octrees in parallel.
+
+  Copyright (C) 2010 The University of Texas System
+  Written by Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac
+
+  p4est is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  p4est is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with p4est; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \page example_points Documentation for the point example program
+ *
+ * The points example refines a domain according to a given set of points.
+ */
+
+/** \example points/generate_points2.c
+ *
+ * Auxiliary program to generate a file of points in parallel.
+ * It uses the MPI I/O functionality of libsc to create one large file.
+ * The file is written to in parallel and using partitioned file access.
+ *
+ * The file contains first a binary integer \ref p4est_gloidx_t
+ * storing the global number of points and then the list of point
+ * coordinates as 3-tuples of binary type double.
+ *
+ * The usage of the program is
+ *
+ *     p4est_points_generate <configuration> <globalnumpoints> <prefix>
+ *
+ * where configuration is one of
+ *
+ *  - `unit`        The 2D unit square,
+ *  - `brick`       A 2x3 grid of squares,
+ *  - `three`       Three squares meeting at a non-planary angle,
+ *  - `moebius`     A five-square moebius strip embedded in 3D space,
+ *  - `star`        A star composed of six rhomboids,
+ *  - `periodic`    The all-periodic unit square
+ *
+ * and prefix is an output basename or filename to which we append `.pts`.
+ */
+
+/** \example points/generate_points3.c
+ *
+ * Auxiliary program to generate a file of points in parallel.
+ * It uses the MPI I/O functionality of libsc to create one large file.
+ * The file is written to in parallel and using partitioned file access.
+ *
+ * The file contains first a binary integer \ref p4est_gloidx_t
+ * storing the global number of points and then the list of point
+ * coordinates as 3-tuples of binary type double.
+ *
+ * The usage of the program is
+ *
+ *     p8est_points_generate <configuration> <globalnumpoints> <prefix>
+ *
+ * where configuration is one of
+ *
+ *  - `unit`        The unit cube,
+ *  - `brick`       An example brick connectivity using configuration
+ *                  (2,3,4) as the number of trees per direction.
+ *  - `periodic`    The unit cube with all-periodic boundary conditions.
+ *  - `rotwrap`     The unit cube with various self-periodic b.c.
+ *  - `twocubes`    Two connected cubes.
+ *  - `rotcubes`    A collection of six connected rotated cubes.
+ */

--- a/doc/examples.dox
+++ b/doc/examples.dox
@@ -21,7 +21,7 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-/** \page Examples Documentation for selected example programs
+/** \page examples Documentation for selected example programs
  *
  * The p4est library comes with various example programs.
  * They are kept under the subdirectory

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -61,15 +61,19 @@ if(P4EST_ENABLE_P8EST)
     COPYONLY)
 endif()
 
-p4est_example(points2 points/points2.c unit 4)
-p4est_example(points3 points/points3.c unit 4)
 
-add_executable(generate_points2 points/generate_points.c)
-target_link_libraries(generate_points2 PRIVATE P4EST::P4EST SC::SC)
+# here we should be checking for SC_ENABLE_MPIIO
+# TODO : update libsc cmake build to expose SC_ENABLE_MPIIO
+if(SC_ENABLE_MPI)
+  p4est_example(points2 points/points2.c unit 4)
+  p4est_example(points3 points/points3.c unit 4)
 
-add_executable(generate_points3 points/generate_points.c)
-target_link_libraries(generate_points3 PRIVATE P4EST::P4EST SC::SC)
-target_compile_definitions(generate_points3 PUBLIC THREED)
+  add_executable(generate_points2 points/generate_points2.c)
+  target_link_libraries(generate_points2 PRIVATE P4EST::P4EST SC::SC)
+
+  add_executable(generate_points3 points/generate_points3.c)
+  target_link_libraries(generate_points3 PRIVATE P4EST::P4EST SC::SC)
+endif()
 
 p4est_example(simple2 simple/simple2.c unit 4)
 if(P4EST_ENABLE_P8EST)
@@ -137,7 +141,7 @@ if(enable_p8est)
 endif()
 
 set(s steps)
-foreach(i 1 2 4)
+foreach(i 1 2 3 4 5)
   set(n p4est_step${i})
   p4est_example(${n} ${s}/${n}.c ${s})
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -50,6 +50,25 @@ configure_file(
 endfunction()
 
 # --- setup examples
+
+p4est_example(mesh2 mesh/mesh2.c unit 4)
+if(P4EST_ENABLE_P8EST)
+  p4est_example(mesh3 mesh/mesh3.c unit 4)
+  p4est_example(periodicity3 mesh/periodicity3.c unit 4)
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/mesh/conndebug.p8c
+    ${CMAKE_BINARY_DIR}/conndebug.p8c
+    COPYONLY)
+endif()
+
+# p4est_example(points2 points/points2.c unit 4)  # missing .pts input files
+
+p4est_example(simple2 simple/simple2.c unit 4)
+if(P4EST_ENABLE_P8EST)
+  p8est_example(simple3 simple/simple3.c unit 4)
+endif()
+
+
 if(P4EST_HAVE_GETOPT_H)
 
 set(n particles)
@@ -128,7 +147,7 @@ if(enable_p8est)
     p4est_copy_resource(${s} hole_3d_${n})
   endforeach()
   endif()
-  
+
 set(t tetgen)
 foreach(n read_conn write_conn)
   p4est_example(${n}2 ${t}/${n}2.c ${t})

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -61,7 +61,15 @@ if(P4EST_ENABLE_P8EST)
     COPYONLY)
 endif()
 
-# p4est_example(points2 points/points2.c unit 4)  # missing .pts input files
+p4est_example(points2 points/points2.c unit 4)
+p4est_example(points3 points/points3.c unit 4)
+
+add_executable(generate_points2 points/generate_points.c)
+target_link_libraries(generate_points2 PRIVATE P4EST::P4EST SC::SC)
+
+add_executable(generate_points3 points/generate_points.c)
+target_link_libraries(generate_points3 PRIVATE P4EST::P4EST SC::SC)
+target_compile_definitions(generate_points3 PUBLIC THREED)
 
 p4est_example(simple2 simple/simple2.c unit 4)
 if(P4EST_ENABLE_P8EST)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -62,16 +62,14 @@ if(P4EST_ENABLE_P8EST)
 endif()
 
 
-if(SC_ENABLE_MPIIO)
-  p4est_example(points2 points/points2.c unit 4)
-  p4est_example(points3 points/points3.c unit 4)
+p4est_example(points2 points/points2.c unit 4)
+p4est_example(points3 points/points3.c unit 4)
 
-  add_executable(generate_points2 points/generate_points2.c)
-  target_link_libraries(generate_points2 PRIVATE P4EST::P4EST SC::SC)
+add_executable(generate_points2 points/generate_points2.c)
+target_link_libraries(generate_points2 PRIVATE P4EST::P4EST SC::SC)
 
-  add_executable(generate_points3 points/generate_points3.c)
-  target_link_libraries(generate_points3 PRIVATE P4EST::P4EST SC::SC)
-endif()
+add_executable(generate_points3 points/generate_points3.c)
+target_link_libraries(generate_points3 PRIVATE P4EST::P4EST SC::SC)
 
 p4est_example(simple2 simple/simple2.c unit 4)
 if(P4EST_ENABLE_P8EST)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -51,29 +51,14 @@ endfunction()
 
 # --- setup examples
 
-p4est_example(mesh2 mesh/mesh2.c unit 4)
-if(P4EST_ENABLE_P8EST)
-  p4est_example(mesh3 mesh/mesh3.c unit 4)
-  p4est_example(periodicity3 mesh/periodicity3.c unit 4)
-  configure_file(
-    ${CMAKE_SOURCE_DIR}/mesh/conndebug.p8c
-    ${CMAKE_BINARY_DIR}/conndebug.p8c
-    COPYONLY)
+p4est_example(points2 points/points2.c "point")
+if(enable_p8est)
+  p8est_example(points3 points/points3.c "point")
 endif()
 
-
-p4est_example(points2 points/points2.c unit 4)
-p4est_example(points3 points/points3.c unit 4)
-
-add_executable(generate_points2 points/generate_points2.c)
-target_link_libraries(generate_points2 PRIVATE P4EST::P4EST SC::SC)
-
-add_executable(generate_points3 points/generate_points3.c)
-target_link_libraries(generate_points3 PRIVATE P4EST::P4EST SC::SC)
-
-p4est_example(simple2 simple/simple2.c unit 4)
-if(P4EST_ENABLE_P8EST)
-  p8est_example(simple3 simple/simple3.c unit 4)
+p4est_example(generate_points2 points/generate_points2.c "point")
+if(enable_p8est)
+  p8est_example(generate_points3 points/generate_points3.c "point")
 endif()
 
 
@@ -85,13 +70,6 @@ if(enable_p8est)
   p8est_example(${n}3 ${n}/${n}3.c ${n})
 endif()
 p4est_copy_resource(${n} separt.pl)
-
-set(n p4est_step3)
-p4est_example(${n} steps/${n}.c "steps")
-if(enable_p8est)
-  set(n p8est_step3)
-  p8est_example(${n} steps/${n}.c "steps")
-endif()
 
 set(n spheres)
 p4est_example(${n}2 "${n}/${n}2.c;${n}/p4est_${n}.c" ${n})
@@ -122,7 +100,7 @@ if(enable_p8est)
   p8est_example(${n}3 balance/${n}3.c "balance")
 endif()
 
-foreach(n mesh points simple)
+foreach(n mesh simple)
   p4est_example(${n}2 ${n}/${n}2.c ${n})
   if(enable_p8est)
     p8est_example(${n}3 ${n}/${n}3.c ${n})

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -62,9 +62,7 @@ if(P4EST_ENABLE_P8EST)
 endif()
 
 
-# here we should be checking for SC_ENABLE_MPIIO
-# TODO : update libsc cmake build to expose SC_ENABLE_MPIIO
-if(SC_ENABLE_MPI)
+if(SC_ENABLE_MPIIO)
   p4est_example(points2 points/points2.c unit 4)
   p4est_example(points3 points/points3.c unit 4)
 

--- a/example/points/Makefile.am
+++ b/example/points/Makefile.am
@@ -3,8 +3,6 @@
 # Makefile.am in example/points
 # included non-recursively from toplevel directory
 
-#if P4EST_ENABLE_MPIIO
-
 if P4EST_ENABLE_BUILD_2D
 bin_PROGRAMS += example/points/p4est_points
 example_points_p4est_points_SOURCES = example/points/points2.c
@@ -24,5 +22,3 @@ example_points_p8est_points_generate_SOURCES = example/points/generate_points3.c
 
 LINT_CSOURCES += $(example_points_p8est_points_SOURCES)
 endif
-
-#endif

--- a/example/points/Makefile.am
+++ b/example/points/Makefile.am
@@ -3,12 +3,14 @@
 # Makefile.am in example/points
 # included non-recursively from toplevel directory
 
+if P4EST_ENABLE_MPIIO
+
 if P4EST_ENABLE_BUILD_2D
 bin_PROGRAMS += example/points/p4est_points
 example_points_p4est_points_SOURCES = example/points/points2.c
 
-bin_PROGRAMS += example/points/p4est_generate_points
-example_points_p4est_generate_points_SOURCES = example/points/generate_points.c
+bin_PROGRAMS += example/points/p4est_points_generate
+example_points_p4est_points_generate_SOURCES = example/points/generate_points2.c
 
 LINT_CSOURCES += $(example_points_p4est_points_SOURCES)
 endif
@@ -17,9 +19,10 @@ if P4EST_ENABLE_BUILD_3D
 bin_PROGRAMS += example/points/p8est_points
 example_points_p8est_points_SOURCES = example/points/points3.c
 
-bin_PROGRAMS += example/points/p8est_generate_points
-example_points_p8est_generate_points_SOURCES = example/points/generate_points.c
-example_points_p8est_generate_points_CPPFLAGS = -DTHREED $(AM_CPPFLAGS)
+bin_PROGRAMS += example/points/p8est_points_generate
+example_points_p8est_points_generate_SOURCES = example/points/generate_points3.c
 
 LINT_CSOURCES += $(example_points_p8est_points_SOURCES)
+endif
+
 endif

--- a/example/points/Makefile.am
+++ b/example/points/Makefile.am
@@ -3,7 +3,7 @@
 # Makefile.am in example/points
 # included non-recursively from toplevel directory
 
-if P4EST_ENABLE_MPIIO
+#if P4EST_ENABLE_MPIIO
 
 if P4EST_ENABLE_BUILD_2D
 bin_PROGRAMS += example/points/p4est_points
@@ -25,4 +25,4 @@ example_points_p8est_points_generate_SOURCES = example/points/generate_points3.c
 LINT_CSOURCES += $(example_points_p8est_points_SOURCES)
 endif
 
-endif
+#endif

--- a/example/points/Makefile.am
+++ b/example/points/Makefile.am
@@ -7,12 +7,19 @@ if P4EST_ENABLE_BUILD_2D
 bin_PROGRAMS += example/points/p4est_points
 example_points_p4est_points_SOURCES = example/points/points2.c
 
+bin_PROGRAMS += example/points/p4est_generate_points
+example_points_p4est_generate_points_SOURCES = example/points/generate_points.c
+
 LINT_CSOURCES += $(example_points_p4est_points_SOURCES)
 endif
 
 if P4EST_ENABLE_BUILD_3D
 bin_PROGRAMS += example/points/p8est_points
 example_points_p8est_points_SOURCES = example/points/points3.c
+
+bin_PROGRAMS += example/points/p8est_generate_points
+example_points_p8est_generate_points_SOURCES = example/points/generate_points.c
+example_points_p8est_generate_points_CPPFLAGS = -DTHREED $(AM_CPPFLAGS)
 
 LINT_CSOURCES += $(example_points_p8est_points_SOURCES)
 endif

--- a/example/points/generate_points2.c
+++ b/example/points/generate_points2.c
@@ -22,10 +22,6 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-#ifdef THREED
-#include <p4est_to_p8est.h>
-#endif
-
 #ifdef P4_TO_P8
 #include <p8est_bits.h>
 #include <p8est_points.h>

--- a/example/points/generate_points2.c
+++ b/example/points/generate_points2.c
@@ -41,22 +41,20 @@ generate_points (const char *filename,
                  sc_MPI_Comm mpicomm)
 {
   int                 mpiret;
-  int                 retval;
-  int                 qshift;
   int                 num_procs, rank;
-  int                 create_mode;
   int                 count;
   p4est_locidx_t      local_num_points;
   p4est_gloidx_t      offset;
-  unsigned            ucount, u, ignored;
-  double              x, y, z;
-  double              qlen;
+  unsigned            u;
   double             *point_buffer;
-  double              theta, dtheta, phi;
-  p4est_quadrant_t   *points, *q;
+  double              theta;
+#ifdef P4_TO_P8
+  double              phi;
+#else
+  double              dtheta;
+#endif
   sc_MPI_File         file_handle;
   sc_MPI_Offset       mpi_offset;
-  sc_MPI_Status       status;
 
   mpiret = sc_MPI_Comm_size (mpicomm, &num_procs);
   SC_CHECK_MPI (mpiret);
@@ -144,13 +142,10 @@ main (int argc, char **argv)
 {
   int                 mpiret;
   int                 num_procs, rank;
-  int                 maxlevel;
   int                 wrongusage;
   char                buffer[BUFSIZ];
   p4est_locidx_t      global_num_points;
   p4est_connectivity_t *conn;
-  p4est_quadrant_t   *points;
-  p4est_t            *p4est;
   sc_MPI_Comm         mpicomm;
   const char         *usage;
 

--- a/example/points/generate_points2.c
+++ b/example/points/generate_points2.c
@@ -33,6 +33,8 @@
 #endif /* !P4_TO_P8 */
 #include <sc_io.h>
 
+/* Please see doc/example_points.dox for a documentation of this program. */
+
 static void
 generate_points (const char *filename,
                  p4est_connectivity_t * conn,
@@ -239,6 +241,7 @@ main (int argc, char **argv)
   snprintf (buffer, BUFSIZ, "%s.pts", argv[3]);
   generate_points (buffer, conn, global_num_points, mpicomm);
 
+  /* in the present version of this program the connectivity is not used */
   p4est_connectivity_destroy (conn);
 
   /* clean up and exit */

--- a/example/points/generate_points2.c
+++ b/example/points/generate_points2.c
@@ -115,7 +115,7 @@ generate_points (const char *filename,
     mpiret = sc_io_write_at (file_handle, 0, &global_num_points,
                             sizeof (p4est_gloidx_t), sc_MPI_BYTE, &count);
     SC_CHECK_MPI (mpiret);
-    SC_CHECK_ABORT (count == sizeof (p4est_gloidx_t), "Write number of global"
+    SC_CHECK_ABORT (count == (int) sizeof (p4est_gloidx_t), "Write number of global"
                     "points: count mismatch");
   }
 
@@ -125,7 +125,7 @@ generate_points (const char *filename,
                                3 * local_num_points * sizeof (double),
                                sc_MPI_BYTE, &count);
   SC_CHECK_MPI (mpiret);
-  SC_CHECK_ABORT (count == 3 * local_num_points * sizeof (double),
+  SC_CHECK_ABORT (count == (int) 3 * local_num_points * sizeof (double),
                   "Write points: count mismatch");
 
 

--- a/example/points/generate_points2.c
+++ b/example/points/generate_points2.c
@@ -125,7 +125,7 @@ generate_points (const char *filename,
                                3 * local_num_points * sizeof (double),
                                sc_MPI_BYTE, &count);
   SC_CHECK_MPI (mpiret);
-  SC_CHECK_ABORT (count == (int) 3 * local_num_points * sizeof (double),
+  SC_CHECK_ABORT (count == (int) (3 * local_num_points * sizeof (double)),
                   "Write points: count mismatch");
 
 

--- a/example/points/generate_points2.c
+++ b/example/points/generate_points2.c
@@ -45,7 +45,7 @@ generate_points (const char *filename,
   int                 count;
   p4est_locidx_t      local_num_points;
   p4est_gloidx_t      offset;
-  unsigned            u;
+  p4est_locidx_t      u;
   double             *point_buffer;
   double              theta;
 #ifdef P4_TO_P8

--- a/example/points/generate_points3.c
+++ b/example/points/generate_points3.c
@@ -1,0 +1,38 @@
+/*
+  This file is part of p4est.
+  p4est is a C library to manage a collection (a forest) of multiple
+  connected adaptive quadtrees or octrees in parallel.
+
+  Copyright (C) 2010 The University of Texas System
+  Additional copyright (C) 2011 individual authors
+  Written by Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac
+
+  p4est is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  p4est is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with p4est; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/*
+ * Usage: p8est_points_generate <configuration> <globalnumpoints> <prefix>
+ *        possible configurations:
+ *        o unit      The unit cube.
+ *        o brick     An example brick connectivity using configuration (2,3,4) as
+ *                    the number of trees per direction.
+ *        o periodic  The unit cube with all-periodic boundary conditions.
+ *        o rotwrap   The unit cube with various self-periodic b.c.
+ *        o twocubes  Two connected cubes.
+ *        o rotcubes  A collection of four connected rotated cubes.
+ */
+
+#include <p4est_to_p8est.h>
+#include "generate_points2.c"

--- a/example/points/generate_points3.c
+++ b/example/points/generate_points3.c
@@ -22,17 +22,7 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-/*
- * Usage: p8est_points_generate <configuration> <globalnumpoints> <prefix>
- *        possible configurations:
- *        o unit      The unit cube.
- *        o brick     An example brick connectivity using configuration (2,3,4) as
- *                    the number of trees per direction.
- *        o periodic  The unit cube with all-periodic boundary conditions.
- *        o rotwrap   The unit cube with various self-periodic b.c.
- *        o twocubes  Two connected cubes.
- *        o rotcubes  A collection of four connected rotated cubes.
- */
+/* Please see doc/example_points.dox for a documentation of this program. */
 
 #include <p4est_to_p8est.h>
 #include "generate_points2.c"

--- a/example/points/points2.c
+++ b/example/points/points2.c
@@ -52,7 +52,6 @@ read_points (const char *filename,
              sc_MPI_Comm mpicomm)
 {
   int                 mpiret;
-  int                 retval;
   int                 qshift;
   int                 num_procs, rank;
   int                 create_mode;
@@ -66,8 +65,7 @@ read_points (const char *filename,
   double             *point_buffer;
   p4est_quadrant_t   *points, *q;
   sc_MPI_File         file_handle;
-  sc_MPI_Offset       mpi_offset, file_size;
-  sc_MPI_Status       status;
+  sc_MPI_Offset       mpi_offset;
 
   /* special treament for brick connectivity */
   if(!strcmp (conn_name, "brick"))

--- a/example/points/points2.c
+++ b/example/points/points2.c
@@ -93,6 +93,10 @@ read_points (const char *filename,
     SC_CHECK_ABORT (count == sizeof (p4est_gloidx_t),
                     "Read number of global points: count mismatch");
   }
+  /* broadcast the global number of points */
+  mpiret = sc_MPI_Bcast (&global_num_points, sizeof (p4est_gloidx_t),
+                          sc_MPI_BYTE, 0, mpicomm);
+  SC_CHECK_MPI (mpiret);
 
   /* local (MPI) number of points */
   *local_num_points = global_num_points / num_procs;

--- a/example/points/points2.c
+++ b/example/points/points2.c
@@ -87,7 +87,7 @@ read_points (const char *filename,
     mpiret = sc_io_read_at (file_handle, 0, &global_num_points,
                             sizeof (p4est_gloidx_t), sc_MPI_BYTE, &count);
     SC_CHECK_MPI (mpiret);
-    SC_CHECK_ABORT (count == sizeof (p4est_gloidx_t),
+    SC_CHECK_ABORT (count == (int) sizeof (p4est_gloidx_t),
                     "Read number of global points: count mismatch");
   }
   /* broadcast the global number of points */
@@ -116,7 +116,7 @@ read_points (const char *filename,
                               &point_buffer[0], 3 * *local_num_points * sizeof (double),
                               sc_MPI_BYTE, &count);
   SC_CHECK_MPI (mpiret);
-  SC_CHECK_ABORT (count == 3 * *local_num_points * sizeof (double),
+  SC_CHECK_ABORT (count == (int) (3 * *local_num_points * sizeof (double)),
                   "Read points: count mismatch");
 
   /* close the file collectively */

--- a/example/points/points2.c
+++ b/example/points/points2.c
@@ -54,7 +54,6 @@ read_points (const char *filename,
   int                 mpiret;
   int                 qshift;
   int                 num_procs, rank;
-  int                 create_mode;
   int                 is_brick_connectivity;
   int                 count;
   unsigned            ucount, u, ignored;

--- a/example/points/points2.c
+++ b/example/points/points2.c
@@ -205,7 +205,14 @@ main (int argc, char **argv)
     "      A value of 0 refines recursively to maxlevel\n"
     "      A value of -1 does no refinement at all\n"
     "   Prefix is for loading a point data file (prefix.pts)\n"
-    "     generate_points2 or generate_points3 are helper to create points files.\n";
+    "     generate_points2 or generate_points3 are helper to create points files.\n"
+    "\n"
+    "Example:\n"
+    " - generate 10000 test points:\n"
+    "   ./generate_points2 unit 10000 test\n"
+    " - run example up to level=10 :\n"
+    "   mpirun -np 4 ./points2 unit 10 100 ./test\n";
+
   wrongusage = 0;
   if (!wrongusage && argc != 5) {
     wrongusage = 1;
@@ -281,11 +288,11 @@ main (int argc, char **argv)
   P4EST_FREE (points);
   p4est_vtk_write_file (p4est, NULL, P4EST_STRING "_points_created");
 
-  p4est_partition (p4est, 0, NULL);
-  p4est_vtk_write_file (p4est, NULL, P4EST_STRING "_points_partition");
-
   p4est_balance (p4est, P4EST_CONNECT_FULL, NULL);
   p4est_vtk_write_file (p4est, NULL, P4EST_STRING "_points_balance");
+
+  p4est_partition (p4est, 0, NULL);
+  p4est_vtk_write_file (p4est, NULL, P4EST_STRING "_points_partition");
 
   p4est_destroy (p4est);
   p4est_connectivity_destroy (conn);

--- a/src/p4est_points.h
+++ b/src/p4est_points.h
@@ -22,14 +22,6 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-/********************************************************************
- *                          IMPORTANT NOTE                          *
- *                                                                  *
- * The p4est_points functionality depends on sc/src/sc_sort.        *
- * That parallel bitonic sort is still buggy (see sc/bugs).         *
- * If you want to use this code you have to fix the sort first.     *
- ********************************************************************/
-
 #ifndef P4EST_POINTS_H
 #define P4EST_POINTS_H
 

--- a/src/p8est_points.h
+++ b/src/p8est_points.h
@@ -22,14 +22,6 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-/********************************************************************
- *                          IMPORTANT NOTE                          *
- *                                                                  *
- * The p4est_points functionality depends on sc/src/sc_sort.        *
- * That parallel bitonic sort is still buggy (see sc/bugs).         *
- * If you want to use this code you have to fix the sort first.     *
- ********************************************************************/
-
 #ifndef P8EST_POINTS_H
 #define P8EST_POINTS_H
 


### PR DESCRIPTION
# Update points example

Following up on issue #211

Proposed changes:
- provide a helper executable to generate example point data
- alos add the brick connectivity (with a slightly different treatment, just for illustrative purpose)
- use MPI-IO to create the point data file (a single file for all MPI processes).

Currently this can only be merged when companion MR https://github.com/cburstedde/libsc/pull/128 which update MPI-IO routines in libsc is merge to. 
The executable that generate point data file need these mpi-io routines in libsc.


