### PR TITLE
fix balance seed example (3d).

### DIFF
--- a/example/balance_seeds/balance_seeds2.c
+++ b/example/balance_seeds/balance_seeds2.c
@@ -46,7 +46,7 @@ static p4est_quadrant_t center = { 0x10000000, 0x10000000, 2, 0, 0, {NULL} };
 #else
 static const int    refine_level = 8;
 static p4est_quadrant_t center =
-  { 0x20000, 0x20000, 0x20000, 2, 0, 0, {NULL} };
+  { 0x10000000, 0x10000000, 0x10000000, 2, 0, 0, {NULL} };
 #endif
 
 static void


### PR DESCRIPTION
# Fix example balance seeds

Following up on issue #186  .

Proposed changes:
adapt the coordinates of center quadrant because P8EST_MAXLEVEL is now 30 (not 19 anymore).