### PR TITLE
CMake Git version bugfix

### DIFF
--- a/cmake/GitSubmodule.cmake
+++ b/cmake/GitSubmodule.cmake
@@ -7,7 +7,8 @@ function(git_submodule submod_dir)
 # get/update Git submodule directory to CMake, assuming the
 # Git submodule directory is a CMake project.
 
-if(NOT IS_DIRECTORY ${PROJECT_SOURCE_DIR}/.git)
+# EXISTS because Git submodules have .git as a file, not directory
+if(NOT EXISTS ${PROJECT_SOURCE_DIR}/.git)
   message(DEBUG "${PROJECT_SOURCE_DIR} is not a Git repository, skipping submodule ${submod_dir}")
   return()
 endif()

--- a/cmake/git.cmake
+++ b/cmake/git.cmake
@@ -5,7 +5,7 @@ set(PROJECT_MINOR 0)
 set(PROJECT_PATCH 0)
 set(PROJECT_VERSION 0.0.0)
 find_program(GIT_VERSION_GEN NAMES git-version-gen
-             PATHS ${CMAKE_SOURCE_DIR}/build-aux NO_DEFAULT_PATH)
+             PATHS ${PROJECT_SOURCE_DIR}/build-aux NO_DEFAULT_PATH)
 if(GIT_VERSION_GEN)
   execute_process(COMMAND ${GIT_VERSION_GEN} .tarball-version
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -32,7 +32,7 @@ add_executable(${name} ${files})
 target_link_libraries(${name} PRIVATE P4EST::P4EST)
 set_target_properties(${name}
   PROPERTIES
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/example/${dir}"
+  RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/example/${dir}"
   LABELS p4est
 )
 
@@ -45,7 +45,7 @@ add_executable(${name} ${files})
 target_link_libraries(${name} PRIVATE P4EST::P4EST)
 set_target_properties(${name}
   PROPERTIES
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/example/${dir}"
+  RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/example/${dir}"
   LABELS p8est
 )
 
@@ -55,7 +55,7 @@ endfunction(p8est_example)
 function(p4est_copy_resource dir res_file)
 configure_file(
   ${PROJECT_SOURCE_DIR}/${dir}/${res_file}
-  ${CMAKE_BINARY_DIR}/example/${dir}/${res_file}
+  ${PROJECT_BINARY_DIR}/example/${dir}/${res_file}
   COPYONLY
 )
 endfunction()


### PR DESCRIPTION
For use as subproject, ensure that Git version is generated from the correct project.

Correct the Git Submodule update logic as for submodules ".git" is a file instead of directory. EXISTS handles both cases.