### PR TITLE
CMake: Add CTest inclusion

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(CTest)
+
 if(P4EST_HAVE_STDLIB_H)
   check_symbol_exists(random stdlib.h P4EST_HAVE_RANDOM)
   check_symbol_exists(srandom stdlib.h P4EST_HAVE_SRANDOM)


### PR DESCRIPTION
# CMake: Add CTest inclusion

Proposed changes: Since we experienced a failing valgrind CI,
```
Cannot find file: /home/runner/work/p4est/p4est/checkCMakeMPIvalgrind/DartConfiguration.tcl
Memory checker (MemoryCheckCommand) not set, or cannot find the specified program.
Errors while running CTest
```
we include CTest in `test/CMakeLists.txt` to ensure that the valgrind installation is found by ctest.