### PR TITLE
Feature gmt sphere

### DIFF
--- a/example/gmt/Makefile.am
+++ b/example/gmt/Makefile.am
@@ -12,6 +12,14 @@ example_gmt_p4est_gmt_SOURCES = \
 
 LINT_CSOURCES += \
         $(example_gmt_p4est_gmt_SOURCES)
+
+bin_PROGRAMS += example/gmt/p4est_coastlines_preprocessing
+
+example_gmt_p4est_coastlines_preprocessing_SOURCES = example/gmt/coastlines_preprocessing.c
+
+LINT_CSOURCES += \
+        $(example_gmt_p4est_coastlines_preprocessing_SOURCES)
+
 endif
 
 if P4EST_ENABLE_BUILD_3D

--- a/example/gmt/coastlines_preprocessing.c
+++ b/example/gmt/coastlines_preprocessing.c
@@ -1,0 +1,405 @@
+/*
+  This file is part of p4est.
+  p4est is a C library to manage a collection (a forest) of multiple
+  connected adaptive quadtrees or octrees in parallel.
+
+  Copyright (C) 2010 The University of Texas System
+  Additional copyright (C) 2011 individual authors
+  Written by Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac
+
+  p4est is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  p4est is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with p4est; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#include "gmt_models.c"
+
+/* Convert from angular coordinates to corresponding point on cube face*/
+static void angular_to_cube(const double angular[2], double xyz[3])
+{
+  double inf_norm;
+  double phi, theta;
+
+  /* Convert to radians*/
+  phi = angular[0] * M_PI / 180.0;
+  theta = angular[1] * M_PI / 180.0;
+
+  xyz[0] = sin(theta) * cos(phi);
+  xyz[1] = sin(theta) * sin(phi);
+  xyz[2] = cos(theta);
+
+  inf_norm = fmax(fabs(xyz[0]), fmax(fabs(xyz[1]), fabs(xyz[2]))) * 2.0;
+  xyz[0] /= inf_norm;
+  xyz[1] /= inf_norm;
+  xyz[2] /= inf_norm;
+  return;
+}
+/**
+ * Which face does a given point belong to
+ *
+ * Note: ties are decided arbitrarily for the time being
+ *
+ * \param[in] xyz  cartesian coordinates on surface of cube [-0.5,0.5]x[-0.5,0.5]
+ */
+static int point_to_tree(const double xyz[3])
+{
+  if (fabs(xyz[0] + 0.5) < SC_EPS)
+    return 2;
+  if (fabs(xyz[0] - 0.5) < SC_EPS)
+    return 5;
+  if (fabs(xyz[1] + 0.5) < SC_EPS)
+    return 4;
+  if (fabs(xyz[1] - 0.5) < SC_EPS)
+    return 1;
+  if (fabs(xyz[2] + 0.5) < SC_EPS)
+    return 0;
+  if (fabs(xyz[2] - 0.5) < SC_EPS)
+    return 3;
+  return -1; // This should not happen
+}
+
+/**
+ * coordinate transformation from the surface of cube [-0.5,0.5]x[-0.5,0.5]
+ * to tree-local coordinates. This is the inverse of p4est_geometry_cubed_X.
+ *
+ * \param[in]  xyz  cartesian coordinates in physical space
+ * \param[in]  which_tree face of cube
+ * \param[out] rst  coordinates in AMR space : [0,1]^3
+ *
+ */
+static void p4est_geometry_cubed_Y(const double xyz[3], double rst[3], int which_tree)
+{
+  rst[2] = 0.0;
+
+  /* align center with origin */
+  switch (which_tree)
+  {
+  case 0:
+    rst[0] = xyz[1] + 0.5;
+    rst[1] = xyz[0] + 0.5;
+    break;
+  case 1:
+    rst[0] = xyz[2] + 0.5;
+    rst[1] = xyz[0] + 0.5;
+    break;
+  case 2:
+    rst[0] = xyz[2] + 0.5;
+    rst[1] = xyz[1] + 0.5;
+    break;
+  case 3:
+    rst[0] = xyz[0] + 0.5;
+    rst[1] = xyz[1] + 0.5;
+    break;
+  case 4:
+    rst[0] = xyz[0] + 0.5;
+    rst[1] = xyz[2] + 0.5;
+    break;
+  case 5:
+    rst[0] = xyz[1] + 0.5;
+    rst[1] = xyz[2] + 0.5;
+    break;
+  default:
+    break;
+  }
+}
+
+/** Returns true if the cone spanned by v1 and v2 intersects the line segment
+ *  between p1 and p2. If an intersection is detected then p_intersect is
+ *  set to the computed intersection point.
+ *
+ */
+static int cone_line_intersection(const double v1[3], const double v2[3], const double p1[3],
+                                  const double p2[3], double p_intersect[3])
+{
+  /* We solve the matrix equation (v1, v2, p1-p2) x = p1 by inverting (v1, v2, p1-p2) */
+  double A[3][3];        /* Matrix we are inverting */
+  double cofactor[3][3]; /* Cofactor matrix */
+  double det_A, det_A_inv;
+  double x[3];
+
+  A[0][0] = v1[0];
+  A[1][0] = v1[1];
+  A[2][0] = v1[2];
+  A[0][1] = v2[0];
+  A[1][1] = v2[1];
+  A[2][1] = v2[2];
+  A[0][2] = p1[0] - p2[0];
+  A[1][2] = p1[1] - p2[1];
+  A[2][2] = p1[2] - p2[2];
+
+  /* Compute minors */
+  for (int r = 0; r < 3; r++)
+  {
+    for (int c = 0; c < 3; c++)
+    {
+      cofactor[r][c] = A[(r + 1) % 3][(c + 1) % 3] * A[(r + 2) % 3][(c + 2) % 3] - A[(r + 1) % 3][(c + 2) % 3] * A[(r + 2) % 3][(c + 1) % 3];
+    }
+  }
+
+  /* Compute the determinant by Laplace expansion along the first column */
+  det_A = 0;
+  for (int r = 0; r < 3; r++)
+  {
+    det_A += A[r][0] * cofactor[r][0];
+  }
+  det_A_inv = 1 / det_A; /* TODO: What if det_A = 0?*/
+
+  /* Multiply p1 with inverse of A */
+  for (int i = 0; i < 3; i++)
+  {
+    /* Compute x[i] */
+    x[i] = 0;
+    for (int j = 0; j < 3; j++)
+    {
+      x[i] += cofactor[j][i] * p1[j];
+    }
+    x[i] *= det_A_inv;
+  }
+
+  if (x[0] < 0 || x[1] < 0 || x[2] < 0 || x[2] > 1)
+  {
+    return 0; /* Invalid intersection */
+  }
+
+  p_intersect[0] = x[0] * v1[0] + x[1] * v2[0];
+  p_intersect[1] = x[0] * v1[1] + x[1] * v2[1];
+  p_intersect[2] = x[0] * v1[2] + x[1] * v2[2];
+  printf("Intersection at coords %f, %f, %f\n", p_intersect[0], p_intersect[1], p_intersect[2]);
+  return 1; /* Valid intersection */
+}
+
+/** If the geodesic between xyz1 and xyz2 intersects the given edge then add this
+ *  intersection point to endpoints and increment the corresponding entry in
+ *  endpoints_count. To deal with edge cases coming from corners we should only update
+ *  if the new intersection point is distinct to previously seen intersection points.
+ */
+static void update_endpoints(const double xyz1[3], const double xyz2[3], int edge,
+                             double endpoints[6][2][3], int endpoints_count[6])
+{
+  double p_intersect[3];
+  int detected;
+
+  /* Which cube faces are adjacent to the given edge */
+  const int edge_to_face[12][2] = {
+      {0, 1},
+      {0, 2},
+      {0, 4},
+      {0, 5},
+      {1, 2},
+      {1, 3},
+      {1, 5},
+      {2, 3},
+      {2, 4},
+      {3, 4},
+      {3, 5},
+      {4, 5}};
+
+  /* Cube edge endpoint coordinates */
+  const double edge_endpoints[12][2][3] = {
+      {{-0.5, 0.5, -0.5}, {0.5, 0.5, -0.5}},   /* 0,1 edge */
+      {{-0.5, -0.5, -0.5}, {-0.5, 0.5, -0.5}}, /* 0,2 edge */
+      {{-0.5, -0.5, -0.5}, {0.5, -0.5, -0.5}}, /* 0,4 edge*/
+      {{0.5, -0.5, -0.5}, {0.5, 0.5, -0.5}},   /* 0,5 edge */
+      {{-0.5, 0.5, -0.5}, {-0.5, 0.5, 0.5}},   /* 1,2 edge */
+      {{-0.5, 0.5, 0.5}, {0.5, 0.5, 0.5}},     /* 1,3 edge */
+      {{0.5, 0.5, -0.5}, {0.5, 0.5, 0.5}},     /* 1,5 edge */
+      {{-0.5, -0.5, 0.5}, {-0.5, 0.5, 0.5}},   /* 2,3 edge */
+      {{-0.5, -0.5, -0.5}, {-0.5, -0.5, 0.5}}, /* 2,4 edge */
+      {{-0.5, -0.5, 0.5}, {0.5, -0.5, 0.5}},   /* 3,4 edge */
+      {{0.5, -0.5, 0.5}, {0.5, 0.5, 0.5}},     /* 3,5 edge */
+      {{0.5, -0.5, -0.5}, 0.5, -0.5, 0.5}      /* 4,5 edge*/
+  };
+
+  detected = cone_line_intersection(xyz1, xyz2, edge_endpoints[edge][0],
+                                    edge_endpoints[edge][1], p_intersect);
+
+  if (detected == 1)
+  {
+    printf("Detection was on edge %d\n", edge);
+    for (int i = 0; i < 2; i++)
+    {
+      if (endpoints_count[edge_to_face[edge][i]] == 0)
+      {
+        /* Record first endpoint */
+        endpoints[edge_to_face[edge][i]][0][0] = p_intersect[0];
+        endpoints[edge_to_face[edge][i]][0][1] = p_intersect[1];
+        endpoints[edge_to_face[edge][i]][0][2] = p_intersect[2];
+        endpoints_count[edge_to_face[edge][i]] += 1; /* update count */
+      }
+      if (endpoints_count[edge_to_face[edge][i]] == 1)
+      {
+        /* Check if distinct from first endpoint */
+        if (fabs(endpoints[edge_to_face[edge][i]][0][0] - p_intersect[0]) > SC_EPS || fabs(endpoints[edge_to_face[edge][i]][0][1] - p_intersect[1]) > SC_EPS || fabs(endpoints[edge_to_face[edge][i]][0][2] - p_intersect[2]) > SC_EPS)
+        {
+          /* Record second endpoint */
+          endpoints[edge_to_face[edge][i]][1][0] = p_intersect[0];
+          endpoints[edge_to_face[edge][i]][1][1] = p_intersect[1];
+          endpoints[edge_to_face[edge][i]][1][2] = p_intersect[2];
+          endpoints_count[edge_to_face[edge][i]] += 1; /* update count */
+        }
+      }
+    }
+  }
+}
+
+/** Load geodesics from coastlines.csv, convert to Cartesian coordinates, split into
+ *  segments corresponding to the trees in the cubed connectivity, then write to array
+ *  of type geodesic_segment_t.
+ * 
+ * The input is a CSV file where each line
+ *    phi1,theta1,phi2,theta2
+ * represents a geodesic between endpoints (phi1, theta1) and (phi2, theta2).
+ *
+*/
+int main(int argc, char **argv)
+{
+  FILE *geodesic_file;
+  FILE *fp;
+  sphere_geodesic_segment_t *geodesics;
+  /* The following variables get reused for each geodesic we read in. */
+  double angular1[2], xyz1[3], rst1[3]; /* angular, cartesian, and tree-local coords respectively*/
+  double angular2[2], xyz2[3], rst2[3];
+  int which_tree_1, which_tree_2;
+  int n_geodesics, capacity; /* capacity is the size of our dynamic array */
+  double endpoints[6][2][3]; /* stores endpoints of split geodesics in cartesian coords */
+  int endpoints_count[6];    /* counts endpoints of split geodesics assigned to each face */
+
+  /* Load geodesics */
+  n_geodesics = 0; /* Start with 0 and allocate memory as needed */
+  capacity = 1;
+  geodesics = P4EST_ALLOC(sphere_geodesic_segment_t, capacity);
+
+  fp = fopen("coastlines.csv", "r");
+
+  /* Each iteration reads a single geodesic in angular coordinates */
+  while (fscanf(fp, "%lf,%lf,%lf,%lf", &angular1[0], &angular1[1], &angular2[0], &angular2[1]) != EOF)
+  {
+    while (n_geodesics + 5 >= capacity)
+    { /* We split a geodesic into less than 5 faces */
+      capacity = capacity * 2;
+      geodesics = P4EST_REALLOC(geodesics, sphere_geodesic_segment_t, capacity);
+    }
+
+    /* Convert to cartesian coordinates */
+    angular_to_cube(angular1, xyz1);
+    angular_to_cube(angular2, xyz2);
+    printf("Scanned 1: %f, %f, %f\n", xyz1[0], xyz1[1], xyz1[2]);
+    printf("Scanned 2: %f, %f, %f\n", xyz2[0], xyz2[1], xyz2[2]);
+
+    /* Find which face the geodesic endpoints belong to */
+    which_tree_1 = point_to_tree(xyz1);
+    which_tree_2 = point_to_tree(xyz2);
+
+    if (which_tree_1 == which_tree_2)
+    { /* Geodesic is contained on one face*/
+      /* Convert to tree-local coordinates*/
+      p4est_geometry_cubed_Y(xyz1, rst1, which_tree_1);
+      p4est_geometry_cubed_Y(xyz2, rst2, which_tree_2);
+
+      /* Store geodesic as a sphere_geodesic_segment_t */
+      geodesics[n_geodesics].which_tree = which_tree_1;
+      geodesics[n_geodesics].p1x = rst1[0];
+      geodesics[n_geodesics].p1y = rst1[1];
+      geodesics[n_geodesics].p2x = rst2[0];
+      geodesics[n_geodesics].p2y = rst2[1];
+
+      n_geodesics++;
+    }
+    else
+    { /* Geodesic spans multiple faces, so we must split geodesic into segments*/
+      /* Reset the mapping {trees : {endpoints}} */
+      memset(endpoints_count, 0, sizeof(endpoints_count[0]) * 6);
+      memset(endpoints, 0.0, sizeof(endpoints[0][0][0]) * 6 * 2 * 3);
+
+      /* Add endpoints */
+      endpoints_count[which_tree_1] += 1;
+      endpoints[which_tree_1][0][0] = xyz1[0];
+      endpoints[which_tree_1][0][1] = xyz1[1];
+      endpoints[which_tree_1][0][2] = xyz1[2];
+
+      endpoints_count[which_tree_2] += 1;
+      endpoints[which_tree_2][0][0] = xyz2[0];
+      endpoints[which_tree_2][0][1] = xyz2[1];
+      endpoints[which_tree_2][0][2] = xyz2[2];
+
+      /* For the 12 edges of the cube compute intersection points and add them to mapping */
+      for (int edge = 0; edge < 12; edge++)
+      {
+        /* Compute the intersection of geodesic with the given edge*/
+        update_endpoints(xyz1, xyz2, edge, endpoints, endpoints_count);
+      }
+      for (int tree = 0; tree < 6; tree++)
+      {
+        if (endpoints_count[tree] == 0)
+        {
+          printf("Continuing on tree %d\n", tree);
+          continue; /* The geodesic does not cross this cube face */
+        }
+        if (endpoints_count[tree] == 1)
+        {
+          printf("One point on tree %d\n", tree);
+          /* The geodesic has an endpoint on the edge of this face (edge case) */
+          xyz1[0] = endpoints[tree][0][0];
+          xyz1[1] = endpoints[tree][0][1];
+          xyz1[2] = endpoints[tree][0][2];
+          xyz2[0] = endpoints[tree][0][0];
+          xyz2[1] = endpoints[tree][0][1];
+          xyz2[2] = endpoints[tree][0][2];
+        }
+        if (endpoints_count[tree] == 2)
+        {
+          printf("Two poins on tree %d\n", tree);
+          printf("Point one: %f, %f, %f\n", endpoints[tree][0][0], endpoints[tree][0][1], endpoints[tree][0][2]);
+          printf("Point two: %f, %f, %f\n", endpoints[tree][1][0], endpoints[tree][1][1], endpoints[tree][1][2]);
+          /* The geodesic has a generic segment on this face */
+          /* Set xyz1 and xyz2 to computed endpoints*/
+          xyz1[0] = endpoints[tree][0][0];
+          xyz1[1] = endpoints[tree][0][1];
+          xyz1[2] = endpoints[tree][0][2];
+          xyz2[0] = endpoints[tree][1][0];
+          xyz2[1] = endpoints[tree][1][1];
+          xyz2[2] = endpoints[tree][1][2];
+        }
+
+        /* Convert to tree-local coordinates*/
+        p4est_geometry_cubed_Y(xyz1, rst1, tree);
+        p4est_geometry_cubed_Y(xyz2, rst2, tree);
+
+        /* Store geodesic as a sphere_geodesic_segment_t */
+        geodesics[n_geodesics].which_tree = tree;
+        geodesics[n_geodesics].p1x = rst1[0];
+        geodesics[n_geodesics].p1y = rst1[1];
+        geodesics[n_geodesics].p2x = rst2[0];
+        geodesics[n_geodesics].p2y = rst2[1];
+
+        n_geodesics++;
+      }
+    }
+  }
+
+  /* Free extra capacity */
+  geodesics = P4EST_REALLOC(geodesics, sphere_geodesic_segment_t, n_geodesics);
+
+  fclose(fp);                                    /* Finished loading geodesics */
+  printf("n_geodesics %d\n", n_geodesics);
+
+  /* Write geodesics to disk */
+  geodesic_file = sc_fopen("geodesics", "w", "opening geodesics file");
+  /* Write n_geodesics */
+  sc_fwrite(&n_geodesics, sizeof(int), 1, geodesic_file, "writing n_geodesics");
+  /* Write geodesics */
+  sc_fwrite(geodesics, sizeof(sphere_geodesic_segment_t), n_geodesics, geodesic_file, "writing geodesics");
+  fclose(geodesic_file); /* Finished writing geodesics*/
+
+  return 0;
+}

