### PR TITLE
Fix file cleanup

### DIFF
--- a/src/p4est_io.c
+++ b/src/p4est_io.c
@@ -601,11 +601,7 @@ p4est_file_error_cleanup (sc_MPI_File * file)
 {
   /* no error checking since we are called under an error condition */
   P4EST_ASSERT (file != NULL);
-#ifdef P4EST_ENABLE_MPIIO
   if (*file != sc_MPI_FILE_NULL) {
-#else
-  if ((*file)->file != sc_MPI_FILE_NULL) {
-#endif
     /* We do not use here the libsc closing function since we do not perform
      * error checking in this function that is only called if we had already
      * an error.

--- a/test/test_io2.c
+++ b/test/test_io2.c
@@ -319,7 +319,7 @@ main (int argc, char **argv)
       SC_CHECK_ABORT (p4est_file_write_field
                       (fc, quad_data.elem_size, &quad_data,
                        "Quadrant-wise char", &errcode) != NULL,
-                      "Write ranks");
+                      "Write chars");
 
       SC_CHECK_ABORT (p4est_file_write_field
                       (fc, quads->elem_size, quads, "Quadrant data", &errcode)


### PR DESCRIPTION
# Fix file cleanup

Proposed changes: Fix the check for `file` being `NULL` in the function `p4est_file_error_cleanup` to prevent accessing `NULL` in the case of handling a failed call of the open function. In addition, a check abort message is updated.
