### PR TITLE
3D documentation of adjusted wrap data size

### DIFF
--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -113,6 +113,8 @@ p8est_wrap_t       *p8est_wrap_new_conn (sc_MPI_Comm mpicomm,
  * \param [in,out] p8est      Valid p8est object that we will own.
  *                            We take ownership of its connectivity too.
  *                            Its user pointer must be NULL and will be changed.
+ *                            Its data size will be set to 0 and the quadrant
+ *                            data will be freed.
  * \param [in] hollow         Do not allocate flags, ghost, and mesh members.
  * \param [in] btype          The neighborhood used for balance, ghost, mesh.
  * \param [in] replace_fn     Callback to replace quadrants during refinement,


### PR DESCRIPTION
# 3D documentation of adjusted wrap data size

The already merged PR https://github.com/cburstedde/p4est/pull/252 had no adjusted documentation in `p8est_wrap.h`.

Proposed changes: Adding the documentation for the adjustments in the PR https://github.com/cburstedde/p4est/pull/252 also in `p8est_wrap.h`.
