### PR TITLE
file_info: Fixes and simplifications

### DIFF
--- a/src/p4est_io.c
+++ b/src/p4est_io.c
@@ -1503,12 +1503,33 @@ p4est_file_read_field (p4est_file_context_t * fc, size_t quadrant_size,
   return retfc;
 }
 
+/** This function checks for successful completion and cleans up if required.
+ *
+ * \param[in,out]  file     The MPI file that will be closed in case of an error.
+ * \param[in]      eclass   The eclass that indicates if an error occured.
+ *                          \b eclass is an MPI, libsc or p4est_file error
+ *                          code.
+ * \param[out]     errcode  The error code that is obtained by converting
+ *                          \b eclass to p4est_file error code.
+ * \return                  -1 if \b eclass indicates an error,
+ *                          0 otherwise.
+ */
+static int
+p4est_file_info_cleanup (sc_MPI_File * file, int eclass, int *errcode)
+{
+  if (!P4EST_FILE_IS_SUCCESS (eclass)) {
+    p4est_file_error_cleanup (file);
+    p4est_file_error_code (eclass, errcode);
+    return -1;
+  }
+  return 0;
+}
+
 int
 p4est_file_info (p4est_t * p4est, const char *filename,
                  char *user_string, sc_array_t * data_sections, int *errcode)
 {
   int                 mpiret, eclass;
-  int                 retval;
   int                 count, count_error;
   long                long_header;
   size_t              current_size, num_pad_bytes;
@@ -1535,10 +1556,9 @@ p4est_file_info (p4est_t * p4est, const char *filename,
   *errcode = eclass = sc_MPI_SUCCESS;   /* MPI defines MPI_SUCCESS to equal 0. */
   file = sc_MPI_FILE_NULL;
 
-  if ((retval =
-       sc_io_open (p4est->mpicomm, filename, SC_IO_READ,
-                   sc_MPI_INFO_NULL, &file)) != sc_MPI_SUCCESS) {
-  }
+  /* we do not use the general error handling since we can not close the file */
+  eclass = sc_io_open (p4est->mpicomm, filename, SC_IO_READ,
+                       sc_MPI_INFO_NULL, &file);
 
   if (!P4EST_FILE_IS_SUCCESS (eclass)) {
     *errcode = eclass;
@@ -1550,7 +1570,7 @@ p4est_file_info (p4est_t * p4est, const char *filename,
   /* read file metadata on root rank */
   P4EST_ASSERT (P4EST_FILE_IS_SUCCESS (eclass));
   if (p4est->mpirank == 0) {
-    if ((retval = sc_io_read_at (file, 0, metadata,
+    if ((eclass = sc_io_read_at (file, 0, metadata,
                                  P4EST_FILE_METADATA_BYTES, sc_MPI_BYTE,
                                  &count))
         != sc_MPI_SUCCESS) {
@@ -1564,9 +1584,8 @@ p4est_file_info (p4est_t * p4est, const char *filename,
   }
   mpiret = sc_MPI_Bcast (&eclass, 1, sc_MPI_INT, 0, p4est->mpicomm);
   SC_CHECK_MPI (mpiret);
-  if (!P4EST_FILE_IS_SUCCESS (eclass)) {
-    p4est_file_error_cleanup (&file);
-    p4est_file_error_code (*errcode, errcode);
+  if (p4est_file_info_cleanup (&file, eclass, errcode)) {
+    /* an error has occured and a clean up was performed */
     return -1;
   }
   mpiret = sc_MPI_Bcast (&count_error, 1, sc_MPI_INT, 0, p4est->mpicomm);
@@ -1576,10 +1595,8 @@ p4est_file_info (p4est_t * p4est, const char *filename,
       P4EST_LERROR (P4EST_STRING
                     "_file_info: read count error for file metadata reading");
     }
-    *errcode = P4EST_FILE_ERR_COUNT;
-    p4est_file_error_cleanup (&file);
-    p4est_file_error_code (*errcode, errcode);
-    return -1;
+    eclass = P4EST_FILE_ERR_COUNT;
+    return p4est_file_info_cleanup (&file, eclass, errcode);
   }
 
   /* broadcast file metadata to all ranks and null-terminate it */
@@ -1593,9 +1610,8 @@ p4est_file_info (p4est_t * p4est, const char *filename,
                                        metadata,
                                        &global_num_quadrants)) !=
       sc_MPI_SUCCESS) {
-    *errcode = P4EST_FILE_ERR_FORMAT;
-    p4est_file_error_code (*errcode, errcode);
-    return p4est_file_error_cleanup (&file);
+    eclass = P4EST_FILE_ERR_FORMAT;
+    return p4est_file_info_cleanup (&file, eclass, errcode);
   }
 
   /* check global number of quadrants */
@@ -1604,9 +1620,8 @@ p4est_file_info (p4est_t * p4est, const char *filename,
       P4EST_LERROR (P4EST_STRING
                     "_file_info: global number of quadrant mismatch");
     }
-    *errcode = P4EST_FILE_ERR_FORMAT;
-    p4est_file_error_code (*errcode, errcode);
-    return p4est_file_error_cleanup (&file);
+    eclass = P4EST_FILE_ERR_FORMAT;
+    return p4est_file_info_cleanup (&file, eclass, errcode);
   }
 
   current_position =
@@ -1616,13 +1631,11 @@ p4est_file_info (p4est_t * p4est, const char *filename,
   if (p4est->mpirank == 0) {
     for (;;) {
       /* read block metadata for current record */
-      mpiret = sc_io_read_at (file, current_position, block_metadata,
+      eclass = sc_io_read_at (file, current_position, block_metadata,
                               P4EST_FILE_FIELD_HEADER_BYTES, sc_MPI_BYTE,
                               &count);
-      *errcode = eclass;
-      if (!P4EST_FILE_IS_SUCCESS (eclass)) {
-        p4est_file_error_code (*errcode, errcode);
-        return p4est_file_error_cleanup (&file);
+      if (p4est_file_info_cleanup (&file, eclass, errcode)) {
+        return -1;
       }
       if (P4EST_FILE_FIELD_HEADER_BYTES != count) {
         /* we did not read the correct number of bytes */
@@ -1687,7 +1700,7 @@ p4est_file_info (p4est_t * p4est, const char *filename,
       p4est_file_get_padding_string (current_size, P4EST_FILE_BYTE_DIV, NULL,
                                      &num_pad_bytes);
       /* read padding bytes */
-      mpiret = sc_io_read_at (file,
+      eclass = sc_io_read_at (file,
                               current_position +
                               P4EST_FILE_FIELD_HEADER_BYTES + current_size,
                               block_metadata, num_pad_bytes, sc_MPI_BYTE,


### PR DESCRIPTION
# file_info: Fixes and simplifications

Proposed changes: Analogously to the ForestClaw PR https://github.com/ForestClaw/forestclaw/pull/301, we introduce the function `p4est_file_info_cleanup` to simplify the error management in the function `p4est_file_info`. In addition, there are some fixes of the error management in `p4est_file_info`.
