### PR TITLE
Add package id getter function

### DIFF
--- a/doc/author_markert.txt
+++ b/doc/author_markert.txt
@@ -1,0 +1,1 @@
+I place my contributions to p4est under the FreeBSD license. Johannes Markert (johannes.markert@dlr.de)

--- a/src/p4est_base.c
+++ b/src/p4est_base.c
@@ -56,6 +56,12 @@ p4est_is_initialized (void)
   return p4est_initialized;
 }
 
+int
+p4est_get_package_id (void)
+{
+  return p4est_package_id;
+}
+
 #ifndef __cplusplus
 #undef P4EST_GLOBAL_LOGF
 #undef P4EST_LOGF

--- a/src/p4est_base.h
+++ b/src/p4est_base.h
@@ -358,6 +358,12 @@ void                p4est_init (sc_log_handler_t log_handler,
  */
 int                 p4est_is_initialized (void);
 
+/** Query the package identity as registered in libsc.
+ * \return          This is -1 before \ref p4est_init has been called
+ *                  and a proper package identifier (>= 0) afterwards.
+ */
+int                 p4est_get_package_id (void);
+
 /** Compute hash value for two p4est_topidx_t integers.
  * \param [in] tt     Array of (at least) two values.
  * \return            An unsigned hash value.


### PR DESCRIPTION
In some scenarios it is useful to have a dedicated query function for the package id registered by libsc. For example, not all wrapper
generators or FFIs (foreign function interfaces) support to read global external variables.
