### PR TITLE
Checksum comparison in wrap_adapt

### DIFF
--- a/src/p4est.h
+++ b/src/p4est.h
@@ -388,12 +388,12 @@ void                p4est_partition (p4est_t * p4est,
 
 /** Compute the checksum for a forest.
  * Based on quadrant arrays only. It is independent of partition and mpisize.
- * \return  Returns the checksum on processor 0 only. 0 on other processors.
+ * \return  Returns the checksum on all processors.
  */
 unsigned            p4est_checksum (p4est_t * p4est);
 
 /** Compute a partition-dependent checksum for a forest.
- * \return  Returns the checksum on processor 0 only. 0 on other processors.
+ * \return  Returns the checksum on all processors.
  */
 unsigned            p4est_checksum_partition (p4est_t * p4est);
 

--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -942,12 +942,12 @@ p4est_comm_checksum (p4est_t * p4est, unsigned local_crc, size_t local_bytes)
 #ifdef P4EST_ENABLE_MPI
   int                 mpiret;
   int                 p;
-  uint64_t            send[2];
-  uint64_t           *gather;
+  long long           send[2];
+  long long          *gather;
 
-  send[0] = (uint64_t) local_crc;
-  send[1] = (uint64_t) local_bytes;
-  gather = P4EST_ALLOC (uint64_t, 2 * p4est->mpisize);
+  send[0] = (long long) local_crc;
+  send[1] = (long long) local_bytes;
+  gather = P4EST_ALLOC (long long, 2 * p4est->mpisize);
   mpiret = sc_MPI_Allgather (send, 2, sc_MPI_LONG_LONG_INT,
                              gather, 2, sc_MPI_LONG_LONG_INT, p4est->mpicomm);
   SC_CHECK_MPI (mpiret);

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -284,11 +284,11 @@ int                 p4est_comm_sync_flag (p4est_t * p4est,
 /** Compute a parallel partition-independent checksum out of local checksums.
  * This checksum depends on the global refinement topology.
  * It does not depend on how the mesh is partitioned.
- * The result is available on rank 0.
+ * The result is available on all processors.
  * \param [in] p4est       The MPI information of this p4est will be used.
  * \param [in] local_crc   Locally computed adler32 checksum.
  * \param [in] local_bytes Number of bytes used for local checksum.
- * \return                 Parallel checksum on rank 0, 0 otherwise.
+ * \return                 Parallel checksum on all processors.
  */
 unsigned            p4est_comm_checksum (p4est_t * p4est,
                                          unsigned local_crc,

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -294,17 +294,6 @@ unsigned            p4est_comm_checksum (p4est_t * p4est,
                                          unsigned local_crc,
                                          size_t local_bytes);
 
-/** Compute a parallel partition-dependent checksum out of local checksums.
- * This checksum depends on both the global refinement topology and partition.
- * \param [in] p4est       The MPI information of this p4est will be used.
- * \param [in] local_crc   Locally computed adler32 checksum.
- * \param [in] local_bytes Number of bytes used for local checksum.
- * \return                 Parallel checksum on rank 0, 0 otherwise.
- */
-unsigned            p4est_comm_checksum_partition (p4est_t * p4est,
-                                                   unsigned local_crc,
-                                                   size_t local_bytes);
-
 /** Context data to allow for split begin/end data transfer. */
 typedef struct p4est_transfer_context
 {

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -475,7 +475,6 @@
 #define p4est_comm_neighborhood_owned   p8est_comm_neighborhood_owned
 #define p4est_comm_sync_flag            p8est_comm_sync_flag
 #define p4est_comm_checksum             p8est_comm_checksum
-#define p4est_comm_checksum_partition   p8est_comm_checksum_partition
 #define p4est_transfer_fixed            p8est_transfer_fixed
 #define p4est_bsearch_partition         p8est_bsearch_partition
 #define p4est_transfer_fixed_begin      p8est_transfer_fixed_begin

--- a/src/p4est_wrap.c
+++ b/src/p4est_wrap.c
@@ -706,10 +706,9 @@ p4est_wrap_adapt (p4est_wrap_t * pp)
 
     /* check if coarsening and balancing canceled out */
     if (global_num_entry == p4est->global_num_quadrants) {
-      /* only compute another checksum, if the global quadrant count changed */
+      /* only compute another checksum for unchanged global quadrant counts */
       checksum_exit = p4est_checksum (p4est);
-      changed = (checksum_entry != checksum_exit);      /* only relevant for rank 0 */
-      sc_MPI_Bcast (&changed, 1, sc_MPI_INT, 0, p4est->mpicomm);
+      changed = (checksum_entry != checksum_exit);
     }
 
     if (changed) {

--- a/src/p4est_wrap.c
+++ b/src/p4est_wrap.c
@@ -639,6 +639,7 @@ int
 p4est_wrap_adapt (p4est_wrap_t * pp)
 {
   int                 changed;
+  int                 have_zlib;
 #ifdef P4EST_ENABLE_DEBUG
   p4est_locidx_t      jl, local_num;
 #endif
@@ -664,9 +665,12 @@ p4est_wrap_adapt (p4est_wrap_t * pp)
                                      (P4EST_CHILDREN - 1) *
                                      pp->num_refine_flags);
 
-  /* store p4est checksum on entry to compare with results after balancing */
-  global_num_entry = p4est->global_num_quadrants;
-  checksum_entry = p4est_checksum (p4est);
+
+  if ((have_zlib = p4est_have_zlib())) {
+    /* store p4est checksum on entry to compare with results after balancing */
+    global_num_entry = p4est->global_num_quadrants;
+    checksum_entry = p4est_checksum (p4est);
+  }
 
   /* Execute refinement */
   pp->inside_counter = pp->num_replaced = 0;
@@ -705,7 +709,7 @@ p4est_wrap_adapt (p4est_wrap_t * pp)
                        pp->params.replace_fn);
 
     /* check if coarsening and balancing canceled out */
-    if (global_num_entry == p4est->global_num_quadrants) {
+    if (have_zlib && (global_num_entry == p4est->global_num_quadrants)) {
       /* only compute another checksum for unchanged global quadrant counts */
       checksum_exit = p4est_checksum (p4est);
       changed = (checksum_entry != checksum_exit);

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -338,6 +338,8 @@ void                p4est_wrap_mark_coarsen (p4est_wrap_t * pp,
  * Checks pp->flags as per-quadrant input against p4est_wrap_flags_t.
  * The pp->flags array is updated along with p4est and reset to zeros.
  * Creates ghost_aux and mesh_aux to represent the intermediate mesh.
+ * If zlib is available, the routine checks whether coarsening and balancing the
+ * p4est canceled out and skips computing ghost_aux and mesh_aux when possible.
  * \param [in,out] pp The p4est wrapper to work with, must not be hollow.
  * \return          boolean whether p4est has changed.
  *                  If true, partition must be called.

--- a/src/p8est.h
+++ b/src/p8est.h
@@ -388,12 +388,12 @@ void                p8est_partition (p8est_t * p8est,
 
 /** Compute the checksum for a forest.
  * Based on quadrant arrays only. It is independent of partition and mpisize.
- * \return  Returns the checksum on processor 0 only. 0 on other processors.
+ * \return  Returns the checksum on all processors.
  */
 unsigned            p8est_checksum (p8est_t * p8est);
 
 /** Compute a partition-dependent checksum for a forest.
- * \return  Returns the checksum on processor 0 only. 0 on other processors.
+ * \return  Returns the checksum on all processors.
  */
 unsigned            p8est_checksum_partition (p8est_t * p8est);
 

--- a/src/p8est_communication.h
+++ b/src/p8est_communication.h
@@ -284,26 +284,15 @@ int                 p8est_comm_sync_flag (p8est_t * p8est,
 /** Compute a parallel partition-independent checksum out of local checksums.
  * This checksum depends on the global refinement topology.
  * It does not depend on how the mesh is partitioned.
- * The result is available on rank 0.
+ * The result is available on all processors.
  * \param [in] p8est       The MPI information of this p8est will be used.
  * \param [in] local_crc   Locally computed adler32 checksum.
  * \param [in] local_bytes Number of bytes used for local checksum.
- * \return                 Parallel checksum on rank 0, 0 otherwise.
+ * \return                 Parallel checksum on all processors.
  */
 unsigned            p8est_comm_checksum (p8est_t * p8est,
                                          unsigned local_crc,
                                          size_t local_bytes);
-
-/** Compute a parallel partition-dependent checksum out of local checksums.
- * This checksum depends on both the global refinement topology and partition.
- * \param [in] p8est       The MPI information of this p8est will be used.
- * \param [in] local_crc   Locally computed adler32 checksum.
- * \param [in] local_bytes Number of bytes used for local checksum.
- * \return                 Parallel checksum on rank 0, 0 otherwise.
- */
-unsigned            p8est_comm_checksum_partition (p8est_t * p8est,
-                                                   unsigned local_crc,
-                                                   size_t local_bytes);
 
 /** Context data to allow for split begin/end data transfer. */
 typedef struct p8est_transfer_context

--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -323,6 +323,8 @@ void                p8est_wrap_mark_coarsen (p8est_wrap_t * pp,
  * Checks pp->flags as per-quadrant input against p8est_wrap_flags_t.
  * The pp->flags array is updated along with p8est and reset to zeros.
  * Creates ghost_aux and mesh_aux to represent the intermediate mesh.
+ * If zlib is available, the routine checks whether coarsening and balancing the
+ * p8est canceled out and skips computing ghost_aux and mesh_aux when possible.
  * \param [in,out] pp The p8est wrapper to work with, must not be hollow.
  * \return          boolean whether p8est has changed.
  *                  If true, partition must be called.

--- a/test/test_io2.c
+++ b/test/test_io2.c
@@ -585,8 +585,7 @@ main (int argc, char **argv)
                               current_user_string);
 
     /* check the checksum */
-    SC_CHECK_ABORT (p4est_checksum (p4est) ==
-                    ((p4est->mpirank == 0) ? checksum : 0),
+    SC_CHECK_ABORT (p4est_checksum (p4est) == checksum,
                     "Forest checksum equality");
 
     empty.elem_count = 1;


### PR DESCRIPTION
We add a checksum comparison in `wrap_adapt` to check whether coarsening and balancing cancel each other out.

One checksum is computed at the start of the function for the p4est of the input wrap. After refining, coarsening and balancing we compute another checksum, if the total amount of quadrants did not change. If the result p4est has the same checksum as the input p4est, we do not compute a new ghost and mesh for the wrap.