### PR TITLE
Doxygen: Fix warnings in p4est_connectivity

### DIFF
--- a/example/simple/simple2.c
+++ b/example/simple/simple2.c
@@ -67,6 +67,8 @@ typedef enum
   P4EST_CONFIG_PDISK,
   P4EST_CONFIG_PERIODIC,
   P4EST_CONFIG_ROTWRAP,
+  P4EST_CONFIG_CIRCLE,
+  P4EST_CONFIG_DROP,
   P4EST_CONFIG_ICOSAHEDRON,
   P4EST_CONFIG_SHELL2D,
   P4EST_CONFIG_DISK2D,
@@ -121,6 +123,8 @@ static const simple_regression_t regression[] =
  { P4EST_CONFIG_PDISK, 5, 5, 0x507fd0c9 },
  { P4EST_CONFIG_ROTWRAP, 1, 6, 0x9dd600c5U },
  { P4EST_CONFIG_ROTWRAP, 3, 6, 0x9dd600c5U },
+ { P4EST_CONFIG_CIRCLE, 3, 6, 0x98ab6cb2U },
+ { P4EST_CONFIG_DROP, 3, 6, 0x98ab6cb2U},
  { P4EST_CONFIG_NULL, 0, 0, 0 }};
 /* *INDENT-ON* */
 
@@ -284,7 +288,7 @@ main (int argc, char **argv)
     "   Configuration can be any of\n"
     "      unit|brick|three|evil|evil3|pillow|moebius|\n"
     "         star|cubed|disk|xdisk|ydisk|pdisk|periodic|\n"
-    "         rotwrap|icosahedron|shell2d|disk2d\n"
+    "         rotwrap|circle|drop|icosahedron|shell2d|disk2d\n"
     "   Level controls the maximum depth of refinement\n";
   wrongusage = 0;
   config = P4EST_CONFIG_NULL;
@@ -336,6 +340,12 @@ main (int argc, char **argv)
     }
     else if (!strcmp (argv[1], "rotwrap")) {
       config = P4EST_CONFIG_ROTWRAP;
+    }
+    else if (!strcmp (argv[1], "circle")) {
+      config = P4EST_CONFIG_CIRCLE;
+    }
+    else if (!strcmp (argv[1], "drop")) {
+      config = P4EST_CONFIG_DROP;
     }
     else if (!strcmp (argv[1], "icosahedron")) {
       config = P4EST_CONFIG_ICOSAHEDRON;
@@ -413,6 +423,12 @@ main (int argc, char **argv)
   }
   else if (config == P4EST_CONFIG_ROTWRAP) {
     connectivity = p4est_connectivity_new_rotwrap ();
+  }
+  else if (config == P4EST_CONFIG_CIRCLE) {
+    connectivity = p4est_connectivity_new_circle ();
+  }
+  else if (config == P4EST_CONFIG_DROP) {
+    connectivity = p4est_connectivity_new_drop ();
   }
   else if (config == P4EST_CONFIG_ICOSAHEDRON) {
     double              R = 1.0;        /* sphere radius default value */

--- a/example/simple/simple2.c
+++ b/example/simple/simple2.c
@@ -123,8 +123,8 @@ static const simple_regression_t regression[] =
  { P4EST_CONFIG_PDISK, 5, 5, 0x507fd0c9 },
  { P4EST_CONFIG_ROTWRAP, 1, 6, 0x9dd600c5U },
  { P4EST_CONFIG_ROTWRAP, 3, 6, 0x9dd600c5U },
- { P4EST_CONFIG_CIRCLE, 3, 6, 0x98ab6cb2U },
- { P4EST_CONFIG_DROP, 3, 6, 0x98ab6cb2U},
+ { P4EST_CONFIG_CIRCLE, 3, 6, 0xd6e4931b },
+ { P4EST_CONFIG_DROP, 3, 6, 0xea6a6726 },
  { P4EST_CONFIG_NULL, 0, 0, 0 }};
 /* *INDENT-ON* */
 
@@ -475,7 +475,7 @@ main (int argc, char **argv)
   p4est_balance (p4est, P4EST_CONNECT_FULL, init_fn);
   P4EST_ASSERT (p4est_checksum (p4est) == crc);
 #endif