--- a/example/gmt/gmt2.c
+++ b/example/gmt/gmt2.c
@@ -38,7 +38,7 @@ typedef struct global
   int                 resolution;
   int                 synthetic;
   int                 latlongno;
-  bool                sphere; /* globe sphere model */
+  int                 sphere; /* globe sphere model */
   sc_MPI_Comm         mpicomm;
   p4est_t            *p4est;
   p4est_gmt_model_t  *model;
@@ -81,9 +81,9 @@ setup_model (global_t * g)
       P4EST_GLOBAL_LERROR ("Latitute-longitude model number exceeded\n");
     }
   }
-  else if (g->sphere) {
+  else if (g->sphere == 1) {
     //TODO
-    g->model = p4est_gmt_model_sphere_new();
+    g->model = p4est_gmt_model_sphere_new(5);
   }
 
   /* on successful initalization the global model is set */
@@ -255,6 +255,8 @@ main (int argc, char **argv)
                       "Choose specific synthetic model");
   sc_options_add_int (opt, 'M', "latlongno", &g->latlongno, -1,
                       "Choose specific latitude-longitude model");
+  sc_options_add_bool (opt, 's', "sphere", &g->sphere, 0,
+                       "Use sphere model");
 
   /* proceed in run-once loop for cleaner error checking */
   ue = 0;

--- a/example/gmt/gmt2.c
+++ b/example/gmt/gmt2.c
@@ -312,11 +312,8 @@ main (int argc, char **argv)
 
   /* deinit main program */
   sc_options_destroy (opt);
-  printf("Option destroyed\n");
-  sc_finalize (); // TODO: using the sphere model we are crashing here
-  printf("sc_finalize\n");
+  sc_finalize ();
   mpiret = sc_MPI_Finalize ();
-  printf("sc_MPI_finalize\n");
   SC_CHECK_MPI (mpiret);
   return ue ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/example/gmt/gmt2.c
+++ b/example/gmt/gmt2.c
@@ -82,8 +82,7 @@ setup_model (global_t * g)
     }
   }
   else if (g->sphere == 1) {
-    //TODO
-    g->model = p4est_gmt_model_sphere_new(5);
+    g->model = p4est_gmt_model_sphere_new(g->resolution);
   }
 
   /* on successful initalization the global model is set */
@@ -163,6 +162,7 @@ run_program (global_t * g)
   P4EST_GLOBAL_PRODUCTIONF ("Setting up %lld search objects\n",
                             (long long) g->model->M);
   points = sc_array_new_count (sizeof (size_t), g->model->M);
+
   for (zz = 0; zz < g->model->M; ++zz) {
     *(size_t *) sc_array_index (points, zz) = zz;
   }
@@ -170,6 +170,8 @@ run_program (global_t * g)
     P4EST_GLOBAL_PRODUCTIONF ("Into refinement iteration %d\n", refiter);
     snprintf (filename, BUFSIZ, "p4est_gmt_%s_%02d",
               g->model->output_prefix, refiter);
+    P4EST_ASSERT(g->model != NULL);
+    P4EST_ASSERT(g->model->model_geom != NULL);
     p4est_vtk_write_file (g->p4est, g->model->model_geom, filename);
     gnq_before = g->p4est->global_num_quadrants;
 
@@ -255,7 +257,7 @@ main (int argc, char **argv)
                       "Choose specific synthetic model");
   sc_options_add_int (opt, 'M', "latlongno", &g->latlongno, -1,
                       "Choose specific latitude-longitude model");
-  sc_options_add_bool (opt, 's', "sphere", &g->sphere, 0,
+  sc_options_add_bool (opt, 'W', "sphere", &g->sphere, 0,
                        "Use sphere model");
 
   /* proceed in run-once loop for cleaner error checking */
@@ -268,9 +270,9 @@ main (int argc, char **argv)
       break;
     }
     P4EST_GLOBAL_PRODUCTIONF ("Manifold dimension is %d\n", P4EST_DIM);
-    if (g->synthetic < 0 && g->latlongno < 0) {
-      g->synthetic = 0;
-    }
+    // if (g->synthetic < 0 && g->latlongno < 0) {
+    //   g->synthetic = 0;
+    // }
     sc_options_print_summary (p4est_package_id, SC_LP_PRODUCTION, opt);
 
     /* check consistency of parameters */
@@ -310,8 +312,11 @@ main (int argc, char **argv)
 
   /* deinit main program */
   sc_options_destroy (opt);
-  sc_finalize ();
+  printf("Option destroyed\n");
+  sc_finalize (); // TODO: using the sphere model we are crashing here
+  printf("sc_finalize\n");
   mpiret = sc_MPI_Finalize ();
+  printf("sc_MPI_finalize\n");
   SC_CHECK_MPI (mpiret);
   return ue ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/example/gmt/gmt2.c
+++ b/example/gmt/gmt2.c
@@ -38,6 +38,7 @@ typedef struct global
   int                 resolution;
   int                 synthetic;
   int                 latlongno;
+  bool                sphere; /* globe sphere model */
   sc_MPI_Comm         mpicomm;
   p4est_t            *p4est;
   p4est_gmt_model_t  *model;
@@ -79,6 +80,10 @@ setup_model (global_t * g)
     default:
       P4EST_GLOBAL_LERROR ("Latitute-longitude model number exceeded\n");
     }
