### PR TITLE
p4est_file: Accept new MPI error codes

### DIFF
--- a/src/p4est_io.c
+++ b/src/p4est_io.c
@@ -1816,8 +1816,8 @@ p4est_file_error_code (int errcode, int *p4est_errcode)
 
   default:
     /* errcode may be MPI version 1.1 error code */
-     return sc_MPI_Error_class (errcode, p4est_errcode);
-    break;
+    *p4est_errcode = P4EST_FILE_ERR_UNKNOWN;
+     return P4EST_FILE_ERR_SUCCESS;
   }
 }
 
@@ -1828,9 +1828,8 @@ p4est_file_error_string (int errclass, char *string, int *resultlen)
   const char         *tstr = NULL;
 
   P4EST_ASSERT (resultlen != NULL);
-  P4EST_ASSERT ((sc_MPI_SUCCESS <= errclass && errclass < sc_MPI_ERR_LASTCODE)
-                || (P4EST_FILE_ERR_SUCCESS <= errclass
-                    && errclass < P4EST_FILE_ERR_LASTCODE));
+  P4EST_ASSERT (P4EST_FILE_ERR_SUCCESS <= errclass
+                && errclass < P4EST_FILE_ERR_LASTCODE);
 
   if (string == NULL || resultlen == NULL) {
     return sc_MPI_ERR_ARG;
@@ -1888,8 +1887,8 @@ p4est_file_error_string (int errclass, char *string, int *resultlen)
     return sc_MPI_Error_string (sc_MPI_ERR_UNKNOWN, string, resultlen);
 
   default:
-    /* errcode may be MPI version 1.1 error code */
-    return sc_MPI_Error_string (errclass, string, resultlen);
+    /* no valid p4est file error code */
+    SC_ABORT_NOT_REACHED ();
   }
   P4EST_ASSERT (tstr != NULL);
 

--- a/src/p4est_io.c
+++ b/src/p4est_io.c
@@ -1815,8 +1815,8 @@ p4est_file_error_code (int errcode, int *p4est_errcode)
     return P4EST_FILE_ERR_SUCCESS;
 
   default:
-    /* errcode is not a valid error code */
-    SC_ABORT_NOT_REACHED ();
+    /* errcode may be MPI version 1.1 error code */
+     return sc_MPI_Error_class (errcode, p4est_errcode);
     break;
   }
 }
@@ -1828,8 +1828,9 @@ p4est_file_error_string (int errclass, char *string, int *resultlen)
   const char         *tstr = NULL;
 
   P4EST_ASSERT (resultlen != NULL);
-  P4EST_ASSERT (P4EST_FILE_ERR_SUCCESS <= errclass
-                && errclass < P4EST_FILE_ERR_LASTCODE);
+  P4EST_ASSERT ((sc_MPI_SUCCESS <= errclass && errclass < sc_MPI_ERR_LASTCODE)
+                || (P4EST_FILE_ERR_SUCCESS <= errclass
+                    && errclass < P4EST_FILE_ERR_LASTCODE));
 
   if (string == NULL || resultlen == NULL) {
     return sc_MPI_ERR_ARG;
@@ -1887,8 +1888,8 @@ p4est_file_error_string (int errclass, char *string, int *resultlen)
     return sc_MPI_Error_string (sc_MPI_ERR_UNKNOWN, string, resultlen);
 
   default:
-    /* no valid p4est file error code */
-    SC_ABORT_NOT_REACHED ();
+    /* errcode may be MPI version 1.1 error code */
+    return sc_MPI_Error_string (errclass, string, resultlen);
   }
   P4EST_ASSERT (tstr != NULL);
 


### PR DESCRIPTION
# p4est_file: Accept new MPI error codes

Currently, the function `p4est_file_error_code` does not accept MPI error codes that we do not expect according to our wrapped MPI error codes. However, error codes depend on the concrete MPI implementation and in particular newer MPI implementation may cause returning error codes that can not be interpreted in the current way , which currently leads to an abort. 

Proposed changes: Instead of calling `SC_ABORT_NOT_REACHED ()` in the case of an unkown error code we always translate such error codes to `P{4,8}EST_FILE_ERR_UNKOWN`.