-
+  
   /* print and verify forest checksum */
   P4EST_GLOBAL_STATISTICSF ("Tree checksum 0x%08x\n", crc);
   if (mpi->mpirank == 0) {

--- a/src/p4est_connectivity.c
+++ b/src/p4est_connectivity.c
@@ -1411,6 +1411,123 @@ p4est_connectivity_new_rotwrap (void)
 }
 
 p4est_connectivity_t *
+p4est_connectivity_new_circle (void)
+{
+  const p4est_topidx_t num_vertices = 12;
+  const p4est_topidx_t num_trees = 6;
+  const p4est_topidx_t num_ctt = 0;
+  const double        vertices[12 * 3] = {
+    /* inner hexagon */
+    0.0, 1.0, 0.0,
+    0.866025404, 0.5, 0.0,
+    0.866025404, -0.5, 0.0,
+    0, -1.0, 0.0,
+    -0.866025404, -0.5, 0.0,
+    -0.866025404, 0.5, 0.0,
+    /* outer hexagon */
+    0.0, 2.0, 0.0,
+    1.73205081, 1.0, 0.0,
+    1.73205081, -1.0, 0.0,
+    0, -2.0, 0.0,
+    -1.73205081, -1.0, 0.0,
+    -1.73205081, 1.0, 0.0,
+  };
+  const p4est_topidx_t tree_to_vertex[6 * 4] = {
+    7, 6, 1, 0,
+    11, 5, 6, 0,
+    5, 11, 4, 10,
+    9, 3, 10, 4,
+    2, 3, 8, 9,
+    8, 7, 2, 1,
+  };
+  const p4est_topidx_t tree_to_tree[6 * 4] = {
+    5, 1, 0, 0,
+    1, 1, 2, 0,
+    2, 2, 1, 3,
+    3, 3, 4, 2,
+    5, 3, 4, 4,
+    4, 0, 5, 5,
+  };
+  const int8_t        tree_to_face[6 * 4] = {
+    1, 3, 2, 3,
+    0, 1, 6, 1,
+    0, 1, 6, 7,
+    0, 1, 5, 7,
+    4, 6, 2, 3,
+    4, 0, 2, 3,
+  };
+
+  return p4est_connectivity_new_copy (num_vertices, num_trees, 0,
+                                      vertices, tree_to_vertex,
+                                      tree_to_tree, tree_to_face,
+                                      NULL, &num_ctt, NULL, NULL);
+}
+
+
+p4est_connectivity_t *
+p4est_connectivity_new_drop (void)
+{
+  const p4est_topidx_t num_vertices = 10;
+  const p4est_topidx_t num_trees = 5;
+  const p4est_topidx_t num_ctt = 1;
+  const double        vertices[10 * 3] = {
+    0, 0, 0,
+    1, 0, 0,
+    3, 0, 0,
+    0, 1, 0,
+    1, 1, 0,
+    2, 1, 0,
+    1, 2, 0,
+    2, 2, 0,
+    0, 3, 0,
+    3, 3, 0,
+  };
+  const p4est_topidx_t tree_to_vertex[5 * 4] = {
+    0,1,3,4,
+    1,2,4,5,
+    5,2,7,9,
+    6,7,8,9,
+    3,4,8,6,
+  };
+  const p4est_topidx_t tree_to_tree[5 * 4] = {
+    0,1,0,4,
+    0,2,1,1,
+    2,2,1,3,
+    4,2,3,3,
+    4,4,0,3,
+  };
+  const int8_t        tree_to_face[5 * 4] = {
+    0,0,2,2,
+    1,2,2,3,
+    0,1,1,1,
+    3,3,2,3,
+    0,1,3,0,
+  };
+
+  const p4est_topidx_t tree_to_corner[5 * 4] = {
+    -1, -1, -1,  0,
+    -1, -1,  0, -1,
+    -1, -1, -1, -1,
+    -1, -1, -1, -1,
+    -1,  0, -1, -1,
+  };
+  const p4est_topidx_t ctt_offset[1 + 1] = {
+    0, 3
+  };
+  const p4est_topidx_t corner_to_tree[3] = {
+    0, 1, 4,
+  };
+  const int8_t corner_to_corner[3] = {
+    3, 2, 1,
+  };
+  return p4est_connectivity_new_copy (num_vertices, num_trees, num_ctt,
+                                      vertices, tree_to_vertex,
+                                      tree_to_tree, tree_to_face,
+                                      tree_to_corner, ctt_offset,
+                                      corner_to_tree, corner_to_corner);
+}
+
+p4est_connectivity_t *
 p4est_connectivity_new_corner (void)
 {
   const p4est_topidx_t num_vertices = 7;

--- a/src/p4est_connectivity.h
+++ b/src/p4est_connectivity.h
@@ -45,9 +45,7 @@ SC_EXTERN_C_BEGIN;
 #define P4EST_DIM 2
 /** The number of faces of a quadrant */
 #define P4EST_FACES (2 * P4EST_DIM)
-/** The number of children of a quadrant
- *
- * also the number of corners */
+/** The number of children of a quadrant, also the number of corners */
 #define P4EST_CHILDREN 4
 /** The number of children/corners touching one face */
 #define P4EST_HALF (P4EST_CHILDREN / 2)
@@ -63,13 +61,14 @@ SC_EXTERN_C_BEGIN;
 /** Exponentiate with dimension */
 #define P4EST_DIM_POW(a) ((a) * (a))
 
-/** size of face transformation encoding */
+/** Data size of face transformation encoding */
 #define P4EST_FTRANSFORM 9
 
 /** p4est identification string */
 #define P4EST_STRING "p4est"
 
-/** Increase this number whenever the on-disk format for
+/** The revision number of the p4est ondisk file format.
+ * Increase this number whenever the on-disk format for
  * p4est_connectivity, p4est, or any other 2D data structure changes.
  * The format for reading and writing must be the same.
  */
@@ -199,9 +198,9 @@ p4est_corner_transform_t;
 /** Information about the neighbors of a corner*/
 typedef struct
 {
-  p4est_topidx_t      icorner; /**< The number of the originating corner*/
+  p4est_topidx_t      icorner; /**< The number of the originating corner */
   sc_array_t          corner_transforms; /**< The array of neighbors of the originating
-                                         corner*/
+                                         corner */
 }
 p4est_corner_info_t;
 
@@ -253,7 +252,7 @@ void                p4est_neighbor_transform_coordinates_reverse
 
 /**  Fill an array with the neighbor transforms based on a specific boundary type.
  *   This function generalizes all other inter-tree transformation objects
- * 
+ *
  * \param [in]  conn   Connectivity structure.
  * \param [in]  tree_id The number of the tree.
  * \param [in]  boundary_type  The type of the boundary connection (self, face, corner, edge).
@@ -455,11 +454,14 @@ p4est_connectivity_t *p4est_connectivity_new_rotwrap (void);
 
 /** Create a connectivity structure for an donut-like circle.
  * The circle consists of 6 trees connecting each other by their faces.
+ * The trees are laid out as a hexagon between [-2, 2] in the y direction
+ * and [-sqrt(3), sqrt(3)] in the x direction.  The hexagon has flat
+ * sides along the y direction and pointy ends in x.
  */
 p4est_connectivity_t *p4est_connectivity_new_circle (void);
 
-/** Create a connectivity structure for an five-trees geometry with an 
- * empty hole as in the circle example.
+/** Create a connectivity structure for a five-trees geometry with a hole.
+ * The geometry covers the square [0, 3]**2, where the hole is [1, 2]**2.
  */
 p4est_connectivity_t *p4est_connectivity_new_drop (void);
 

--- a/src/p4est_connectivity.h
+++ b/src/p4est_connectivity.h
@@ -453,6 +453,16 @@ p4est_connectivity_t *p4est_connectivity_new_periodic (void);
  */
 p4est_connectivity_t *p4est_connectivity_new_rotwrap (void);
 
+/** Create a connectivity structure for an donut-like circle.
+ * The circle consists of 6 trees connecting each other by their faces.
+ */
+p4est_connectivity_t *p4est_connectivity_new_circle (void);
+
+/** Create a connectivity structure for an five-trees geometry with an 
+ * empty hole as in the circle example.
+ */
+p4est_connectivity_t *p4est_connectivity_new_drop (void);
+
 /** Create a connectivity structure for two trees being rotated
  * w.r.t. each other in a user-defined way
  * \param[in] l_face      index of left face


### PR DESCRIPTION
Doxygen: deal with warnings in p4est_connectivity.h during document generation.

# Warnings in p4est_connectivity.h during document generation