+  }
+  else if (g->sphere) {
+    //TODO
+    g->model = p4est_gmt_model_sphere_new();
   }
 
   /* on successful initalization the global model is set */

--- a/example/gmt/gmt_models.c
+++ b/example/gmt/gmt_models.c
@@ -25,14 +25,14 @@
 #include "gmt_models.h"
 
 static void
-model_set_geom (p4est_gmt_model_t * model,
-                const char *name, p4est_geometry_X_t X)
+model_set_geom(p4est_gmt_model_t *model,
+               const char *name, p4est_geometry_X_t X)
 {
   model->sgeom.name = name;
-  //TODO: in p4est_geometry_connectivity_X user is assumed to point to
-  //the relevant connectivity. The following line will cause geometries
-  // to violate that assumption.
-  model->sgeom.user = model; 
+  // TODO: in p4est_geometry_connectivity_X user is assumed to point to
+  // the relevant connectivity. The following line will cause geometries
+  //  to violate that assumption.
+  model->sgeom.user = model;
   model->sgeom.X = X;
   model->sgeom.destroy = NULL;
   model->model_geom = &model->sgeom;
@@ -40,39 +40,38 @@ model_set_geom (p4est_gmt_model_t * model,
 
 typedef struct p4est_gmt_model_synth
 {
-  int                 synthno;
-  int                 resolution;
-  size_t              num_points;
-  double             *points;
-}
-p4est_gmt_model_synth_t;
+  int synthno;
+  int resolution;
+  size_t num_points;
+  double *points;
+} p4est_gmt_model_synth_t;
 
 static void
-model_synth_destroy_data (void *vmodel_data)
+model_synth_destroy_data(void *vmodel_data)
 {
-  p4est_gmt_model_synth_t *sdata = (p4est_gmt_model_synth_t *) vmodel_data;
-  P4EST_FREE (sdata->points);
-  P4EST_FREE (sdata);
+  p4est_gmt_model_synth_t *sdata = (p4est_gmt_model_synth_t *)vmodel_data;
+  P4EST_FREE(sdata->points);
+  P4EST_FREE(sdata);
 }
 
 static int
-model_synth_intersect (p4est_topidx_t which_tree, const double coord[4],
-                       size_t m, void *vmodel)
+model_synth_intersect(p4est_topidx_t which_tree, const double coord[4],
+                      size_t m, void *vmodel)
 {
-  p4est_gmt_model_t  *model = (p4est_gmt_model_t *) vmodel;
+  p4est_gmt_model_t *model = (p4est_gmt_model_t *)vmodel;
   p4est_gmt_model_synth_t *sdata;
-  const double       *pco;
-  double              hx, hy;
+  const double *pco;
+  double hx, hy;
 
-  P4EST_ASSERT (model != NULL);
-  P4EST_ASSERT (m < model->M);
-  sdata = (p4est_gmt_model_synth_t *) model->model_data;
-  P4EST_ASSERT (sdata != NULL && sdata->points != NULL);
+  P4EST_ASSERT(model != NULL);
+  P4EST_ASSERT(m < model->M);
+  sdata = (p4est_gmt_model_synth_t *)model->model_data;
+  P4EST_ASSERT(sdata != NULL && sdata->points != NULL);
   pco = sdata->points + 2 * m;
-  P4EST_ASSERT (sdata->resolution >= 0);
+  P4EST_ASSERT(sdata->resolution >= 0);
 
   /* In this model we have only one tree, the unit square. */
-  P4EST_ASSERT (which_tree == 0);
+  P4EST_ASSERT(which_tree == 0);
 
   /* Rectangle coordinates are in [0, 1] for the numbered reference tree and
    * stored as { lower left x, lower left y, upper right x, upper right y }. */
@@ -80,13 +79,15 @@ model_synth_intersect (p4est_topidx_t which_tree, const double coord[4],
   /* We do not refine if target resolution is reached. */
   hx = coord[2] - coord[0];
   hy = coord[3] - coord[1];
-  if (SC_MAX (hx, hy) <= pow (.5, sdata->resolution)) {
+  if (SC_MAX(hx, hy) <= pow(.5, sdata->resolution))
+  {
     return 0;
   }
 
   /* In this synthetic example the point IS the object.  There are no lines. */
   if ((coord[0] <= pco[0] && pco[0] <= coord[2]) &&
-      (coord[1] <= pco[1] && pco[1] <= coord[3])) {
+      (coord[1] <= pco[1] && pco[1] <= coord[3]))
+  {
     return 1;
   }
 
@@ -95,33 +96,34 @@ model_synth_intersect (p4est_topidx_t which_tree, const double coord[4],
 }
 
 static void
-model_synth_geom_X (p4est_geometry_t * geom, p4est_topidx_t which_tree,
-                    const double abc[3], double xyz[3])
+model_synth_geom_X(p4est_geometry_t *geom, p4est_topidx_t which_tree,
+                   const double abc[3], double xyz[3])
 {
   /* In this model we have only one tree, the unit square. */
-  P4EST_ASSERT (which_tree == 0);
+  P4EST_ASSERT(which_tree == 0);
 
   /* We work with the unit square as physical space. */
-  memcpy (xyz, abc, 3 * sizeof (double));
+  memcpy(xyz, abc, 3 * sizeof(double));
 }
 
-p4est_gmt_model_t  *
-p4est_gmt_model_synth_new (int synthno, int resolution)
+p4est_gmt_model_t *
+p4est_gmt_model_synth_new(int synthno, int resolution)
 {
-  p4est_gmt_model_t  *model = P4EST_ALLOC_ZERO (p4est_gmt_model_t, 1);
+  p4est_gmt_model_t *model = P4EST_ALLOC_ZERO(p4est_gmt_model_t, 1);
   p4est_gmt_model_synth_t *sdata = NULL;
-  double             *p;
+  double *p;
 
   /* initalize model */
-  switch (synthno) {
+  switch (synthno)
+  {
   case 0:
     model->output_prefix = "triangle";
-    model->conn = p4est_connectivity_new_unitsquare ();
-    model->model_data = sdata = P4EST_ALLOC (p4est_gmt_model_synth_t, 1);
+    model->conn = p4est_connectivity_new_unitsquare();
+    model->model_data = sdata = P4EST_ALLOC(p4est_gmt_model_synth_t, 1);
     sdata->synthno = synthno;
     sdata->resolution = resolution;
     sdata->num_points = model->M = 3;
-    p = sdata->points = P4EST_ALLOC (double, 6);
+    p = sdata->points = P4EST_ALLOC(double, 6);
     p[0] = 0.2;
     p[1] = 0.1;
     p[2] = 0.7;
@@ -130,27 +132,27 @@ p4est_gmt_model_synth_new (int synthno, int resolution)
     p[5] = 0.8;
     model->destroy_data = model_synth_destroy_data;
     model->intersect = model_synth_intersect;
-    model_set_geom (model, model->output_prefix, model_synth_geom_X);
+    model_set_geom(model, model->output_prefix, model_synth_geom_X);
     break;
     /* possibly add more cases that work with polygon segments */
   default:
-    SC_ABORT_NOT_REACHED ();
+    SC_ABORT_NOT_REACHED();
   }
 
   /* return initialized model */
-  P4EST_ASSERT (sdata != NULL);
+  P4EST_ASSERT(sdata != NULL);
   sdata->synthno = synthno;
   return model;
 }
 
 static int
-model_latlong_intersect (p4est_topidx_t which_tree, const double coord[4],
-                         size_t m, void *vmodel)
+model_latlong_intersect(p4est_topidx_t which_tree, const double coord[4],
+                        size_t m, void *vmodel)
 {
-  p4est_gmt_model_t  *model = (p4est_gmt_model_t *) vmodel;
+  p4est_gmt_model_t *model = (p4est_gmt_model_t *)vmodel;
 
-  P4EST_ASSERT (model != NULL);
-  P4EST_ASSERT (m < model->M);
+  P4EST_ASSERT(model != NULL);
+  P4EST_ASSERT(m < model->M);
 
   /* Rectangle coordinates are in [0, 1] for the numbered reference tree and
    * stored as { lower left x, lower left y, upper right x, upper right y }. */
@@ -159,15 +161,15 @@ model_latlong_intersect (p4est_topidx_t which_tree, const double coord[4],
 }
 
 static void
-model_latlong_geom_X (p4est_geometry_t * geom, p4est_topidx_t which_tree,
-                      const double abc[3], double xyz[3])
+model_latlong_geom_X(p4est_geometry_t *geom, p4est_topidx_t which_tree,
+                     const double abc[3], double xyz[3])
 {
 #if LATLONG_DATA_HAS_BEEN_PROGRAMMED
-  p4est_gmt_model_t  *model = (p4est_gmt_model_t *) geom->user;
+  p4est_gmt_model_t *model = (p4est_gmt_model_t *)geom->user;
 
   /* put the parameters latitude, longitude into the model data */
   longitude =
-    ((typecast into gmt lanlong model data *) model->model_data)->longitude;
+      ((typecast into gmt lanlong model data *)model->model_data)->longitude;
   latitude = ...;
 
   xyz[0] = longitude[0] + (longitude->[1] - longitude[0]) * abc[0];
@@ -179,298 +181,161 @@ model_latlong_geom_X (p4est_geometry_t * geom, p4est_topidx_t which_tree,
   xyz[2] = 0.;
 }
 
-p4est_gmt_model_t  *
-p4est_gmt_model_latlong_new (p4est_gmt_model_latlong_params_t * params)
+p4est_gmt_model_t *
+p4est_gmt_model_latlong_new(p4est_gmt_model_latlong_params_t *params)
 {
-  p4est_gmt_model_t  *model = P4EST_ALLOC_ZERO (p4est_gmt_model_t, 1);
+  p4est_gmt_model_t *model = P4EST_ALLOC_ZERO(p4est_gmt_model_t, 1);
 
   /* the latlong models live on the unit square as reference domain */
-  model->conn = p4est_connectivity_new_unitsquare ();
+  model->conn = p4est_connectivity_new_unitsquare();
 
   /* load model properties */
-  model->model_data = NULL;     /* <- Load something from params->load_filename,
-                                   also deep copy the parameters into it. */
+  model->model_data = NULL; /* <- Load something from params->load_filename,
+                               also deep copy the parameters into it. */
 
   /* set virtual functions */
   model->intersect = model_latlong_intersect;
-  model->destroy_data = NULL;   /* <- needs to free whatever is in model_data */
+  model->destroy_data = NULL; /* <- needs to free whatever is in model_data */
 
   /* setup input/output parameters */
   model->output_prefix = params->output_prefix;
-  model_set_geom (model, params->output_prefix, model_latlong_geom_X);
+  model_set_geom(model, params->output_prefix, model_latlong_geom_X);
 
   /* the model is ready */
-  model->M = 17;                /* <- update to actual value */
+  model->M = 17; /* <- update to actual value */
   return model;
 }
 
 /** Represents the intersection of a geodesic with one of the cubed
  * connectivity faces.
- * 
+ *
  * The endpoints p1 and p2 are given in tree-local coordinates and
  * in local coordinates the geodesic is just the line segment between
  * them.
-*/
+ */
 typedef struct sphere_geodesic_segment
 {
-  int                 which_tree;
-  double              p1x, p1y, p2x, p2y;
+  int which_tree;
+  double p1x, p1y, p2x, p2y;
 } sphere_geodesic_segment_t;
 
 typedef struct p4est_gmt_model_sphere
 {
-  int                         resolution;
-  size_t                      num_geodesics;
-  sphere_geodesic_segment_t  *geodesics;
-}
-p4est_gmt_model_sphere_t;
+  int resolution;
+  size_t num_geodesics;
+  sphere_geodesic_segment_t *geodesics;
+} p4est_gmt_model_sphere_t;
 
 static void
-model_sphere_destroy_data (void *vmodel_data)
+model_sphere_destroy_data(void *vmodel_data)
 {
-  p4est_gmt_model_sphere_t *sdata = (p4est_gmt_model_sphere_t *) vmodel_data;
-  P4EST_FREE (sdata->geodesics);
-  P4EST_FREE (sdata);
-}
-
-/* Convert from angular coordinates to corresponding point on cube face*/
-static void angular_to_cube(const double angular[2], double xyz[3]) {
-    double inf_norm;
-    double phi, theta;
-
-    /* Convert to radians*/
-    phi = angular[0]*M_PI/180.0;
-    theta = angular[1]*M_PI/180.0;
-
-    xyz[0] = sin(theta) * cos(phi);
-    xyz[1] = sin(theta) * sin(phi);
-    xyz[2] = cos(theta);
-
-    inf_norm = fmax(fabs(xyz[0]), fmax(fabs(xyz[1]), fabs(xyz[2])))*2.0;
-    xyz[0] /= inf_norm;
-    xyz[1] /= inf_norm;
-    xyz[2] /= inf_norm;
-    return;
-}
-
-/**
- * Which face does a given point belong to
- * 
- * Note: ties are decided arbitrarily for the time being
- * 
- * \param[in] xyz  cartesian coordinates on surface of cube [-0.5,0.5]x[-0.5,0.5]
- */
-static int point_to_tree(const double xyz[3]) {
-    if (fabs(xyz[0]+0.5) < SC_EPS) return 2;
-    if (fabs(xyz[0]-0.5) < SC_EPS) return 5;
-    if (fabs(xyz[1]+0.5) < SC_EPS) return 4;
-    if (fabs(xyz[1]-0.5) < SC_EPS) return 1;
-    if (fabs(xyz[2]+0.5) < SC_EPS) return 0;
-    if (fabs(xyz[2]-0.5) < SC_EPS) return 3;
-    return -1; // This should not happen
-}
-
-/**
- * coordinate transformation from the surface of cube [-0.5,0.5]x[-0.5,0.5]
- * to tree-local coordinates. This is the inverse of p4est_geometry_cubed_X.
- *
- * \param[in]  xyz  cartesian coordinates in physical space
- * \param[in]  which_tree face of cube
- * \param[out] rst  coordinates in AMR space : [0,1]^3
- * 
- */
-static void p4est_geometry_cubed_Y(const double xyz[3], double rst[3], int which_tree) {
-    rst[2] = 0.0;
-
-    //int tree = point_to_tree(xyz); //TODO this is resulting in the wrong tree for edge values
-    //printf("Tree in local transform %d\n", tree);
-
-    /* align center with origin */
-    switch (which_tree)
-    {
-    case 0:
-        rst[0] = xyz[1]+0.5;
-        rst[1] = xyz[0]+0.5;
-        break;
-    case 1:
-        rst[0] = xyz[2]+0.5;
-        rst[1] = xyz[0]+0.5;
-        break;
-    case 2:
-        rst[0] = xyz[2]+0.5;
-        rst[1] = xyz[1]+0.5;
-        break;
-    case 3:
-        rst[0] = xyz[0]+0.5;
-        rst[1] = xyz[1]+0.5;
-        break;
-    case 4:
-        rst[0] = xyz[0]+0.5;
-        rst[1] = xyz[2]+0.5;
-        break;
-    case 5:
-        rst[0] = xyz[1]+0.5;
-        rst[1] = xyz[2]+0.5;
-        break;
-    default:
-        break;
-    }
+  p4est_gmt_model_sphere_t *sdata = (p4est_gmt_model_sphere_t *)vmodel_data;
+  P4EST_FREE(sdata->geodesics);
+  P4EST_FREE(sdata);
 }
 
 /** Returns 1 if the line segments (p0 to p1) and (p2 to p3) intersect, otherwise 0 */
-static int lines_intersect(double p0_x, double p0_y, double p1_x, double p1_y, 
-    double p2_x, double p2_y, double p3_x, double p3_y)
+static int lines_intersect(double p0_x, double p0_y, double p1_x, double p1_y,
+                           double p2_x, double p2_y, double p3_x, double p3_y)
 {
-    /* We solve the matrix equation (p1-p0, p2-p3) (s, t)^T = (p2-p0),
-     * by inverting the matrix (p1-p0, p2-p3). */
+  /* We solve the matrix equation (p1-p0, p2-p3) (s, t)^T = (p2-p0),
+   * by inverting the matrix (p1-p0, p2-p3). */
 
-    /* Precompute reused values for efficiency */
-    double s1_x, s1_y, s2_x, s2_y;
-    s1_x = p1_x - p0_x;     s1_y = p1_y - p0_y;
-    s2_x = p3_x - p2_x;     s2_y = p3_y - p2_y;
+  /* Precompute reused values for efficiency */
+  double s1_x, s1_y, s2_x, s2_y;
+  s1_x = p1_x - p0_x;
+  s1_y = p1_y - p0_y;
+  s2_x = p3_x - p2_x;
+  s2_y = p3_y - p2_y;
 
-    /* Compute line intersection */
-    double s, t;
-    s = (-s1_y * (p0_x - p2_x) + s1_x * (p0_y - p2_y)) / (-s2_x * s1_y + s1_x * s2_y);
-    t = ( s2_x * (p0_y - p2_y) - s2_y * (p0_x - p2_x)) / (-s2_x * s1_y + s1_x * s2_y);
+  /* Compute line intersection */
+  double s, t;
+  s = (-s1_y * (p0_x - p2_x) + s1_x * (p0_y - p2_y)) / (-s2_x * s1_y + s1_x * s2_y);
+  t = (s2_x * (p0_y - p2_y) - s2_y * (p0_x - p2_x)) / (-s2_x * s1_y + s1_x * s2_y);
 
-    /* Check intersection lies on relevant segment */
-    if (s >= 0 && s <= 1 && t >= 0 && t <= 1)
-    {
-        return 1;
-    }
-
-    return 0;
-}
-
-/** Returns true if the cone spanned by v1 and v2 intersects the line segment
- *  between p1 and p2. If an intersection is detected then p_intersect is
- *  set to the computed intersection point.
- * 
-*/
-static int cone_line_intersection(const double v1[3], const double v2[3], const double p1[3], 
-                              const double p2[3], double p_intersect[3]) 
-{
-  /* We solve the matrix equation (v1, v2, p1-p2) x = p1 by inverting (v1, v2, p1-p2) */
-  double A[3][3]; /* Matrix we are inverting */
-  double cofactor[3][3]; /* Cofactor matrix */
-  double det_A, det_A_inv;
-  double x[3];
-  
-  A[0][0] = v1[0];
-  A[1][0] = v1[1];
-  A[2][0] = v1[2];
-  A[0][1] = v2[0];
-  A[1][1] = v2[1];
-  A[2][1] = v2[2];
-  A[0][2] = p1[0]-p2[0];
-  A[1][2] = p1[1]-p2[1];
-  A[2][2] = p1[2]-p2[2];
-
-  /* Compute minors */
-  for (int r = 0; r < 3; r++) {
-    for (int c = 0; c < 3; c++) {
-      cofactor[r][c] = A[(r+1)%3][(c+1)%3] * A[(r+2)%3][(c+2)%3]
-                        - A[(r+1)%3][(c+2)%3] * A[(r+2)%3][(c+1)%3];
-    }
+  /* Check intersection lies on relevant segment */
+  if (s >= 0 && s <= 1 && t >= 0 && t <= 1)
+  {
+    return 1;
   }
 
-  /* Compute the determinant by Laplace expansion along the first column */
-  det_A = 0;
-  for (int r=0; r<3; r++) {
-    det_A += A[r][0] * cofactor[r][0];
-  }
-  det_A_inv = 1/det_A; /* TODO: What if det_A = 0?*/
-  
-
-  /* Multiply p1 with inverse of A */
-  for (int i=0; i<3; i++) {
-    /* Compute x[i] */
-    x[i] = 0;
-    for (int j=0; j<3; j++) {
-      x[i] += cofactor[j][i] * p1[j];
-    }
-    x[i] *= det_A_inv;
-  }
-  
-  if (x[0] < 0 || x[1] < 0 || x[2] < 0 || x[2] > 1) {
-    return 0; /* Invalid intersection */
-  }
-
-  p_intersect[0] = x[0] * v1[0] + x[1] * v2[0];
-  p_intersect[1] = x[0] * v1[1] + x[1] * v2[1];
-  p_intersect[2] = x[0] * v1[2] + x[1] * v2[2];
-  printf("Intersection at coords %f, %f, %f\n", p_intersect[0], p_intersect[1], p_intersect[2]);
-  return 1; /* Valid intersection */
+  return 0;
 }
 
 /** Returns 1 if the given geodesic intersects the given rectangle and 0 otherwise.
- * 
+ *
  * \param[in] which_tree  tree id inside forest
  * \param[in] coord       rectangle for intersection checking. Rectangle coordinates
  *                        are in [0, 1] for the numbered reference tree and stored as
  *                        { lower left x, lower left y, upper right x, upper right y }.
  * \param[in] m           index of the geodesic we are checking
  * \param[in] vmodel      spherical model
- * 
-*/
+ *
+ */
 static int
-model_sphere_intersect (p4est_topidx_t which_tree, const double coord[4],
-                         size_t m, void *vmodel)
+model_sphere_intersect(p4est_topidx_t which_tree, const double coord[4],
+                       size_t m, void *vmodel)
 {
-  p4est_gmt_model_t  *model = (p4est_gmt_model_t *) vmodel;
+  p4est_gmt_model_t *model = (p4est_gmt_model_t *)vmodel;
   p4est_gmt_model_sphere_t *sdata;
-  const sphere_geodesic_segment_t  *pco; /* mth geodesic segment */
-  double                            hx, hy; /* width, height */
+  const sphere_geodesic_segment_t *pco; /* mth geodesic segment */
+  double hx, hy;                        /* width, height */
 
-  P4EST_ASSERT (model != NULL);
-  P4EST_ASSERT (m < model->M);
-  sdata = (p4est_gmt_model_sphere_t *) model->model_data;
-  P4EST_ASSERT (sdata != NULL && sdata->geodesics != NULL);
+  P4EST_ASSERT(model != NULL);
+  P4EST_ASSERT(m < model->M);
+  sdata = (p4est_gmt_model_sphere_t *)model->model_data;
+  P4EST_ASSERT(sdata != NULL && sdata->geodesics != NULL);
   pco = sdata->geodesics + m;
-  P4EST_ASSERT (sdata->resolution >= 0);
+  P4EST_ASSERT(sdata->resolution >= 0);
 
   /* In this model we have 6 trees */
-  P4EST_ASSERT (which_tree >= 0 && which_tree <= 5);
+  P4EST_ASSERT(which_tree >= 0 && which_tree <= 5);
 
   /* Check the segment is on the relevant tree */
-  if (pco->which_tree != which_tree) {
+  if (pco->which_tree != which_tree)
+  {
     return 0;
   }
 
   /* We do not refine if target resolution is reached. */
   hx = coord[2] - coord[0];
   hy = coord[3] - coord[1];
-  if (SC_MAX (hx, hy) <= pow (.5, sdata->resolution)) {
+  if (SC_MAX(hx, hy) <= pow(.5, sdata->resolution))
+  {
     return 0;
   }
 
   /* Check if the line segment L between p1 and p2 intersects the edges of
-   * the rectangle. 
+   * the rectangle.
    */
-  
+
   /* Check if L intersects the bottom edge of rectangle */
-  if (lines_intersect(pco->p1x, pco->p1y, pco->p2x, pco->p2y, coord[0], coord[1], coord[2], coord[1])) {
+  if (lines_intersect(pco->p1x, pco->p1y, pco->p2x, pco->p2y, coord[0], coord[1], coord[2], coord[1]))
+  {
     return 1;
   }
   /* Check if L intersects the top edge of rectangle */
-  if (lines_intersect(pco->p1x, pco->p1y, pco->p2x, pco->p2y, coord[0], coord[3], coord[2], coord[3])) {
+  if (lines_intersect(pco->p1x, pco->p1y, pco->p2x, pco->p2y, coord[0], coord[3], coord[2], coord[3]))
+  {
     return 1;
   }
   /* Check if L intersects the left edge of rectangle */
-  if (lines_intersect(pco->p1x, pco->p1y, pco->p2x, pco->p2y, coord[0], coord[1], coord[0], coord[3])) {
+  if (lines_intersect(pco->p1x, pco->p1y, pco->p2x, pco->p2y, coord[0], coord[1], coord[0], coord[3]))
+  {
     return 1;
   }
   /* Check if L intersects the right edge of rectangle */
-  if (lines_intersect(pco->p1x, pco->p1y, pco->p2x, pco->p2y, coord[2], coord[1], coord[2], coord[3])) {
+  if (lines_intersect(pco->p1x, pco->p1y, pco->p2x, pco->p2y, coord[2], coord[1], coord[2], coord[3]))
+  {
     return 1;
   }
-  
+
   /* Check if L is contained in the interior of rectangle.
    * Since we have already ruled out intersections it suffices
    * to check if one of the endpoints of L is in the interior.
-  */
-  if (pco->p1x >= coord[0] && pco->p1x <= coord[2] && pco->p1y >= coord[1] && pco->p1y <= coord[3]) {
+   */
+  if (pco->p1x >= coord[0] && pco->p1x <= coord[2] && pco->p1y >= coord[1] && pco->p1y <= coord[3])
+  {
     return 1;
   }
 
@@ -478,237 +343,48 @@ model_sphere_intersect (p4est_topidx_t which_tree, const double coord[4],
   return 0;
 }
 
-/** If the geodesic between xyz1 and xyz2 intersects the given edge then add this
- *  intersection point to endpoints and increment the corresponding entry in
- *  endpoints_count. To deal with edge cases coming from corners we should only update
- *  if the new intersection point is distinct to previously seen intersection points.
- */
-static void update_endpoints(const double xyz1[3], const double xyz2[3], int edge,
-                              double endpoints[6][2][3], int endpoints_count[6])
-{
-  double p_intersect[3];
-  int detected;
-
-  /* Which cube faces are adjacent to the given edge */
-  const int edge_to_face[12][2] = {
-    {0,1},
-    {0,2},
-    {0,4},
-    {0,5},
-    {1,2},
-    {1,3},
-    {1,5},
-    {2,3},
-    {2,4},
-    {3,4},
-    {3,5},
-    {4,5}
-  }; 
-
-  /* Cube edge endpoint coordinates */
-  const double edge_endpoints[12][2][3] = {
-    {{-0.5, 0.5, -0.5}, {0.5, 0.5, -0.5}}, /* 0,1 edge */
-    {{-0.5, -0.5, -0.5}, {-0.5, 0.5, -0.5}}, /* 0,2 edge */
-    {{-0.5, -0.5, -0.5}, {0.5, -0.5, -0.5}}, /* 0,4 edge*/
-    {{0.5, -0.5, -0.5}, {0.5, 0.5, -0.5}}, /* 0,5 edge */
-    {{-0.5, 0.5, -0.5}, {-0.5, 0.5, 0.5}}, /* 1,2 edge */
-    {{-0.5, 0.5, 0.5}, {0.5, 0.5, 0.5}}, /* 1,3 edge */
-    {{0.5, 0.5, -0.5}, {0.5, 0.5, 0.5}}, /* 1,5 edge */
-    {{-0.5, -0.5, 0.5}, {-0.5, 0.5, 0.5}}, /* 2,3 edge */
-    {{-0.5, -0.5, -0.5}, {-0.5, -0.5, 0.5}}, /* 2,4 edge */
-    {{-0.5, -0.5, 0.5}, {0.5, -0.5, 0.5}}, /* 3,4 edge */
-    {{0.5, -0.5, 0.5}, {0.5, 0.5, 0.5}}, /* 3,5 edge */
-    {{0.5, -0.5, -0.5}, 0.5, -0.5, 0.5} /* 4,5 edge*/
-  }; 
-
-  detected = cone_line_intersection(xyz1, xyz2, edge_endpoints[edge][0], 
-                            edge_endpoints[edge][1], p_intersect);
-  
-  if (detected == 1) {
-    printf("Detection was on edge %d\n", edge);
-    for (int i = 0; i < 2; i++) {
-      if (endpoints_count[edge_to_face[edge][i]] == 0) { 
-        /* Record first endpoint */
-        endpoints[edge_to_face[edge][i]][0][0] = p_intersect[0];
-        endpoints[edge_to_face[edge][i]][0][1] = p_intersect[1];
-        endpoints[edge_to_face[edge][i]][0][2] = p_intersect[2];
-        endpoints_count[edge_to_face[edge][i]] += 1; /* update count */
-      }
-      if (endpoints_count[edge_to_face[edge][i]] == 1) { 
-        /* Check if distinct from first endpoint */
-        if ( fabs(endpoints[edge_to_face[edge][i]][0][0] - p_intersect[0]) > SC_EPS
-            || fabs(endpoints[edge_to_face[edge][i]][0][1] - p_intersect[1]) > SC_EPS
-            || fabs(endpoints[edge_to_face[edge][i]][0][2] - p_intersect[2]) > SC_EPS ) 
-        {
-          /* Record second endpoint */
-          endpoints[edge_to_face[edge][i]][1][0] = p_intersect[0];
-          endpoints[edge_to_face[edge][i]][1][1] = p_intersect[1];
-          endpoints[edge_to_face[edge][i]][1][2] = p_intersect[2];
-          endpoints_count[edge_to_face[edge][i]] += 1; /* update count */
-        }
-      }
-    }
-  }
-}
-
 /** The sphere model refines a spherical mesh based on geodesics. More specifically,
  * squares in the mesh are recursively refined as long as they intersect a geodesic and
  * have refinement level less than the desired resolution. An example application is
  * refining a map of the globe based on coastlines.
- * 
+ *
  * A geodesic is represented by its endpoints given in spherical coordinates. We take
- * the convention described here https://en.wikipedia.org/wiki/Spherical_coordinate_system 
+ * the convention described here https://en.wikipedia.org/wiki/Spherical_coordinate_system
  * so that a spherical coordinate is a pair (phi, theta) where:
  *  0 <= theta <= 180     is the polar angle
  *  0 <= phi <= 360   is the azimuth
  * The input is a CSV file where each line
  *    phi1,theta1,phi2,theta2
  * represents a geodesic between endpoints (phi1, theta1) and (phi2, theta2).
- * 
+ *
  * \warning Currently geodesics are assumed not to cross faces. Full geodesic support will
  * be implemented soon.
- * 
+ *
  * \param[in] resolution maximum refinement level
- * 
-*/
-p4est_gmt_model_t  *
-p4est_gmt_model_sphere_new (int resolution)
+ *
+ */
+p4est_gmt_model_t *
+p4est_gmt_model_sphere_new(int resolution)
 {
-  p4est_gmt_model_t  *model = P4EST_ALLOC_ZERO (p4est_gmt_model_t, 1);
+  p4est_gmt_model_t *model = P4EST_ALLOC_ZERO(p4est_gmt_model_t, 1);
   p4est_gmt_model_sphere_t *sdata = NULL;
-  sphere_geodesic_segment_t *p;
-  FILE               *fp;
-  /* The following variables get reused for each geodesic we read in. */
-  double angular1[2], xyz1[3], rst1[3]; /* angular, cartesian, and tree-local coords respectively*/
-  double angular2[2], xyz2[3], rst2[3];
-  int which_tree_1, which_tree_2;
-  int n_geodesics, capacity; /* capacity is the size of our dynamic array */
-  double endpoints[6][2][3]; /* stores endpoints of split geodesics in cartesian coords */
-  int endpoints_count[6]; /* counts endpoints of split geodesics assigned to each face */
+  int n_geodesics;
 
   /* the sphere model lives on the cube surface reference */
-  model->conn = p4est_connectivity_new_cubed ();
+  model->conn = p4est_connectivity_new_cubed();
   model->output_prefix = "sphere";
-  model->model_data = sdata = P4EST_ALLOC (p4est_gmt_model_sphere_t, 1);
+  model->model_data = sdata = P4EST_ALLOC(p4est_gmt_model_sphere_t, 1);
 
-  /* Load geodesics */
-  n_geodesics = 0; /* Start with 0 and allocate memory as needed */
-  capacity = 1;
-  p = sdata->geodesics = P4EST_ALLOC (sphere_geodesic_segment_t, capacity);
+  /* Read in precomputed geodesic segments */
+  FILE *geodesic_file = sc_fopen("geodesics", "r", "opening geodesics file");
+  sc_fread(&n_geodesics, sizeof(int), 1, geodesic_file, "reading n_geodesics");
+  sdata->geodesics = P4EST_REALLOC(sdata->geodesics, sphere_geodesic_segment_t,
+                                     n_geodesics);
+  sc_fread(sdata->geodesics, sizeof(sphere_geodesic_segment_t), n_geodesics, 
+            geodesic_file, "reading geodesics");
+  fclose(geodesic_file);
 
-  fp = fopen("coastlines.csv","r");
-
-  /* Each iteration reads a single geodesic in angular coordinates */
-  while (fscanf(fp, "%lf,%lf,%lf,%lf", &angular1[0], &angular1[1], &angular2[0], &angular2[1]) != EOF)
-  {
-      printf("Loop\n");
-      /* Expand capacity when necessary */
-      // if (n_geodesics == capacity) {
-      //       capacity = capacity * 2;
-      //       p = sdata->geodesics = P4EST_REALLOC(sdata->geodesics, sphere_geodesic_segment_t, capacity);
-      // }
-      while (n_geodesics + 5 >= capacity) { /* We split a geodesic into less than 5 faces */
-          capacity = capacity * 2;
-          p = sdata->geodesics = P4EST_REALLOC(sdata->geodesics, sphere_geodesic_segment_t, capacity);
-      }
-
-      /* Convert to cartesian coordinates */
-      angular_to_cube(angular1, xyz1);
-      angular_to_cube(angular2, xyz2);
-      printf("Scanned 1: %f, %f, %f\n", xyz1[0], xyz1[1], xyz1[2]);
-      printf("Scanned 2: %f, %f, %f\n", xyz2[0], xyz2[1], xyz2[2]);
-      
-      /* Find which face the geodesic endpoints belong to */
-      which_tree_1 = point_to_tree(xyz1);
-      which_tree_2 = point_to_tree(xyz2);
-
-      if (which_tree_1 == which_tree_2) { /* Geodesic is contained on one face*/
-        /* Convert to tree-local coordinates*/
-        p4est_geometry_cubed_Y(xyz1, rst1, which_tree_1);
-        p4est_geometry_cubed_Y(xyz2, rst2, which_tree_2);
-
-        /* Store geodesic as a sphere_geodesic_segment_t */
-        p[n_geodesics].which_tree = which_tree_1;
-        p[n_geodesics].p1x = rst1[0];
-        p[n_geodesics].p1y = rst1[1];
-        p[n_geodesics].p2x = rst2[0];
-        p[n_geodesics].p2y = rst2[1];
-
-        n_geodesics++;
-      }
-      else { /* Geodesic spans multiple faces, so we must split geodesic into segments*/
-        /* Reset the mapping {trees : {endpoints}} */
-        memset(endpoints_count, 0, sizeof(endpoints_count[0]) * 6);
-        memset(endpoints, 0.0, sizeof(endpoints[0][0][0]) * 6 * 2 * 3);
-
-        /* Add endpoints */
-        endpoints_count[which_tree_1] += 1;
-        endpoints[which_tree_1][0][0] = xyz1[0];
-        endpoints[which_tree_1][0][1] = xyz1[1];
-        endpoints[which_tree_1][0][2] = xyz1[2];
-
-        endpoints_count[which_tree_2] += 1;
-        endpoints[which_tree_2][0][0] = xyz2[0];
-        endpoints[which_tree_2][0][1] = xyz2[1];
-        endpoints[which_tree_2][0][2] = xyz2[2];
-
-        /* For the 12 edges of the cube compute intersection points and add them to mapping */
-        for (int edge = 0; edge < 12; edge++) {
-            /* Compute the intersection of geodesic with the given edge*/
-            update_endpoints(xyz1, xyz2, edge, endpoints, endpoints_count);
-        }
-
-        for (int tree = 0; tree < 6; tree++) {
-          if (endpoints_count[tree] == 0) {
-            printf("Continuing on tree %d\n", tree);
-            continue; /* The geodesic does not cross this cube face */
-          }
-          if (endpoints_count[tree] == 1) {
-            printf("One point on tree %d\n", tree);
-            /* The geodesic has an endpoint on the edge of this face (edge case) */
-            xyz1[0] = endpoints[tree][0][0];
-            xyz1[1] = endpoints[tree][0][1];
-            xyz1[2] = endpoints[tree][0][2];
-            xyz2[0] = endpoints[tree][0][0];
-            xyz2[1] = endpoints[tree][0][1];
-            xyz2[2] = endpoints[tree][0][2];
-          }
-          if (endpoints_count[tree] == 2) {
-            printf("Two poins on tree %d\n", tree);
-            printf("Point one: %f, %f, %f\n", endpoints[tree][0][0], endpoints[tree][0][1], endpoints[tree][0][2]);
-            printf("Point two: %f, %f, %f\n", endpoints[tree][1][0], endpoints[tree][1][1], endpoints[tree][1][2]);
-            /* The geodesic has a generic segment on this face */
-            /* Set xyz1 and xyz2 to computed endpoints*/
-            xyz1[0] = endpoints[tree][0][0];
-            xyz1[1] = endpoints[tree][0][1];
-            xyz1[2] = endpoints[tree][0][2];
-            xyz2[0] = endpoints[tree][1][0];
-            xyz2[1] = endpoints[tree][1][1];
-            xyz2[2] = endpoints[tree][1][2];
-          }
-
-          /* Convert to tree-local coordinates*/
-          p4est_geometry_cubed_Y(xyz1, rst1, tree);
-          p4est_geometry_cubed_Y(xyz2, rst2, tree);
-
-          /* Store geodesic as a sphere_geodesic_segment_t */
-          p[n_geodesics].which_tree = tree;
-          p[n_geodesics].p1x = rst1[0];
-          p[n_geodesics].p1y = rst1[1];
-          p[n_geodesics].p2x = rst2[0];
-          p[n_geodesics].p2y = rst2[1];
-
-          n_geodesics++;
-        }
-      }
-  }
-
-  /* Free extra capacity */
-  p = sdata->geodesics = P4EST_REALLOC(sdata->geodesics, sphere_geodesic_segment_t, n_geodesics);
-  
-  fclose(fp); /* Finished loading geodesics */
   sdata->num_geodesics = model->M = n_geodesics; /* Set final geodesic count */
-  printf("n_geodesics %d\n", n_geodesics);
 
   /* Assign resolution, intersector and destructor */
   sdata->resolution = resolution;
@@ -717,7 +393,7 @@ p4est_gmt_model_sphere_new (int resolution)
 
   /* Assign geometry */
   /* Note: the problem with the following is that it allocates memory externally,
-   * rather than in sgeom. 
+   * rather than in sgeom.
    */
   model->model_geom = p4est_geometry_new_sphere2d(model->conn, 1.0);
 
@@ -725,17 +401,18 @@ p4est_gmt_model_sphere_new (int resolution)
   return model;
 }
 
-void
-p4est_gmt_model_destroy (p4est_gmt_model_t * model)
+void p4est_gmt_model_destroy(p4est_gmt_model_t *model)
 {
-  if (model->destroy_data != NULL) {
+  if (model->destroy_data != NULL)
+  {
     /* only needed for non-trivial free code */
-    model->destroy_data (model->model_data);
+    model->destroy_data(model->model_data);
   }
-  else {
+  else
+  {
     /* the default clears a standard allocation or respects NULL */
-    P4EST_FREE (model->model_data);
+    P4EST_FREE(model->model_data);
   }
   p4est_geometry_destroy(model->model_geom);
-  P4EST_FREE (model);
+  P4EST_FREE(model);
 }

--- a/example/gmt/gmt_models.c
+++ b/example/gmt/gmt_models.c
@@ -29,7 +29,10 @@ model_set_geom (p4est_gmt_model_t * model,
                 const char *name, p4est_geometry_X_t X)
 {
   model->sgeom.name = name;
-  model->sgeom.user = model;
+  //TODO: in p4est_geometry_connectivity_X user is assumed to point to
+  //the relevant connectivity. The following line will cause geometries
+  // to violate that assumption.
+  model->sgeom.user = model; 
   model->sgeom.X = X;
   model->sgeom.destroy = NULL;
   model->model_geom = &model->sgeom;
@@ -201,21 +204,47 @@ p4est_gmt_model_latlong_new (p4est_gmt_model_latlong_params_t * params)
   return model;
 }
 
+/** Represents the intersection of a geodesic with one of the cubed
+ * connectivity faces.
+ * 
+ * The endpoints p1 and p2 are given in tree-local coordinates and
+ * in local coordinates the geodesic is just the line segment between
+ * them.
+*/
+typedef struct sphere_geodesic_segment
+{
+  int                 which_tree;
+  double              p1x, p1y, p2x, p2y;
+} sphere_geodesic_segment_t;
+
 typedef struct p4est_gmt_model_sphere
 {
-  int                 resolution;
-  size_t              num_geodesics;
-  double             *geodesics;
+  int                         resolution;
+  size_t                      num_geodesics;
+  sphere_geodesic_segment_t  *geodesics;
 }
 p4est_gmt_model_sphere_t;
+
+static void
+model_sphere_destroy_data (void *vmodel_data)
+{
+  p4est_gmt_model_sphere_t *sdata = (p4est_gmt_model_sphere_t *) vmodel_data;
+  P4EST_FREE (sdata->geodesics);
+  P4EST_FREE (sdata);
+}
 
 /* Convert from angular coordinates to corresponding point on cube face*/
 static void angular_to_cube(const double angular[2], double xyz[3]) {
     double inf_norm;
+    double phi, theta;
 
-    xyz[0] = sin(angular[1]) * cos(angular[0]);
-    xyz[1] = sin(angular[1]) * sin(angular[0]);
-    xyz[2] = cos(angular[1]);
+    /* Convert to radians*/
+    phi = angular[0]*M_PI/180.0;
+    theta = angular[1]*M_PI/180.0;
+
+    xyz[0] = sin(theta) * cos(phi);
+    xyz[1] = sin(theta) * sin(phi);
+    xyz[2] = cos(theta);
 
     inf_norm = fmax(fabs(xyz[0]), fmax(fabs(xyz[1]), fabs(xyz[2])))*2.0;
     xyz[0] /= inf_norm;
@@ -243,7 +272,7 @@ static int point_to_tree(const double xyz[3]) {
 
 /**
  * coordinate transformation from the surface of cube [-0.5,0.5]x[-0.5,0.5]
- * to AMR space
+ * to tree-local coordinates. This is the inverse of p4est_geometry_cubed_X.
  *
  * \param[in]  xyz  cartesian coordinates in physical space
  * \param[out] rst  coordinates in AMR space : [0,1]^3
@@ -286,32 +315,53 @@ static void p4est_geometry_cubed_Y(const double xyz[3], double rst[3]) {
     }
 }
 
+/** Returns 1 if the line segments intersect, otherwise 0 */
+static int lines_intersect(double p0_x, double p0_y, double p1_x, double p1_y, 
+    double p2_x, double p2_y, double p3_x, double p3_y)
+{
+    double s1_x, s1_y, s2_x, s2_y;
+    s1_x = p1_x - p0_x;     s1_y = p1_y - p0_y;
+    s2_x = p3_x - p2_x;     s2_y = p3_y - p2_y;
+
+    double s, t;
+    s = (-s1_y * (p0_x - p2_x) + s1_x * (p0_y - p2_y)) / (-s2_x * s1_y + s1_x * s2_y);
+    t = ( s2_x * (p0_y - p2_y) - s2_y * (p0_x - p2_x)) / (-s2_x * s1_y + s1_x * s2_y);
+
+    if (s >= 0 && s <= 1 && t >= 0 && t <= 1)
+    {
+        // Collision detected
+        return 1;
+    }
+
+    return 0; // No collision
+}
+
 static int
 model_sphere_intersect (p4est_topidx_t which_tree, const double coord[4],
                          size_t m, void *vmodel)
 {
   p4est_gmt_model_t  *model = (p4est_gmt_model_t *) vmodel;
   p4est_gmt_model_sphere_t *sdata;
-  const double       *pco;
-  double              hx, hy;
-  double              xyz1[3], xyz2[3]; // Cube coordinates
-  double              rst1[3], rst2[3]; // AMR coordinates
-  double              x1, y1, x2, y2; // AMR coordinates (readability)
-  double              slope, slope_inv, x, y;
+  const sphere_geodesic_segment_t  *pco; /* mth geodesic segment */
+  double                            hx, hy; /* width, height */
 
   P4EST_ASSERT (model != NULL);
   P4EST_ASSERT (m < model->M);
-  sdata = (p4est_gmt_model_synth_t *) model->model_data;
+  sdata = (p4est_gmt_model_sphere_t *) model->model_data;
   P4EST_ASSERT (sdata != NULL && sdata->geodesics != NULL);
-  pco = sdata->geodesics + 4 * m; /* Each geodesic is 4 doubles*/
+  pco = sdata->geodesics + m;
   P4EST_ASSERT (sdata->resolution >= 0);
 
   /* In this model we have 6 trees */
   P4EST_ASSERT (which_tree >= 0 && which_tree <= 5);
 
+  /* Check the segment is on the relevant tree */
+  if (pco->which_tree != which_tree) {
+    return 0;
+  }
+
   /* Rectangle coordinates are in [0, 1] for the numbered reference tree and
    * stored as { lower left x, lower left y, upper right x, upper right y }. */
-
   /* We do not refine if target resolution is reached. */
   hx = coord[2] - coord[0];
   hy = coord[3] - coord[1];
@@ -319,59 +369,32 @@ model_sphere_intersect (p4est_topidx_t which_tree, const double coord[4],
     return 0;
   }
 
-  /* Convert geodesics endpoints to points on cube */
-  angular_to_cube(pco, xyz1);
-  angular_to_cube(pco+2, xyz2);
-
-  /* Convert to AMR coordinates*/
-  p4est_geometry_cubed_Y(xyz1, rst1);
-  x1 = rst1[0];
-  y1 = rst1[1];
-  p4est_geometry_cubed_Y(xyz2, rst2);
-  x2 = rst2[0];
-  y2 = rst2[1];
-
-  /* Check if the line segment L between (x1,y1) and (x2,y2)
-   * intersects the edges of the rectangle. To avoid avoid dividing
-   * by zero we have to distinguish the cases when L is vertical or
-   * horizontal. */
-
-  /* L is not vertical */
-  if (!(x2-x1 < SC_EPS)) {
-    slope = (y2-y1)/(x2-x1);
-    /* Check if L intersects the left edge of rectangle */
-    y = slope * (coord[0] - x1) + y1;
-    if (y >= coord[1] && y <= coord[3]) {
-      return 1;
-    }
-    /* Check if L intersects the right edge of rectangle */
-    y = slope * (coord[2] - x1) + y1;
-    if (y >= coord[1] && y <= coord[3]) {
-      return 1;
-    }
+  /* Check if the line segment L between p1 and p2 intersects the edges of
+   * the rectangle. 
+   */
+  
+  /* Check if L intersects the bottom edge of rectangle */
+  if (lines_intersect(pco->p1x, pco->p1y, pco->p2x, pco->p2y, coord[0], coord[1], coord[2], coord[1])) {
+    return 1;
   }
-
-  /* L is not horizontal */
-  if (!(y2-y1 < SC_EPS)) {
-    slope_inv = (x2-x1)/(y2-y1);
-    /* Check if L intersects the bottom edge of rectangle */
-    x = slope_inv * (coord[1] - y1) + x1;
-    if (x >= coord[0] && x <= coord[2]) {
-      return 1;
-    }
-
-    /* Check if L intersects the top edge of rectangle */
-    x = slope_inv * (coord[3] - y1) + x1;
-    if (x >= coord[0] && x <= coord[2]) {
-      return 1;
-    }
+  /* Check if L intersects the top edge of rectangle */
+  if (lines_intersect(pco->p1x, pco->p1y, pco->p2x, pco->p2y, coord[0], coord[3], coord[2], coord[3])) {
+    return 1;
+  }
+  /* Check if L intersects the left edge of rectangle */
+  if (lines_intersect(pco->p1x, pco->p1y, pco->p2x, pco->p2y, coord[0], coord[1], coord[0], coord[3])) {
+    return 1;
+  }
+  /* Check if L intersects the right edge of rectangle */
+  if (lines_intersect(pco->p1x, pco->p1y, pco->p2x, pco->p2y, coord[2], coord[1], coord[2], coord[3])) {
+    return 1;
   }
   
   /* Check if L is contained in the interior of rectangle.
    * Since we have already ruled out intersections it suffices
    * to check if one of the endpoints of L is in the interior.
   */
-  if (x1 >= coord[0] && x1 <= coord[2] && y1 >= coord[1] && y1 >= coord[3]) {
+  if (pco->p1x >= coord[0] && pco->p1x <= coord[2] && pco->p1y >= coord[1] && pco->p1y <= coord[3]) {
     return 1;
   }
 
@@ -384,48 +407,88 @@ p4est_gmt_model_sphere_new (int resolution)
 {
   p4est_gmt_model_t  *model = P4EST_ALLOC_ZERO (p4est_gmt_model_t, 1);
   p4est_gmt_model_sphere_t *sdata = NULL;
-  double             *p;
+  sphere_geodesic_segment_t *p;
+  FILE               *fp;
+  //double phi1, theta1, phi2, theta2;
+  double angular1[2], xyz1[3], rst1[3];
+  double angular2[2], xyz2[3], rst2[3];
+  int which_tree_1, which_tree_2;
+
 
   /* the sphere model lives on the unit square as reference domain */
   model->conn = p4est_connectivity_new_cubed ();
-
-  /* load model properties */
-  model->model_data = NULL;     /* <- Load something from params->load_filename,
-                                   also deep copy the parameters into it. */
-
-  /* set virtual functions */
-  model->intersect = model_sphere_intersect;
-  model->destroy_data = NULL;   /* <- needs to free whatever is in model_data */
-
-  //model_set_geom (model, params->output_prefix, model_latlong_geom_X);
-
   model->output_prefix = "sphere";
   model->model_data = sdata = P4EST_ALLOC (p4est_gmt_model_sphere_t, 1);
 
-  //TODO: Load geodesics
-  int n_geodesics = 2;
+  /* Load geodesics */
+  int n_geodesics = 406708;
   sdata->num_geodesics = model->M = n_geodesics;
-  /* A geodesic is given by 4 consecutive doubles phi1, theta1, phi2, theta2 */
-  p = sdata->geodesics = P4EST_ALLOC (double, n_geodesics*4);
-  /* First geodesics*/
-  //[21.80140948635181, 69.62547281126481] [57.9946167919165, 49.70211194894342]
-  p[0] = 21.80140948635181;
-  p[1] = 69.62547281126481;
-  p[2] = 57.9946167919165;
-  p[3] = 49.70211194894342;
-  /* Second geodesics*/
-  //[21.80140948635181, 33.946295027753955] [57.9946167919165, 78.0305368753927]
-  p[4] = 21.80140948635181;
-  p[5] = 33.946295027753955;
-  p[6] = 57.9946167919165;
-  p[7] = 78.0305368753927;
+  printf("Allocating\n");
+  //p = sdata->geodesics = P4EST_ALLOC (double, n_geodesics*4);
+  p = sdata->geodesics = P4EST_ALLOC (sphere_geodesic_segment_t, n_geodesics);
+  printf("Allocated\n");
 
+  fp = fopen("coastlines.csv","r");
+  printf("File opened\n");
+
+  int r = 0;
+  while (!feof(fp) && r < n_geodesics)
+  {
+      /* Read geodesic in angular coordinates */
+      fscanf(fp, "%lf,%lf,%lf,%lf", &angular1[0], &angular1[1], &angular2[0], &angular2[1]);
+      // printf("Scanned %f, %f, %f, %f\n", angular1[0], angular1[1], angular2[0], angular2[1]);
+
+      /* Convert to cartesian coordinates */
+      angular_to_cube(angular1, xyz1);
+      angular_to_cube(angular2, xyz2);
+      // printf("Cube coords 1: %f, %f, %f\n", xyz1[0], xyz1[1], xyz1[2]);
+      // printf("Cube coords 2: %f, %f, %f\n", xyz2[0], xyz2[1], xyz2[2]);
+
+
+      /* Find which face the geodesic endpoints belong to */
+      which_tree_1 = point_to_tree(xyz1);
+      which_tree_2 = point_to_tree(xyz2);
+      P4EST_ASSERT(which_tree_1 == which_tree_2);
+
+      /* TODO eventually this should support inter-face geodesics.
+       * Currently we require that geodesics do not cross faces.
+       */
+
+      /* Convert to tree-local coordinates*/
+      p4est_geometry_cubed_Y(xyz1, rst1);
+      p4est_geometry_cubed_Y(xyz2, rst2);
+      // printf("Local coords 1: %f, %f\n", rst1[0], rst1[1]);
+      // printf("Local coords 2: %f, %f\n", rst2[0], rst2[1]);
+      // printf("\n");
+
+      /* Store geodesic as a sphere_geodesic_segment_t */
+      p[r].which_tree = which_tree_1;
+      p[r].p1x = rst1[0];
+      p[r].p1y = rst1[1];
+      p[r].p2x = rst2[0];
+      p[r].p2y = rst2[1];
+      
+      r += 1;
+  }
+
+  fclose(fp); /* Finished loading geodesics */
+  
+  /* Assign resolution, intersector and destructor */
   sdata->resolution = resolution;
-
-  //TODO
-  model->destroy_data = model_synth_destroy_data;
+  model->destroy_data = model_sphere_destroy_data;
   model->intersect = model_sphere_intersect;
-  model_set_geom (model, model->output_prefix, model_synth_geom_X);
+
+  /* Assign geometry */
+  //p4est_geometry_t *temp = p4est_geometry_new_sphere2d(model->conn, 1.0);
+  //model->sgeom = *temp; /* We cannot directly create the geometry in sgeom */
+  //model->model_geom = &model->sgeom;
+  //p4est_geometry_destroy(temp); /* Delete temporary  */
+
+  
+  /* Note: the problem with the following is that it allocates memory externally,
+   * rather than in sgeom. The destructor then doesn't know about this
+  */
+  model->model_geom = p4est_geometry_new_sphere2d(model->conn, 1.0);
 
   /* the model is ready */
   return model;
@@ -442,5 +505,6 @@ p4est_gmt_model_destroy (p4est_gmt_model_t * model)
     /* the default clears a standard allocation or respects NULL */
     P4EST_FREE (model->model_data);
   }
+  p4est_geometry_destroy(model->model_geom);
   P4EST_FREE (model);
 }

--- a/example/gmt/gmt_models.h
+++ b/example/gmt/gmt_models.h
@@ -73,6 +73,9 @@ p4est_gmt_model_latlong_params_t;
 p4est_gmt_model_t  *p4est_gmt_model_latlong_new
   (p4est_gmt_model_latlong_params_t * params);
 
+/** Create a specific sphere model*/
+p4est_gmt_model_t  * p4est_gmt_model_sphere_new (int resolution);
+
 /** Destroy model */
 void                p4est_gmt_model_destroy (p4est_gmt_model_t * model);
 

--- a/example/simple/simple2.c
+++ b/example/simple/simple2.c
@@ -42,7 +42,7 @@
  *        o rotwrap   Refinement on the unit square with weird periodic b.c.
  *        o circle    Refinement on a 6-tree donut-like circle.
  *        o drop      Refinement on a 5-trees geometry with an inner hole.
- *        o icosahedron   Refinement on the sphere
+ *        o icosahedron   Refinement on the icosahedron sphere with geometry.
  *        o shell2d       Refinement on a 2d shell with geometry.
  *        o disk2d        Refinement on a 2d disk with geometry.
  *        o bowtie    Refinement on a 2-tree bowtie domain.

--- a/example/simple/simple2.c
+++ b/example/simple/simple2.c
@@ -46,6 +46,7 @@
  *        o shell2d       Refinement on a 2d shell with geometry.
  *        o disk2d        Refinement on a 2d disk with geometry.
  *        o bowtie    Refinement on a 2-tree bowtie domain.
+ *        o sphere2d      Refinement on a 6-tree sphere surface with geometry.
  */
 
 #include <p4est_bits.h>
@@ -76,6 +77,7 @@ typedef enum
   P4EST_CONFIG_SHELL2D,
   P4EST_CONFIG_DISK2D,
   P4EST_CONFIG_BOWTIE,
+  P4EST_CONFIG_SPHERE2D,
   P4EST_CONFIG_LAST
 }
 simple_config_t;
@@ -293,7 +295,7 @@ main (int argc, char **argv)
     "   Configuration can be any of\n"
     "      unit|brick|three|evil|evil3|pillow|moebius|\n"
     "         star|cubed|disk|xdisk|ydisk|pdisk|periodic|\n"
-    "         rotwrap|circle|drop|icosahedron|shell2d|disk2d|bowtie\n"
+    "         rotwrap|circle|drop|icosahedron|shell2d|disk2d|bowtie|sphere2d\n"
     "   Level controls the maximum depth of refinement\n";
   wrongusage = 0;
   config = P4EST_CONFIG_NULL;
@@ -363,6 +365,9 @@ main (int argc, char **argv)
     }
     else if (!strcmp (argv[1], "bowtie")) {
       config = P4EST_CONFIG_BOWTIE;
+    }
+    else if (!strcmp (argv[1], "sphere2d")) {
+      config = P4EST_CONFIG_SPHERE2D;
     }
     else {
       wrongusage = 1;
@@ -457,6 +462,10 @@ main (int argc, char **argv)
   }
   else if (config == P4EST_CONFIG_BOWTIE) {
     connectivity = p4est_connectivity_new_bowtie ();
+  }
+  else if (config == P4EST_CONFIG_SPHERE2D) {
+    connectivity = p4est_connectivity_new_cubed ();
+    geom = p4est_geometry_new_sphere2d (connectivity, 1.0);
   }
   else {
     connectivity = p4est_connectivity_new_unitsquare ();

--- a/src/p4est_geometry.c
+++ b/src/p4est_geometry.c
@@ -109,7 +109,9 @@ p4est_geometry_destroy (p4est_geometry_t * geom)
 
 /**
  * Geometric coordinate transformation for default geometry created with
- * \ref p4est_geometry_new_connectivity.
+ * \ref p4est_geometry_new_connectivity. May also be used for user 
+ * convenience to build custom geometric coordinate transforms. See for
+ * example \ref p4est_geometry_sphere2d_X or \ref p4est_geometry_disk2d_X.
  *
  * Define the geometric transformation from logical space (where AMR
  * is performed) to the physical space.
@@ -119,6 +121,9 @@ p4est_geometry_destroy (p4est_geometry_t * geom)
  * \param[in]  abc        coordinates in AMR space : [0,1]^3
  * \param[out] xyz        cartesian coordinates in physical space after geometry
  *
+ * \warning The associated geometry is assumed to have a connectivity
+ * as its *user field, and this connectivity is assumed to have vertex
+ * information in its *tree_to_vertex field.
  */
 static void
 p4est_geometry_connectivity_X (p4est_geometry_t * geom,

--- a/src/p4est_geometry.c
+++ b/src/p4est_geometry.c
@@ -118,7 +118,9 @@ p4est_geometry_connectivity_X (p4est_geometry_t * geom,
   /* these are reference coordinates in [0, 1]**d */
   eta_x = abc[0];
   eta_y = abc[1];
+#ifdef P4_TO_P8
   eta_z = abc[2];
+#endif
 
   /* bi/trilinear transformation */
   for (j = 0; j < 3; ++j) {

--- a/src/p4est_geometry.c
+++ b/src/p4est_geometry.c
@@ -540,8 +540,6 @@ p4est_geometry_new_disk2d (p4est_connectivity_t * conn, double R0, double R1)
  * \param[in]  rst        coordinates in AMR space : [0,1]^3
  * \param[out] xyz        cartesian coordinates in physical space after geometry
  *
- * Note abc[3] contains cartesian coordinates in logical
- * vertex space (before geometry).
  */
 static void
 p4est_geometry_sphere2d_X (p4est_geometry_t * geom,
@@ -551,48 +549,10 @@ p4est_geometry_sphere2d_X (p4est_geometry_t * geom,
   const struct p4est_geometry_builtin_sphere2d *sphere2d
     = &((p4est_geometry_builtin_t *) geom)->p.sphere2d;
   double              R;
-  double              abc[3];
 
   /* transform from the AMR space into physical space using bi/trilinear
    transformation of connectivity*/
-  //p4est_geometry_connectivity_X (geom, which_tree, rst, abc);
-
-  /* convert to unit cube coordinates */
-  //TODO: it should be possible to do this from the connectivity (and reuse code)
-  switch (which_tree) {
-  case 0:
-    xyz[0] = rst[1];
-    xyz[1] = rst[0];
-    xyz[2] = 0.0;
-    break;
-  case 1:
-    xyz[0] = rst[1];
-    xyz[1] = 1.0;
-    xyz[2] = rst[0];
-    break;
-  case 2:
-    xyz[0] = 0.0;
-    xyz[1] = rst[1];
-    xyz[2] = rst[0];
-    break;
-  case 3:
-    xyz[0] = rst[0];
-    xyz[1] = rst[1];
-    xyz[2] = 1.0;
-    break;
-  case 4:
-    xyz[0] = rst[0];
-    xyz[1] = 0.0;
-    xyz[2] = rst[1];
-    break;
-  case 5:
-    xyz[0] = 1.0;
-    xyz[1] = rst[0];
-    xyz[2] = rst[1];
-    break;
-  default:
-    SC_ABORT_NOT_REACHED ();
-  }
+  p4est_geometry_connectivity_X (geom, which_tree, rst, xyz);
 
   /* align center with origin */
   xyz[0] -= 0.5;

--- a/src/p4est_geometry.c
+++ b/src/p4est_geometry.c
@@ -107,7 +107,19 @@ p4est_geometry_destroy (p4est_geometry_t * geom)
   }
 }
 
-//TODO comment this function
+/**
+ * Geometric coordinate transformation for default geometry created with
+ * \ref p4est_geometry_new_connectivity.
+ *
+ * Define the geometric transformation from logical space (where AMR
+ * is performed) to the physical space.
+ *
+ * \param[in]  geom       associated geometry
+ * \param[in]  which_tree tree id inside forest
+ * \param[in]  abc        coordinates in AMR space : [0,1]^3
+ * \param[out] xyz        cartesian coordinates in physical space after geometry
+ *
+ */
 static void
 p4est_geometry_connectivity_X (p4est_geometry_t * geom,
                                p4est_topidx_t which_tree,
@@ -169,7 +181,18 @@ p4est_geometry_new_connectivity (p4est_connectivity_t * conn)
 
 #ifndef P4_TO_P8
 
-/* geometric coordinate transformation */
+/**
+ * Geometric coordinate transformation for icosahedron geometry.
+ *
+ * Define the geometric transformation from logical space (where AMR
+ * is performed) to the physical space.
+ *
+ * \param[in]  geom       associated geometry
+ * \param[in]  which_tree tree id inside forest
+ * \param[in]  rst        coordinates in AMR space : [0,1]^3
+ * \param[out] xyz        cartesian coordinates in physical space after geometry
+ *
+ */
 static void
 p4est_geometry_icosahedron_X (p4est_geometry_t * geom,
                               p4est_topidx_t which_tree,
@@ -324,7 +347,18 @@ p4est_geometry_new_icosahedron (p4est_connectivity_t * conn, double R)
 
 }                               /* p4est_geometry_new_icosahedron */
 
-/* geometric coordinate transformation */
+/**
+ * Geometric coordinate transformation for shell2d geometry.
+ *
+ * Define the geometric transformation from logical space (where AMR
+ * is performed) to the physical space.
+ *
+ * \param[in]  geom       associated geometry
+ * \param[in]  which_tree tree id inside forest
+ * \param[in]  rst        coordinates in AMR space : [0,1]^3
+ * \param[out] xyz        cartesian coordinates in physical space after geometry
+ *
+ */
 static void
 p4est_geometry_shell2d_X (p4est_geometry_t * geom,
                           p4est_topidx_t which_tree,
@@ -408,7 +442,7 @@ p4est_geometry_new_shell2d (p4est_connectivity_t * conn, double R2, double R1)
  * Define the geometric transformation from logical space (where AMR
  * is performed) to the physical space.
  *
- * \param[in]  p4est      the forest
+ * \param[in]  geom       associated geometry
  * \param[in]  which_tree tree id inside forest
  * \param[in]  rst        coordinates in AMR space : [0,1]^3
  * \param[out] xyz        cartesian coordinates in physical space after geometry
@@ -535,7 +569,7 @@ p4est_geometry_new_disk2d (p4est_connectivity_t * conn, double R0, double R1)
  * Define the geometric transformation from logical space (where AMR
  * is performed) to the physical space.
  *
- * \param[in]  p4est      the forest
+ * \param[in]  geom       associated geometry
  * \param[in]  which_tree tree id inside forest
  * \param[in]  rst        coordinates in AMR space : [0,1]^3
  * \param[out] xyz        cartesian coordinates in physical space after geometry
@@ -554,12 +588,12 @@ p4est_geometry_sphere2d_X (p4est_geometry_t * geom,
    transformation of connectivity*/
   p4est_geometry_connectivity_X (geom, which_tree, rst, xyz);
 
-  /* align center with origin */
+  /* align cube center with origin */
   xyz[0] -= 0.5;
   xyz[1] -= 0.5;
   xyz[2] -= 0.5;
 
-  /* normalise to length R */
+  /* normalise to radius R sphere */
   R = sphere2d->R;
   double R_on_norm = R/sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1] + xyz[2]*xyz[2]);
   xyz[0] *= R_on_norm;

--- a/src/p4est_geometry.c
+++ b/src/p4est_geometry.c
@@ -555,43 +555,44 @@ p4est_geometry_sphere2d_X (p4est_geometry_t * geom,
 
   /* transform from the AMR space into physical space using bi/trilinear
    transformation of connectivity*/
-  p4est_geometry_connectivity_X (geom, which_tree, rst, abc);
+  //p4est_geometry_connectivity_X (geom, which_tree, rst, abc);
 
   /* convert to unit cube coordinates */
-  // TODO: it should be possible to do this from the connectivity (and reuse code)
-  // switch (which_tree) {
-  // case 0:
-  //   xyz[0] = rst[1];
-  //   xyz[1] = rst[0];
-  //   xyz[2] = 0.0;
-  //   break;
-  // case 1:
-  //   xyz[0] = rst[1];
-  //   xyz[1] = 1.0;
-  //   xyz[2] = rst[0];
-  //   break;
-  // case 2:
-  //   xyz[0] = 0.0;
-  //   xyz[1] = rst[1];
-  //   xyz[2] = rst[0];
-  //   break;
-  // case 3:
-  //   xyz[0] = rst[0];
-  //   xyz[1] = rst[1];
-  //   xyz[2] = 1.0;
-  //   break;
-  // case 4:
-  //   xyz[0] = rst[0];
-  //   xyz[1] = 0.0;
-  //   xyz[1] = rst[1];
-  //   break;
-  // case 5:
-  //   xyz[0] = 1.0;
-  //   xyz[1] = rst[0];
-  //   xyz[2] = rst[1];
-  // default:
-  //   SC_ABORT_NOT_REACHED ();
-  // }
+  //TODO: it should be possible to do this from the connectivity (and reuse code)
+  switch (which_tree) {
+  case 0:
+    xyz[0] = rst[1];
+    xyz[1] = rst[0];
+    xyz[2] = 0.0;
+    break;
+  case 1:
+    xyz[0] = rst[1];
+    xyz[1] = 1.0;
+    xyz[2] = rst[0];
+    break;
+  case 2:
+    xyz[0] = 0.0;
+    xyz[1] = rst[1];
+    xyz[2] = rst[0];
+    break;
+  case 3:
+    xyz[0] = rst[0];
+    xyz[1] = rst[1];
+    xyz[2] = 1.0;
+    break;
+  case 4:
+    xyz[0] = rst[0];
+    xyz[1] = 0.0;
+    xyz[2] = rst[1];
+    break;
+  case 5:
+    xyz[0] = 1.0;
+    xyz[1] = rst[0];
+    xyz[2] = rst[1];
+    break;
+  default:
+    SC_ABORT_NOT_REACHED ();
+  }
 
   /* align center with origin */
   xyz[0] -= 0.5;

--- a/src/p4est_geometry.h
+++ b/src/p4est_geometry.h
@@ -53,7 +53,14 @@ typedef void        (*p4est_geometry_X_t) (p4est_geometry_t * geom,
  */
 typedef void        (*p4est_geometry_destroy_t) (p4est_geometry_t * geom);
 
-/** This structure can be filled or allocated by the user.
+/** Encapsulates a custom transformation from AMR space to 
+ * user defined physical space.
+ * 
+ * Used in \ref p4est_vtk.h to write vtk files for visualization.
+ * In this case *user is assumed to point to a \ref p4est_connectivity.
+ * In general it can be used however the user likes. 
+ * 
+ * This structure can be filled or allocated by the user.
  * p4est will never change its contents.
  */
 struct p4est_geometry

--- a/src/p4est_geometry.h
+++ b/src/p4est_geometry.h
@@ -106,6 +106,19 @@ p4est_geometry_t   *p4est_geometry_new_shell2d (p4est_connectivity_t * conn,
 p4est_geometry_t   *p4est_geometry_new_disk2d (p4est_connectivity_t * conn,
                                                double R0, double R1);
 
+/**
+ * sphere2d geometry associated to cubed connectivity.
+ *
+ * \param[in] R radius of the sphere
+ *
+ *
+ * This geometry is meant to be used with the cubed connectivity
+ * \ref p4est_connectivity_new_cubed, which is a 6-tree connectivity,
+ * to map the sphere.
+ */
+p4est_geometry_t   *p4est_geometry_new_sphere2d (p4est_connectivity_t * conn,
+                                               double R);
+
 SC_EXTERN_C_END;
 
 #endif /* !P4EST_GEOMETRY_H */


### PR DESCRIPTION
# gmt sphere Draft PR 

This builds another example on top of the search based refinement in feature-gmt. More specifically it refines the spherical geometry based on geodesics on the surface of the sphere. Geodesics are read in from a csv where each line `phi1,theta1,phi2,theta2` represents the two endpoints of a geodesic in spherical coordinates.

The options handling is not very elegant at the moment so I will fix this. I will also clean up the documentation to better explain the workflow of preparing a dataset for use.



