### PR TITLE
cmake: P4EST_BUILD_TESTING to allow parent project control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ HOMEPAGE_URL https://www.p4est.org/
 DESCRIPTION "p4est manages a collection---a forest---of octrees in parallel."
 VERSION ${PROJECT_VERSION})
 
-include(CTest)
+enable_testing()
 
 # --- user options
 
@@ -69,9 +69,9 @@ add_subdirectory(src)
 
 # --- optional test and install
 
-if(BUILD_TESTING)
+if(P4EST_BUILD_TESTING)
   add_subdirectory(test)
-endif(BUILD_TESTING)
+endif()
 
 # --- packaging
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,6 +1,8 @@
 option(enable_p6est "build p6est" on)
 option(enable_p8est "build p8est" on)
 
+option(P4EST_BUILD_TESTING "build p4est testing" on)
+
 option(enable-file-deprecated "use deprecated data file format" off)
 
 option(vtk_binary "VTK binary interface" on)


### PR DESCRIPTION
by using a more specific name like "P4EST_BUILD_TESTING" instead of "BUILD_TESTING" this allows parent projects like Forestclaw to select which tests to build and run. This avoids outdated test dependencies causing a top-level project to fail build/test.

Like libsc, since CDash isn't used, there isn't a need for the overhead of `include(CTest)`.


This does _not_ depend on libsc PR just made.