### PR TITLE
Symbol P4EST_ENABLE_DEBUG should only be defined in DEBUG mode.

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -114,7 +114,7 @@ if(ZLIB_FOUND)
   endif()
 endif()
 
-if(CMAKE_BUILD_TYPE MATCHES "(Debug|RelWithDebInfo)")
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
   set(P4EST_ENABLE_DEBUG 1)
 endif()
 


### PR DESCRIPTION
# Fix cmake debug mode

Following up on issue #218  .

P4EST_ENABLE_DEBUG shouldn't be defined in RelWithDebInfo cmake build mode. See #218

Proposed changes:
cmake variable P4EST_ENABLE_DEBUG is now only defined in Debug cmake build mode.