### PR TITLE
Fix build archive when git executable is not available

### DIFF
--- a/cmake/sc.cmake
+++ b/cmake/sc.cmake
@@ -1,8 +1,20 @@
 # provides imported target SC::SC
 include(ExternalProject)
-include(${CMAKE_CURRENT_LIST_DIR}/GitSubmodule.cmake)
 
-git_submodule("${PROJECT_SOURCE_DIR}/sc")
+# checking if we are building from a git repository or using an archive file
+# if using an archive, we should be able to build p4est without git installed.
+if(EXISTS "${PROJECT_SOURCE_DIR}/.git")
+
+  # make sure libsc git submodule is up to date
+  include(${CMAKE_CURRENT_LIST_DIR}/GitSubmodule.cmake)
+  git_submodule("${PROJECT_SOURCE_DIR}/sc")
+
+endif()
+
+# check that libsc source directory is populated
+if(NOT EXISTS "${PROJECT_SOURCE_DIR}/sc/CMakeLists.txt")
+  message(FATAL_ERROR "Something is wrong, libsc sources directory is not valid. Please check your archive file.")
+endif()
 
 # --- libsc externalProject
 


### PR DESCRIPTION
# Fix building p4est from an archive file

We should not require that git is installed on the build platform; the archive file contains a copy of libsc sources.
One way to test this PR would be to re-create an archive file.

Following up on issue #217 .

