### PR TITLE
Move bsearch function up

### DIFF
--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -36,6 +36,23 @@
 #include <zlib.h>
 #endif
 
+int
+p4est_bsearch_partition (p4est_gloidx_t target,
+                         const p4est_gloidx_t * gfq, int nmemb)
+{
+  size_t              res;
+
+  P4EST_ASSERT (nmemb > 0);
+  P4EST_ASSERT (gfq[0] <= target);
+  P4EST_ASSERT (target < gfq[nmemb]);
+
+  res = sc_bsearch_range (&target, gfq, (size_t) nmemb,
+                          sizeof (p4est_gloidx_t), p4est_gloidx_compare);
+  P4EST_ASSERT (res < (size_t) nmemb);
+
+  return (int) res;
+}
+
 void
 p4est_comm_parallel_env_assign (p4est_t * p4est, sc_MPI_Comm mpicomm)
 {
@@ -996,23 +1013,6 @@ p4est_transfer_assign_comm (const p4est_gloidx_t * dest_gfq,
   P4EST_ASSERT (0 <= src_gfq[*mpirank] &&
                 src_gfq[*mpirank] <= src_gfq[*mpirank + 1] &&
                 src_gfq[*mpirank + 1] <= src_gfq[*mpisize]);
-}
-
-int
-p4est_bsearch_partition (p4est_gloidx_t target,
-                         const p4est_gloidx_t * gfq, int nmemb)
-{
-  size_t              res;
-
-  P4EST_ASSERT (nmemb > 0);
-  P4EST_ASSERT (gfq[0] <= target);
-  P4EST_ASSERT (target < gfq[nmemb]);
-
-  res = sc_bsearch_range (&target, gfq, (size_t) nmemb,
-                          sizeof (p4est_gloidx_t), p4est_gloidx_compare);
-  P4EST_ASSERT (res < (size_t) nmemb);
-
-  return (int) res;
 }
 
 p4est_transfer_context_t *

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -29,6 +29,23 @@
 
 SC_EXTERN_C_BEGIN;
 
+/** Given target, find index p such that `gfq[p] <= target < gfq[p + 1]`.
+ * \param[in] target    The value that is searched in \a gfq. \a target
+ *                      has to satisfy `gfq[0] <= target < gfq[nmemb]`.
+ * \param[in] gfq       The sorted array (ascending) in that the function will
+ *                      search.
+ * \param [in] nmemb    Number of entries in array MINUS ONE.
+ * \return              Index p such that `gfq[p] <= target < gfq[p + 1]`.
+ * \note                This function differs from \ref p4est_find_partiton
+ *                      since \ref p4est_find_partition searches for two
+ *                      targets using binary search in an optimized way
+ *                      but \ref p4est_bsearch_partition only performs a
+ *                      single binary search.
+ */
+int                 p4est_bsearch_partition (p4est_gloidx_t target,
+                                             const p4est_gloidx_t * gfq,
+                                             int nmemb);
+
 /** Assign an MPI communicator to p4est; retrieve parallel environment.
  *
  * \param [in] mpicomm    A valid MPI communicator.
@@ -332,23 +349,6 @@ void                p4est_transfer_fixed (const p4est_gloidx_t * dest_gfq,
                                           void *dest_data,
                                           const void *src_data,
                                           size_t data_size);
-
-/** Given target, find index p such that `gfq[p] <= target < gfq[p + 1]`.
- * \param[in] target    The value that is searched in \a gfq. \a target
- *                      has to satisfy `gfq[0] <= target < gfq[nmemb]`.
- * \param[in] gfq       The sorted array (ascending) in that the function will
- *                      search.
- * \param [in] nmemb    Number of entries in array MINUS ONE.
- * \return              Index p such that `gfq[p] <= target < gfq[p + 1]`.
- * \note                This function differs from \ref p4est_find_partiton
- *                      since \ref p4est_find_partition searches for two
- *                      targets using binary search in an optimized way
- *                      but \ref p4est_bsearch_partition only performs a
- *                      single binary search.
- */
-int                 p4est_bsearch_partition (p4est_gloidx_t target,
-                                             const p4est_gloidx_t * gfq,
-                                             int nmemb);
 
 /** Initiate a fixed-size data transfer between partitions.
  * See \ref p4est_transfer_fixed for a full description.

--- a/src/p8est_communication.h
+++ b/src/p8est_communication.h
@@ -29,6 +29,23 @@
 
 SC_EXTERN_C_BEGIN;
 
+/** Given target, find index p such that `gfq[p] <= target < gfq[p + 1]`.
+ * \param[in] target    The value that is searched in \a gfq. \a target
+ *                      has to satisfy `gfq[0] <= target < gfq[nmemb]`.
+ * \param[in] gfq       The sorted array (ascending) in that the function will
+ *                      search.
+ * \param [in] nmemb    Number of entries in array MINUS ONE.
+ * \return              Index p such that `gfq[p] <= target < gfq[p + 1]`.
+ * \note                This function differs from \ref p8est_find_partiton
+ *                      since \ref p8est_find_partition searches for two
+ *                      targets using binary search in an optimized way
+ *                      but \ref p8est_bsearch_partition only performs a
+ *                      single binary search.
+ */
+int                 p8est_bsearch_partition (p4est_gloidx_t target,
+                                             const p4est_gloidx_t * gfq,
+                                             int nmemb);
+
 /** Assign an MPI communicator to p8est; retrieve parallel environment.
  *
  * \param [in] mpicomm    A valid MPI communicator.
@@ -329,23 +346,6 @@ void                p8est_transfer_fixed (const p4est_gloidx_t * dest_gfq,
                                           void *dest_data,
                                           const void *src_data,
                                           size_t data_size);
-
-/** Given target, find index p such that `gfq[p] <= target < gfq[p + 1]`.
- * \param[in] target    The value that is searched in \a gfq. \a target
- *                      has to satisfy `gfq[0] <= target < gfq[nmemb]`.
- * \param[in] gfq       The sorted array (ascending) in that the function will
- *                      search.
- * \param [in] nmemb    Number of entries in array MINUS ONE.
- * \return              Index p such that `gfq[p] <= target < gfq[p + 1]`.
- * \note                This function differs from \ref p8est_find_partiton
- *                      since \ref p8est_find_partition searches for two
- *                      targets using binary search in an optimized way
- *                      but \ref p8est_bsearch_partition only performs a
- *                      single binary search.
- */
-int                 p8est_bsearch_partition (p4est_gloidx_t target,
-                                             const p4est_gloidx_t * gfq,
-                                             int nmemb);
 
 /** Initiate a fixed-size data transfer between partitions.
  * See \ref p8est_transfer_fixed for a full description.


### PR DESCRIPTION
# Move bsearch function up

Proposed changes: The function `p4est_bsearch_partition` was placed between `p4est_transfer_custom` and `p4est_transfer_begin`. The function is moved to the top of `p4est_communication.{c,h}` and of `p8est_communication.h` to make the ordering of the functions more consistent.
