### PR TITLE
Update mail address

### DIFF
--- a/doc/author_lahnert.txt
+++ b/doc/author_lahnert.txt
@@ -1,1 +1,2 @@
-I place my contributions to p4est under the FreeBSD license. Michael Lahnert (michael.lahnert@ipvs.uni-stuttgart.de)
+I place my contributions to p4est under the FreeBSD license. Michael Lahnert (michael.lahnert@gmail.com)
+


### PR DESCRIPTION
# Fix mail address

Address from University of Stuttgart is no longer active.