### PR TITLE
sphere2d geometry

### DIFF
--- a/example/simple/simple2.c
+++ b/example/simple/simple2.c
@@ -42,7 +42,7 @@
  *        o rotwrap   Refinement on the unit square with weird periodic b.c.
  *        o circle    Refinement on a 6-tree donut-like circle.
  *        o drop      Refinement on a 5-trees geometry with an inner hole.
- *        o icosahedron   Refinement on the sphere
+ *        o icosahedron   Refinement on the icosahedron sphere with geometry.
  *        o shell2d       Refinement on a 2d shell with geometry.
  *        o disk2d        Refinement on a 2d disk with geometry.
  *        o bowtie    Refinement on a 2-tree bowtie domain.

--- a/example/simple/simple2.c
+++ b/example/simple/simple2.c
@@ -46,6 +46,7 @@
  *        o shell2d       Refinement on a 2d shell with geometry.
  *        o disk2d        Refinement on a 2d disk with geometry.
  *        o bowtie    Refinement on a 2-tree bowtie domain.
+ *        o sphere2d      Refinement on a 6-tree sphere surface with geometry.
  */
 
 #include <p4est_bits.h>
@@ -76,6 +77,7 @@ typedef enum
   P4EST_CONFIG_SHELL2D,
   P4EST_CONFIG_DISK2D,
   P4EST_CONFIG_BOWTIE,
+  P4EST_CONFIG_SPHERE2D,
   P4EST_CONFIG_LAST
 }
 simple_config_t;
@@ -293,7 +295,7 @@ main (int argc, char **argv)
     "   Configuration can be any of\n"
     "      unit|brick|three|evil|evil3|pillow|moebius|\n"
     "         star|cubed|disk|xdisk|ydisk|pdisk|periodic|\n"
-    "         rotwrap|circle|drop|icosahedron|shell2d|disk2d|bowtie\n"
+    "         rotwrap|circle|drop|icosahedron|shell2d|disk2d|bowtie|sphere2d\n"
     "   Level controls the maximum depth of refinement\n";
   wrongusage = 0;
   config = P4EST_CONFIG_NULL;
