### PR TITLE
Feature soversion

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -100,7 +100,7 @@ jobs:
   mac:
     runs-on: macos-latest
     name: CMake build on MacOS
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     strategy:
       matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ include(cmake/compilers.cmake)
 
 add_library(p4est)
 set_property(TARGET p4est PROPERTY EXPORT_NAME P4EST)
-set_property(TARGET p4est PROPERTY VERSION ${PROJECT_VERSION})
+set_property(TARGET p4est PROPERTY SOVERSION ${P4EST_SOVERSION})
 target_include_directories(p4est PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -2,6 +2,13 @@ include(CheckIncludeFile)
 include(CheckSymbolExists)
 include(ProcessorCount)
 
+# --- retrieve library interface version from configuration file
+file(STRINGS config/p4est_soversion.in P4EST_SOVERSION_READ
+             REGEX "^[ \t]*P4EST_SOVERSION *= *[0-9:]+")
+string(REGEX REPLACE ".*= *([0-9]+):([0-9]+):([0-9]+)" "\\1.\\2.\\3"
+             P4EST_SOVERSION ${P4EST_SOVERSION_READ})
+message(STATUS "p4est SOVERSION configured as ${P4EST_SOVERSION}")
+
 # on some platforms e.g. ARM, we have to try a few ways to get CPU count > 1 for multi-core systems
 cmake_host_system_information(RESULT Ncpu QUERY NUMBER_OF_PHYSICAL_CORES)
 if(Ncpu LESS 2)

--- a/config/p4est_soversion.in
+++ b/config/p4est_soversion.in
@@ -1,0 +1,7 @@
+# This file contains p4est's .so version in libtool format; see:
+# https://www.gnu.org/software/libtool/manual/libtool.html#Versioning
+# The format is P4EST_SOVERSION = current:revision:age (note the colons)
+
+# This file is included by src/Makefile.am and parsed by cmake/config.cmake.
+
+P4EST_SOVERSION = 2:0:0

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -74,6 +74,9 @@ endif
 # this variable is used for headers that are not publicly installed
 P4EST_CPPFLAGS =
 
+# read the .so version from configuration file
+include config/p4est_soversion.in
+
 justlibs-local: src/libp4est.la
 lib_LTLIBRARIES += src/libp4est.la
 src_libp4est_la_SOURCES = \
@@ -82,7 +85,7 @@ src_libp4est_la_SOURCES = \
 src_libp4est_la_CPPFLAGS = $(AM_CPPFLAGS) $(P4EST_CPPFLAGS)
 ## This is the official API versioning scheme of libtool.  Please see:
 ## Read https://www.gnu.org/software/libtool/manual/libtool.html#Versioning
-src_libp4est_la_LDFLAGS = -version-info 2:0:0
+src_libp4est_la_LDFLAGS = -version-info $(P4EST_SOVERSION)
 src_libp4est_la_LIBADD = @P4EST_SC_LIBADD@
 EXTRA_src_libp4est_la_DEPENDENCIES = @P4EST_SC_EDEPS@
 


### PR DESCRIPTION
# Read SOVERSION from configuration file.

We place the library API version by the libtool convention in one global configuration file.
This is sourced from both the autoconf and cmake build processes.

In passing increase the CI runtime for CMake on MacOS from 20 to 25 minutes.