### PR TITLE
Adjust data size handling in wrap_new_p4est

### DIFF
--- a/src/p4est_wrap.c
+++ b/src/p4est_wrap.c
@@ -211,6 +211,9 @@ p4est_wrap_new_p4est (p4est_t * p4est, int hollow, p4est_connect_type_t btype,
     pp->mesh = p4est_mesh_new_ext (pp->p4est, pp->ghost, 1, 1, pp->btype);
   }
 
+  /* reset the data size since changing the p4est_wrap will affect p.user_int */
+  p4est_reset_data (pp->p4est, 0, NULL, NULL);
+
   pp->p4est->user_pointer = pp;
   pp->user_pointer = user_pointer;
 

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -113,6 +113,8 @@ p4est_wrap_t       *p4est_wrap_new_conn (sc_MPI_Comm mpicomm,
  * \param [in,out] p4est      Valid p4est object that we will own.
  *                            We take ownership of its connectivity too.
  *                            Its user pointer must be NULL and will be changed.
+ *                            Its data size will be set to 0 and the quadrant
+ *                            data will be freed.
  * \param [in] hollow         Do not allocate flags, ghost, and mesh members.
  * \param [in] btype          The neighborhood used for balance, ghost, mesh.
  * \param [in] replace_fn     Callback to replace quadrants during refinement,


### PR DESCRIPTION
# Adjust data size handling in `wrap_new_p4est`

Currently the function `p4est_wrap_new_p4est` does not reset the data size of the given p4est to 0 and does not free the quadrant data. However, during changing the created p4est_wrap `p.user_int` is used. This PR is a prerequisite for the PR https://github.com/ForestClaw/forestclaw/pull/289.  

### Proposed changes

We ensure that we do not lose pointers to quadrant data during changing the p4est_wrap by resetting the data size to 0 and freeing the quadrant data in advance in the function `p4est_wrap_new_p4est`.