@@ -363,6 +365,9 @@ main (int argc, char **argv)
     }
     else if (!strcmp (argv[1], "bowtie")) {
       config = P4EST_CONFIG_BOWTIE;
+    }
+    else if (!strcmp (argv[1], "sphere2d")) {
+      config = P4EST_CONFIG_SPHERE2D;
     }
     else {
       wrongusage = 1;
@@ -457,6 +462,10 @@ main (int argc, char **argv)
   }
   else if (config == P4EST_CONFIG_BOWTIE) {
     connectivity = p4est_connectivity_new_bowtie ();
+  }
+  else if (config == P4EST_CONFIG_SPHERE2D) {
+    connectivity = p4est_connectivity_new_cubed ();
+    geom = p4est_geometry_new_sphere2d (connectivity, 1.0);
   }
   else {
     connectivity = p4est_connectivity_new_unitsquare ();

--- a/src/p4est_geometry.c
+++ b/src/p4est_geometry.c
@@ -109,7 +109,9 @@ p4est_geometry_destroy (p4est_geometry_t * geom)
 
 /**
  * Geometric coordinate transformation for default geometry created with
- * \ref p4est_geometry_new_connectivity.
+ * \ref p4est_geometry_new_connectivity. May also be used for user 
+ * convenience to build custom geometric coordinate transforms. See for
+ * example \ref p4est_geometry_sphere2d_X or \ref p4est_geometry_disk2d_X.
  *
  * Define the geometric transformation from logical space (where AMR
  * is performed) to the physical space.
@@ -119,6 +121,9 @@ p4est_geometry_destroy (p4est_geometry_t * geom)
  * \param[in]  abc        coordinates in AMR space : [0,1]^3
  * \param[out] xyz        cartesian coordinates in physical space after geometry
  *
+ * \warning The associated geometry is assumed to have a connectivity
+ * as its *user field, and this connectivity is assumed to have vertex
+ * information in its *tree_to_vertex field.
  */
 static void
 p4est_geometry_connectivity_X (p4est_geometry_t * geom,

--- a/src/p4est_geometry.c
+++ b/src/p4est_geometry.c
@@ -119,7 +119,7 @@ p4est_geometry_destroy (p4est_geometry_t * geom)
  * \param[in]  which_tree tree id inside forest
  * \param[in]  abc        tree-local reference coordinates : [0,1]^d. 
  *                        Note: abc[2] is only accessed by the P4_TO_P8 version
- * \param[out] xyz        cartesian coordinates in physical space after geometry
+ * \param[out] xyz        Cartesian coordinates in physical space after geometry
  *
  * \warning The associated geometry is assumed to have a connectivity
  * as its *user field, and this connectivity is assumed to have vertex
@@ -130,9 +130,9 @@ p4est_geometry_connectivity_X (p4est_geometry_t * geom,
                                p4est_topidx_t which_tree,
                                const double abc[3], double xyz[3])
 {
-  P4EST_ASSERT(geom->user != NULL);
+  P4EST_ASSERT (geom->user != NULL);
   p4est_connectivity_t *connectivity = (p4est_connectivity_t *) geom->user;
-  P4EST_ASSERT(connectivity->tree_to_vertex != NULL); 
+  P4EST_ASSERT (connectivity->tree_to_vertex != NULL);
   const p4est_topidx_t *tree_to_vertex = connectivity->tree_to_vertex;
   const double       *v = connectivity->vertices;
   double              eta_x, eta_y, eta_z = 0.;
@@ -198,7 +198,7 @@ p4est_geometry_new_connectivity (p4est_connectivity_t * conn)
  * \param[in]  which_tree tree id inside forest
  * \param[in]  rst        tree-local reference coordinates : [0,1]^2.
  *                        Note: rst[2] is never accessed
- * \param[out] xyz        cartesian coordinates in physical space after geometry
+ * \param[out] xyz        Cartesian coordinates in physical space after geometry
  *
  */
 static void
@@ -222,7 +222,7 @@ p4est_geometry_icosahedron_X (p4est_geometry_t * geom,
   eta_y = rst[1];
 
   /*
-   * icosahedron node cartesian coordinates
+   * icosahedron node Cartesian coordinates
    * used for mapping connectivity vertices to 3D nodes.
    */
   const double        N[12 * 3] = {
@@ -285,7 +285,7 @@ p4est_geometry_icosahedron_X (p4est_geometry_t * geom,
     const int           i2 = tree_to_nodes[which_tree * 4 + 2];
     const int           i3 = tree_to_nodes[which_tree * 4 + 3];
 
-    /* get 3D cartesian coordinates of our face */
+    /* get 3D Cartesian coordinates of our face */
     const double        n0[3] =
       { N[i0 * 3 + 0], N[i0 * 3 + 1], N[i0 * 3 + 2] };
     const double        n1[3] =
@@ -365,7 +365,7 @@ p4est_geometry_new_icosahedron (p4est_connectivity_t * conn, double R)
  * \param[in]  which_tree tree id inside forest
  * \param[in]  rst        tree-local reference coordinates : [0,1]^2.
  *                        Note: rst[2] is never accessed
- * \param[out] xyz        cartesian coordinates in physical space after geometry
+ * \param[out] xyz        Cartesian coordinates in physical space after geometry
  *
  */
 static void
@@ -455,9 +455,9 @@ p4est_geometry_new_shell2d (p4est_connectivity_t * conn, double R2, double R1)
  * \param[in]  which_tree tree id inside forest
  * \param[in]  rst        tree-local reference coordinates : [0,1]^2.
  *                        Note: rst[2] is never accessed.
- * \param[out] xyz        cartesian coordinates in physical space after geometry
+ * \param[out] xyz        Cartesian coordinates in physical space after geometry
  *
- * Note abc[3] contains cartesian coordinates in logical
+ * Note abc[3] contains Cartesian coordinates in logical
  * vertex space (before geometry).
  */
 static void
@@ -583,13 +583,13 @@ p4est_geometry_new_disk2d (p4est_connectivity_t * conn, double R0, double R1)
  * \param[in]  which_tree tree id inside forest
  * \param[in]  rst        tree-local reference coordinates : [0,1]^2.
  *                        Note: rst[2] is never accessed
- * \param[out] xyz        cartesian coordinates in physical space after geometry
+ * \param[out] xyz        Cartesian coordinates in physical space after geometry
  *
  */
 static void
 p4est_geometry_sphere2d_X (p4est_geometry_t * geom,
-                         p4est_topidx_t which_tree,
-                         const double rst[3], double xyz[3])
+                           p4est_topidx_t which_tree,
+                           const double rst[3], double xyz[3])
 {
   const struct p4est_geometry_builtin_sphere2d *sphere2d
     = &((p4est_geometry_builtin_t *) geom)->p.sphere2d;
@@ -607,7 +607,8 @@ p4est_geometry_sphere2d_X (p4est_geometry_t * geom,
 
   /* normalise to radius R sphere */
   R = sphere2d->R;
-  double R_on_norm = R/sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1] + xyz[2]*xyz[2]);
+  double              R_on_norm =
+    R / sqrt (xyz[0] * xyz[0] + xyz[1] * xyz[1] + xyz[2] * xyz[2]);
   xyz[0] *= R_on_norm;
   xyz[1] *= R_on_norm;
   xyz[2] *= R_on_norm;
@@ -630,6 +631,6 @@ p4est_geometry_new_sphere2d (p4est_connectivity_t * conn, double R)
   builtin->geom.X = p4est_geometry_sphere2d_X;
 
   return (p4est_geometry_t *) builtin;
-}                              /* p4est_geometry_new_sphere2d */
+}                               /* p4est_geometry_new_sphere2d */
 
 #endif /* !P4_TO_P8 */

--- a/src/p4est_geometry.c
+++ b/src/p4est_geometry.c
@@ -540,8 +540,6 @@ p4est_geometry_new_disk2d (p4est_connectivity_t * conn, double R0, double R1)
  * \param[in]  rst        coordinates in AMR space : [0,1]^3
  * \param[out] xyz        cartesian coordinates in physical space after geometry
  *
- * Note abc[3] contains cartesian coordinates in logical
- * vertex space (before geometry).
  */
 static void
 p4est_geometry_sphere2d_X (p4est_geometry_t * geom,
@@ -551,48 +549,10 @@ p4est_geometry_sphere2d_X (p4est_geometry_t * geom,
   const struct p4est_geometry_builtin_sphere2d *sphere2d
     = &((p4est_geometry_builtin_t *) geom)->p.sphere2d;
   double              R;
-  double              abc[3];
 
   /* transform from the AMR space into physical space using bi/trilinear
    transformation of connectivity*/
-  //p4est_geometry_connectivity_X (geom, which_tree, rst, abc);
-
-  /* convert to unit cube coordinates */
-  //TODO: it should be possible to do this from the connectivity (and reuse code)
-  switch (which_tree) {
-  case 0:
-    xyz[0] = rst[1];
-    xyz[1] = rst[0];
-    xyz[2] = 0.0;
-    break;
-  case 1:
-    xyz[0] = rst[1];
-    xyz[1] = 1.0;
-    xyz[2] = rst[0];
-    break;
-  case 2:
-    xyz[0] = 0.0;
-    xyz[1] = rst[1];
-    xyz[2] = rst[0];
-    break;
-  case 3:
-    xyz[0] = rst[0];
-    xyz[1] = rst[1];
-    xyz[2] = 1.0;
-    break;
-  case 4:
-    xyz[0] = rst[0];
-    xyz[1] = 0.0;
-    xyz[2] = rst[1];
-    break;
-  case 5:
-    xyz[0] = 1.0;
-    xyz[1] = rst[0];
-    xyz[2] = rst[1];
-    break;
-  default:
-    SC_ABORT_NOT_REACHED ();
-  }
+  p4est_geometry_connectivity_X (geom, which_tree, rst, xyz);
 
   /* align center with origin */
   xyz[0] -= 0.5;

--- a/src/p4est_geometry.c
+++ b/src/p4est_geometry.c
@@ -107,7 +107,19 @@ p4est_geometry_destroy (p4est_geometry_t * geom)
   }
 }
 
-//TODO comment this function
+/**
+ * Geometric coordinate transformation for default geometry created with
+ * \ref p4est_geometry_new_connectivity.
+ *
+ * Define the geometric transformation from logical space (where AMR
+ * is performed) to the physical space.
+ *
+ * \param[in]  geom       associated geometry
+ * \param[in]  which_tree tree id inside forest
+ * \param[in]  abc        coordinates in AMR space : [0,1]^3
+ * \param[out] xyz        cartesian coordinates in physical space after geometry
+ *
+ */
 static void
 p4est_geometry_connectivity_X (p4est_geometry_t * geom,
                                p4est_topidx_t which_tree,
@@ -169,7 +181,18 @@ p4est_geometry_new_connectivity (p4est_connectivity_t * conn)
 
 #ifndef P4_TO_P8
 
-/* geometric coordinate transformation */
+/**
+ * Geometric coordinate transformation for icosahedron geometry.
+ *
+ * Define the geometric transformation from logical space (where AMR
+ * is performed) to the physical space.
+ *
+ * \param[in]  geom       associated geometry
+ * \param[in]  which_tree tree id inside forest
+ * \param[in]  rst        coordinates in AMR space : [0,1]^3
+ * \param[out] xyz        cartesian coordinates in physical space after geometry
+ *
+ */
 static void
 p4est_geometry_icosahedron_X (p4est_geometry_t * geom,
                               p4est_topidx_t which_tree,
@@ -324,7 +347,18 @@ p4est_geometry_new_icosahedron (p4est_connectivity_t * conn, double R)
 
 }                               /* p4est_geometry_new_icosahedron */
 
-/* geometric coordinate transformation */
+/**
+ * Geometric coordinate transformation for shell2d geometry.
+ *
+ * Define the geometric transformation from logical space (where AMR
+ * is performed) to the physical space.
+ *
+ * \param[in]  geom       associated geometry
+ * \param[in]  which_tree tree id inside forest
+ * \param[in]  rst        coordinates in AMR space : [0,1]^3
+ * \param[out] xyz        cartesian coordinates in physical space after geometry
+ *
+ */
 static void
 p4est_geometry_shell2d_X (p4est_geometry_t * geom,
                           p4est_topidx_t which_tree,
@@ -408,7 +442,7 @@ p4est_geometry_new_shell2d (p4est_connectivity_t * conn, double R2, double R1)
  * Define the geometric transformation from logical space (where AMR
  * is performed) to the physical space.
  *
- * \param[in]  p4est      the forest
+ * \param[in]  geom       associated geometry
  * \param[in]  which_tree tree id inside forest
  * \param[in]  rst        coordinates in AMR space : [0,1]^3
  * \param[out] xyz        cartesian coordinates in physical space after geometry
@@ -535,7 +569,7 @@ p4est_geometry_new_disk2d (p4est_connectivity_t * conn, double R0, double R1)
  * Define the geometric transformation from logical space (where AMR
  * is performed) to the physical space.
  *
- * \param[in]  p4est      the forest
+ * \param[in]  geom       associated geometry
  * \param[in]  which_tree tree id inside forest
  * \param[in]  rst        coordinates in AMR space : [0,1]^3
  * \param[out] xyz        cartesian coordinates in physical space after geometry
@@ -554,12 +588,12 @@ p4est_geometry_sphere2d_X (p4est_geometry_t * geom,
    transformation of connectivity*/
   p4est_geometry_connectivity_X (geom, which_tree, rst, xyz);
 
-  /* align center with origin */
+  /* align cube center with origin */
   xyz[0] -= 0.5;
   xyz[1] -= 0.5;
   xyz[2] -= 0.5;
 
-  /* normalise to length R */
+  /* normalise to radius R sphere */
   R = sphere2d->R;
   double R_on_norm = R/sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1] + xyz[2]*xyz[2]);
   xyz[0] *= R_on_norm;

--- a/src/p4est_geometry.c
+++ b/src/p4est_geometry.c
@@ -555,43 +555,44 @@ p4est_geometry_sphere2d_X (p4est_geometry_t * geom,
 
   /* transform from the AMR space into physical space using bi/trilinear
    transformation of connectivity*/
-  p4est_geometry_connectivity_X (geom, which_tree, rst, abc);
+  //p4est_geometry_connectivity_X (geom, which_tree, rst, abc);
 
   /* convert to unit cube coordinates */
-  // TODO: it should be possible to do this from the connectivity (and reuse code)
-  // switch (which_tree) {
-  // case 0:
-  //   xyz[0] = rst[1];
-  //   xyz[1] = rst[0];
-  //   xyz[2] = 0.0;
-  //   break;
-  // case 1:
-  //   xyz[0] = rst[1];
-  //   xyz[1] = 1.0;
-  //   xyz[2] = rst[0];
-  //   break;
-  // case 2:
-  //   xyz[0] = 0.0;
-  //   xyz[1] = rst[1];
-  //   xyz[2] = rst[0];
-  //   break;
-  // case 3:
-  //   xyz[0] = rst[0];
-  //   xyz[1] = rst[1];
-  //   xyz[2] = 1.0;
-  //   break;
-  // case 4:
-  //   xyz[0] = rst[0];
-  //   xyz[1] = 0.0;
-  //   xyz[1] = rst[1];
-  //   break;
-  // case 5:
-  //   xyz[0] = 1.0;
-  //   xyz[1] = rst[0];
-  //   xyz[2] = rst[1];
-  // default:
-  //   SC_ABORT_NOT_REACHED ();
-  // }
+  //TODO: it should be possible to do this from the connectivity (and reuse code)
+  switch (which_tree) {
+  case 0:
+    xyz[0] = rst[1];
+    xyz[1] = rst[0];
+    xyz[2] = 0.0;
+    break;
+  case 1:
+    xyz[0] = rst[1];
+    xyz[1] = 1.0;
+    xyz[2] = rst[0];
+    break;
+  case 2:
+    xyz[0] = 0.0;
+    xyz[1] = rst[1];
+    xyz[2] = rst[0];
+    break;
+  case 3:
+    xyz[0] = rst[0];
+    xyz[1] = rst[1];
+    xyz[2] = 1.0;
+    break;
+  case 4:
+    xyz[0] = rst[0];
+    xyz[1] = 0.0;
+    xyz[2] = rst[1];
+    break;
+  case 5:
+    xyz[0] = 1.0;
+    xyz[1] = rst[0];
+    xyz[2] = rst[1];
+    break;
+  default:
+    SC_ABORT_NOT_REACHED ();
+  }
 
   /* align center with origin */
   xyz[0] -= 0.5;

--- a/src/p4est_geometry.h
+++ b/src/p4est_geometry.h
@@ -118,8 +118,8 @@ p4est_geometry_t   *p4est_geometry_new_icosahedron (p4est_connectivity_t *
  *  This a direct adaptation of geometric shell in 3d.
  * 
  * \param[in] conn      The result of \ref p4est_connectivity_new_shell2d.
- * \param[in] R0        radius of the inner circle (internal border).
- * \param[in] R1        radius of the outer circle (external border).
+ * \param[in] R1        radius of the inner circle (internal border).
+ * \param[in] R2        radius of the outer circle (external border).
  * 
  */
 p4est_geometry_t   *p4est_geometry_new_shell2d (p4est_connectivity_t * conn,
@@ -139,10 +139,10 @@ p4est_geometry_t   *p4est_geometry_new_disk2d (p4est_connectivity_t * conn,
                                                double R0, double R1);
 
 /**
- * sphere2d geometry associated to cubed connectivity.
+ * Create sphere geometry associated to cubed connectivity.
  *
+ * \param[in] conn The result of \ref p4est_connectivity_new_cubed.
  * \param[in] R radius of the sphere
- *
  *
  * This geometry is meant to be used with the cubed connectivity
  * \ref p4est_connectivity_new_cubed, which is a 6-tree connectivity,

--- a/src/p4est_geometry.h
+++ b/src/p4est_geometry.h
@@ -22,17 +22,18 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-/** \file p4est_geometry.h transforms from tree-local "reference" coordinate system
+/** \file p4est_geometry.h Transform from tree-local "reference" coordinate system
  * to global "physical space" coordinates. These are used in \ref p4est_vtk.h to write
  * global coordinate meshes to disk.
- * 
+ *
  * We provide several example geometries for use. You may also implement your own
  * geometry as you see fit.
- * 
- * \note Each tree has the local coordinate system [0,1]^d. For legacy/p8est
- * compatibility reasons the local coordinates are always represented as a triple abc[3]. 
- * For a 2D quadtree mesh the local coordinates are abc[0] and abc[1] and the third 
- * coordinate abc[2] should be ignored.
+ *
+ * \note For geometry purposes, each tree has the local coordinate system
+ * \f$[0,1]^d\f$. For legacy/\ref p8est compatibility reasons the local
+ * coordinates are always represented as a triple abc[3].
+ * For a 2D quadtree mesh the local coordinates are abc[0] and abc[1] and
+ * the third coordinate abc[2] should be ignored.
  *
  * \ingroup p4est
  */
@@ -48,14 +49,14 @@ SC_EXTERN_C_BEGIN;
 typedef struct p4est_geometry p4est_geometry_t;
 
 /** Forward transformation from the tree-local coordinates to physical space.
- * 
+ *
  * \note The two-dimensional connectivities built into p4est have 3D vertex coordinates
  * that can be used in the transformation if so desired. However, connectivities are
  * not in general required to have vertex coordinate information.
- * 
+ *
  * \param[in]  geom       associated geometry
  * \param[in]  which_tree tree id inside forest
- * \param[in]  abc        tree-local coordinates : [0,1]^d. 
+ * \param[in]  abc        tree-local coordinates: \f$[0,1]^d\f$.
  *                        For 2D meshes abc[2] should never be accessed.
  * \param[out] xyz        cartesian coordinates in physical space after geometry
  */
@@ -64,19 +65,19 @@ typedef void        (*p4est_geometry_X_t) (p4est_geometry_t * geom,
                                            const double abc[3],
                                            double xyz[3]);
 
-/** Destructor prototype for a user-allocated \a p4est_geometry_t.
- * It is invoked by p4est_geometry_destroy.  If the user chooses to
- * reserve the structure statically, simply don't call p4est_geometry_destroy.
+/** Destructor prototype for a user-allocated \ref p4est_geometry_t.
+ * It is invoked by \ref p4est_geometry_destroy.  If the user chooses to
+ * reserve the structure statically, there is no need to provide it.
  */
 typedef void        (*p4est_geometry_destroy_t) (p4est_geometry_t * geom);
 
-/** Encapsulates a custom transformation from tree-local coordinates to 
+/** Encapsulates a custom transformation from tree-local coordinates to
  * user defined physical space.
- * 
- * \warning Used in \ref p4est_vtk.h to write global-coordinate meshes. 
+ *
+ * \warning Used in \ref p4est_vtk.h to write global-coordinate meshes.
  * In this case *user is assumed to point to a \ref p4est_connectivity.
- * In general it can be used however the user likes. 
- * 
+ * In general it can be used however the user likes.
+ *
  * This structure can be filled or allocated by the user.
  * p4est will never change its contents.
  */
@@ -86,21 +87,21 @@ struct p4est_geometry
   void               *user;     /**< User's choice is arbitrary. */
   p4est_geometry_X_t  X;        /**< Coordinate transformation. */
   p4est_geometry_destroy_t destroy;     /**< Destructor called by
-                                             p4est_geometry_destroy.  If
+                                             \ref p4est_geometry_destroy.  If
                                              NULL, P4EST_FREE is called. */
 };
 
 /** Can be used to conveniently destroy a geometry structure.
  * The user is free not to call this function at all if they handle the
- * memory of the p4est_geometry_t in their own way.
+ * memory of the \ref p4est_geometry_t in their own way.
  */
 void                p4est_geometry_destroy (p4est_geometry_t * geom);
 
 /** Create a geometry structure based on the vertices in a connectivity.
  * The transformation is constructed using bilinear interpolation.
- * \param [in] conn A p4est_connectivity_t with vertex coordinate information.
- *                  We do NOT take ownership and expect this structure to stay alive.
- * \return          Geometry structure; use with p4est_geometry_destroy.
+ * \param [in] conn A connectivity with vertex coordinate information.
+ *                  We do \a not take ownership and expect this structure to stay alive.
+ * \return          Geometry structure; use with \ref p4est_geometry_destroy.
  */
 p4est_geometry_t   *p4est_geometry_new_connectivity (p4est_connectivity_t *
                                                      conn);
@@ -109,18 +110,16 @@ p4est_geometry_t   *p4est_geometry_new_connectivity (p4est_connectivity_t *
  *
  * \param[in] conn      The result of \ref p4est_connectivity_new_icosahedron.
  * \param[in] R         The radius of the sphere.
- * 
  */
 p4est_geometry_t   *p4est_geometry_new_icosahedron (p4est_connectivity_t *
                                                     conn, double R);
 
 /** Create a geometry for mapping the annulus.
  *  This a direct adaptation of geometric shell in 3d.
- * 
+ *
  * \param[in] conn      The result of \ref p4est_connectivity_new_shell2d.
  * \param[in] R1        radius of the inner circle (internal border).
  * \param[in] R2        radius of the outer circle (external border).
- * 
  */
 p4est_geometry_t   *p4est_geometry_new_shell2d (p4est_connectivity_t * conn,
                                                 double R2, double R1);
@@ -149,7 +148,7 @@ p4est_geometry_t   *p4est_geometry_new_disk2d (p4est_connectivity_t * conn,
  * to map the sphere.
  */
 p4est_geometry_t   *p4est_geometry_new_sphere2d (p4est_connectivity_t * conn,
-                                               double R);
+                                                 double R);
 
 SC_EXTERN_C_END;
 

--- a/src/p4est_geometry.h
+++ b/src/p4est_geometry.h
@@ -53,7 +53,14 @@ typedef void        (*p4est_geometry_X_t) (p4est_geometry_t * geom,
  */
 typedef void        (*p4est_geometry_destroy_t) (p4est_geometry_t * geom);
 
-/** This structure can be filled or allocated by the user.
+/** Encapsulates a custom transformation from AMR space to 
+ * user defined physical space.
+ * 
+ * Used in \ref p4est_vtk.h to write vtk files for visualization.
+ * In this case *user is assumed to point to a \ref p4est_connectivity.
+ * In general it can be used however the user likes. 
+ * 
+ * This structure can be filled or allocated by the user.
  * p4est will never change its contents.
  */
 struct p4est_geometry

--- a/src/p4est_geometry.h
+++ b/src/p4est_geometry.h
@@ -106,6 +106,19 @@ p4est_geometry_t   *p4est_geometry_new_shell2d (p4est_connectivity_t * conn,
 p4est_geometry_t   *p4est_geometry_new_disk2d (p4est_connectivity_t * conn,
                                                double R0, double R1);
 
+/**
+ * sphere2d geometry associated to cubed connectivity.
+ *
+ * \param[in] R radius of the sphere
+ *
+ *
+ * This geometry is meant to be used with the cubed connectivity
+ * \ref p4est_connectivity_new_cubed, which is a 6-tree connectivity,
+ * to map the sphere.
+ */
+p4est_geometry_t   *p4est_geometry_new_sphere2d (p4est_connectivity_t * conn,
+                                               double R);
+
 SC_EXTERN_C_END;
 
 #endif /* !P4EST_GEOMETRY_H */

--- a/src/p4est_vtk.h
+++ b/src/p4est_vtk.h
@@ -50,8 +50,8 @@ typedef struct p4est_vtk_context p4est_vtk_context_t;
  * This function will abort if there is a file error.
  *
  * \param [in] p4est    The p4est to be written.
- * \param [in] geom     A p4est_geometry_t structure or NULL for vertex space
- *                      as defined by p4est->connectivity.
+ * \param [in] geom     A \ref p4est_geometry_t structure or NULL for vertex space
+ *                      as defined by the \a p4est's \ref p4est_connectivity_t member.
  * \param [in] filename The first part of the file name which will have the
  *                      MPI rank appended to it: The output file will be
  *                      filename_rank.vtu, and the meta file filename.pvtu.
@@ -89,7 +89,7 @@ p4est_vtk_context_t *p4est_vtk_context_new (p4est_t * p4est,
  * \param [in,out] cont         The context is modified.
  *                              It must not yet have been used to start writing
  *                              in \ref p4est_vtk_write_header.
- * \param geom      A p4est_geometry_t structure, or NULL for vertex space.
+ * \param geom      A \ref p4est_geometry_t structure, or NULL for vertex space.
  *                  If NULL, \b p4est->connectivity->vertices and
  *                  \b tree_to_vertex must be non-NULL.
  */

--- a/src/p4est_vtk.h
+++ b/src/p4est_vtk.h
@@ -89,7 +89,7 @@ p4est_vtk_context_t *p4est_vtk_context_new (p4est_t * p4est,
  * \param [in,out] cont         The context is modified.
  *                              It must not yet have been used to start writing
  *                              in \ref p4est_vtk_write_header.
- * \param geom      A \ref p4est_geometry_t structure, or NULL for vertex space.
+ * \param geom      A p4est_geometry_t structure, or NULL for vertex space.
  *                  If NULL, \b p4est->connectivity->vertices and
  *                  \b tree_to_vertex must be non-NULL.
  */

--- a/src/p8est_geometry.h
+++ b/src/p8est_geometry.h
@@ -22,7 +22,15 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-/** \file p8est_geometry.h transforms from vertex frame to physical space.
+/** \file p8est_geometry.h Transform from tree-local "reference" coordinate system
+ * to global "physical space" coordinates. These are used in \ref p8est_vtk.h to write
+ * global coordinate meshes to disk.
+ *
+ * We provide several example geometries for use. You may also implement your own
+ * geometry as you see fit.
+ *
+ * \note For geometry purposes, each tree has the local coordinate system
+ * \f$[0,1]^3\f$.
  *
  * \ingroup p8est
  */
@@ -47,7 +55,7 @@ typedef void        (*p8est_geometry_X_t) (p8est_geometry_t * geom,
 
 /** Destructor prototype for a user-allocated \a p8est_geometry_t.
  * It is invoked by p8est_geometry_destroy.  If the user chooses to
- * reserve the structure statically, simply don't call p4est_geometry_destroy.
+ * reserve the structure statically, there is no need to provide it.
  */
 typedef void        (*p8est_geometry_destroy_t) (p8est_geometry_t * geom);
 
@@ -66,7 +74,7 @@ struct p8est_geometry
 
 /** Can be used to conveniently destroy a geometry structure.
  * The user is free not to call this function at all if they handle the
- * memory of the p8est_geometry_t in their own way.
+ * memory of the \ref p8est_geometry_t in their own way.
  */
 void                p8est_geometry_destroy (p8est_geometry_t * geom);
 
@@ -74,7 +82,7 @@ void                p8est_geometry_destroy (p8est_geometry_t * geom);
  * The transformation is constructed using trilinear interpolation.
  * \param [in] conn A p8est_connectivity_t with valid vertices.  We do NOT
  *                  take ownership and expect this structure to stay alive.
- * \return          Geometry structure; use with p4est_geometry_destroy.
+ * \return          Geometry structure; use with \ref p4est_geometry_destroy.
  */
 p8est_geometry_t   *p8est_geometry_new_connectivity (p8est_connectivity_t *
                                                      conn);
@@ -84,7 +92,7 @@ p8est_geometry_t   *p8est_geometry_new_connectivity (p8est_connectivity_t *
  *                  We do NOT take ownership and expect it to stay alive.
  * \param [in] R2   The outer radius of the shell.
  * \param [in] R1   The inner radius of the shell.
- * \return          Geometry structure; use with p4est_geometry_destroy.
+ * \return          Geometry structure; use with \ref p4est_geometry_destroy.
  */
 p8est_geometry_t   *p8est_geometry_new_shell (p8est_connectivity_t * conn,
                                               double R2, double R1);
@@ -95,7 +103,7 @@ p8est_geometry_t   *p8est_geometry_new_shell (p8est_connectivity_t * conn,
  * \param [in] R2   The outer radius of the sphere.
  * \param [in] R1   The outer radius of the inner shell.
  * \param [in] R0   The inner radius of the inner shell.
- * \return          Geometry structure; use with p4est_geometry_destroy.
+ * \return          Geometry structure; use with \ref p4est_geometry_destroy.
  */
 p8est_geometry_t   *p8est_geometry_new_sphere (p8est_connectivity_t * conn,
                                                double R2, double R1,
@@ -116,7 +124,7 @@ p8est_geometry_t   *p8est_geometry_new_sphere (p8est_connectivity_t * conn,
  * \param [in] R0   The inner radius of the 2d disk slice.
  * \param [in] R1   The outer radius of the 2d disk slice.
  * \param [in] R2   The outer radius of the torus.
- * \return          Geometry structure; use with p4est_geometry_destroy.
+ * \return          Geometry structure; use with \ref p4est_geometry_destroy.
  */
 p8est_geometry_t   *p8est_geometry_new_torus (p8est_connectivity_t * conn,
                                               double R0, double R1,

--- a/src/p8est_vtk.h
+++ b/src/p8est_vtk.h
@@ -50,8 +50,8 @@ typedef struct p8est_vtk_context p8est_vtk_context_t;
  * This function will abort if there is a file error.
  *
  * \param [in] p8est    The p8est to be written.
- * \param [in] geom     A p8est_geometry_t structure or NULL for vertex space
- *                      as defined by p8est->connectivity.
+ * \param [in] geom     A \ref p8est_geometry_t structure or NULL for vertex space
+ *                      as defined by the \a p8est's \ref p8est_connectivity_t member.
  * \param [in] filename The first part of the file name which will have the
  *                      MPI rank appended to it: The output file will be
  *                      filename_rank.vtu, and the meta file filename.pvtu.


### PR DESCRIPTION
# PR for sphere2d geometry

Fixed this to be based on develop instead of master.

Proposed changes: Add sphere geometry for use with the 6-tree cubed connectivity. Add configuration to use this geometry in example/simple/simple2.c. Add documentation for p4est_geometry
