### PR TITLE
Feature GMT distributed

### DIFF
--- a/example/gmt/Makefile.am
+++ b/example/gmt/Makefile.am
@@ -8,7 +8,8 @@ bin_PROGRAMS += example/gmt/p4est_gmt
 
 example_gmt_p4est_gmt_SOURCES = \
         example/gmt/gmt2.c \
-        example/gmt/gmt_models.c example/gmt/gmt_models.h
+        example/gmt/gmt_models.c example/gmt/gmt_models.h \
+        example/gmt/gmt_global.h
 
 bin_PROGRAMS += example/gmt/p4est_sphere_preprocessing
 

--- a/example/gmt/gmt2.c
+++ b/example/gmt/gmt2.c
@@ -54,6 +54,7 @@ typedef struct global
   int                 synthetic;
   int                 latlongno;
   int                 sphere;   /* globe sphere model */
+  int                 distributed; /* distributed file read */
   const char         *input_filename;
   const char         *output_prefix;
   sc_MPI_Comm         mpicomm;
@@ -102,7 +103,8 @@ setup_model (global_t * g)
   else if (g->sphere) {
     g->model =
       p4est_gmt_model_sphere_new (g->resolution, g->input_filename,
-                                  g->output_prefix, g->mpicomm);
+                                  g->output_prefix, g->distributed,
+                                  g->mpicomm);
   }
 
   /* on successful initalization the global model is set */
@@ -281,6 +283,8 @@ main (int argc, char **argv)
                          "Choose model-specific input file name");
   sc_options_add_string (opt, 'O', "out-prefix", &g->output_prefix, NULL,
                          "Choose prefix for output file(s)");
+  sc_options_add_bool (opt, 'd', "distributed", &g->distributed, 0,
+                       "Distributed read mode");
 
   /* proceed in run-once loop for cleaner error checking */
   ue = 0;

--- a/example/gmt/gmt2.c
+++ b/example/gmt/gmt2.c
@@ -42,26 +42,9 @@
 #include <p4est_vtk.h>
 #include <sc_options.h>
 #include "gmt_models.h"
+#include "gmt_global.h"
 
 static const double irootlen = 1. / (double) P4EST_ROOT_LEN;
-
-typedef struct global
-{
-  int                 minlevel;
-  int                 maxlevel;
-  int                 balance;
-  int                 resolution;
-  int                 synthetic;
-  int                 latlongno;
-  int                 sphere;   /* globe sphere model */
-  int                 distributed; /* distributed file read */
-  const char         *input_filename;
-  const char         *output_prefix;
-  sc_MPI_Comm         mpicomm;
-  p4est_t            *p4est;
-  p4est_gmt_model_t  *model;
-}
-global_t;
 
 static int
 setup_model (global_t * g)

--- a/example/gmt/gmt2.c
+++ b/example/gmt/gmt2.c
@@ -67,7 +67,7 @@ setup_model (global_t * g)
 
     switch (g->latlongno) {
     case 0:
-      // NOTE: We can make even this a command line input...
+      /* NOTE: We can make even this a command line input... */
       ap.latitude[0] = -50.;
       ap.latitude[1] = 0.;
       ap.longitude[0] = 0.;

--- a/example/gmt/gmt2.c
+++ b/example/gmt/gmt2.c
@@ -90,8 +90,16 @@ setup_model (global_t * g)
                                   g->mpicomm);
   }
 
+  /* check that model supports distributed mode */
+  if (g->model != NULL && g->distributed && g->model->points == NULL) {
+    P4EST_GLOBAL_INFO ("Warning: model cannot be run in distributed mode as "
+                       "it does not set g->model->points. Running in "
+                       "non-distributed mode instead.\n");
+    g->distributed = 0;
+  }
+
   /* initially a model is responsible for all points it knows */
-  if (g->distributed && g->model != NULL) {
+  if (g->model != NULL && g->distributed) {
     g->model->num_resp = g->model->M;
     g->model->num_own = 0;
   }

--- a/example/gmt/gmt_global.h
+++ b/example/gmt/gmt_global.h
@@ -1,0 +1,41 @@
+/*
+  This file is part of p4est.
+  p4est is a C library to manage a collection (a forest) of multiple
+  connected adaptive quadtrees or octrees in parallel.
+
+  Copyright (C) 2010 The University of Texas System
+  Additional copyright (C) 2011 individual authors
+  Written by Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac
+
+  p4est is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  p4est is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with p4est; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+typedef struct global
+{
+  int                 minlevel;
+  int                 maxlevel;
+  int                 balance;
+  int                 resolution;
+  int                 synthetic;
+  int                 latlongno;
+  int                 sphere;   /* globe sphere model */
+  int                 distributed; /* distributed file read */
+  const char         *input_filename;
+  const char         *output_prefix;
+  sc_MPI_Comm         mpicomm;
+  p4est_t            *p4est;
+  p4est_gmt_model_t  *model;
+}
+global_t;

--- a/example/gmt/gmt_models.c
+++ b/example/gmt/gmt_models.c
@@ -576,7 +576,6 @@ p4est_gmt_model_sphere_new (int resolution, const char *input,
   SC_CHECK_MPI (mpiret);
 
   /* set read offsets */
-  /* note: these will be more relevant in the distributed version */
   mpi_offset = 0;
 
   /* set read offsets depending on whether we are running distributed */
@@ -874,11 +873,10 @@ compute_outgoing_points (p4est_gmt_comm_t *resp,
   sc_array_t         *points;
 
   /* initialise to -1 to signify no points have been added to send buffers */
-  model->last_procs = P4EST_ALLOC (int, model->num_resp);
-  /* TODO is this memset standard C? 
-   * Here we are relying on the fact that the char -1 is 11111111 in bits,
+  /* Here we are relying on the fact that the char -1 is 11111111 in bits,
    * and so the resulting int array will be filled with -1.
    */
+  model->last_procs = P4EST_ALLOC (int, model->num_resp);
   memset (model->last_procs, -1, model->num_resp * sizeof (int));
 
   /* initialise index of outgoing message buffers */

--- a/example/gmt/gmt_models.c
+++ b/example/gmt/gmt_models.c
@@ -1036,11 +1036,12 @@ p4est_gmt_communicate_points (sc_MPI_Comm mpicomm,
 {
   int                 mpiret;
   int                 num_procs;
-  /** Communication data */
-  p4est_gmt_comm_t   *own = &model->own;        /* not responsible */
-  p4est_gmt_comm_t   *resp = &model->resp;      /* responsible */
-  sc_MPI_Request     *send_req; /* requests for sending to receivers */
-  sc_MPI_Request     *recv_req; /* requests for receiving from senders */
+
+  /* Communication data */
+  p4est_gmt_comm_t   *own = &model->own;        /**< not responsible */
+  p4est_gmt_comm_t   *resp = &model->resp;      /**< responsible */
+  sc_MPI_Request     *send_req; /**< requests for sending to receivers */
+  sc_MPI_Request     *recv_req; /**< requests for receiving from senders */
 
   /* get total process count */
   mpiret = sc_MPI_Comm_size (mpicomm, &num_procs);

--- a/example/gmt/gmt_models.h
+++ b/example/gmt/gmt_models.h
@@ -104,10 +104,13 @@ p4est_gmt_sphere_geoseg_t;
  * \param[in] resolution maximum refinement level
  * \param[in] input      name of input file created with preprocessing script
  * \param[in] output_prefix name of file written
+ * \param[in] dist       distributed read mode
+ * \param[in] mpicomm    MPI communicator
  */
 p4est_gmt_model_t  *p4est_gmt_model_sphere_new (int resolution,
                                                 const char *input,
                                                 const char *output_prefix,
+                                                int dist,
                                                 sc_MPI_Comm mpicomm);
 
 /** Destroy model */

--- a/example/gmt/gmt_models.h
+++ b/example/gmt/gmt_models.h
@@ -163,7 +163,7 @@ void                p4est_gmt_model_destroy (p4est_gmt_model_t * model);
  * Used in distributed mode so that points are moved to the appropriate
  * processes before refinement. This function also handles updating the field
  * model->M, as well as internal communication metadata for subsequent
- * iterations.
+ * iterations.  This function is collective over the communicator.
  * 
  * To support distributed mode a model should (in setup) load a distinct
  * subset of points on each process. Each process must set model->M as the
@@ -173,9 +173,9 @@ void                p4est_gmt_model_destroy (p4est_gmt_model_t * model);
  * intersection function model->intersect should be written so that an input
  * of m refers to the mth point stored in model->points. 
  * 
- * \param[in] mpicomm   MPI communicator
- * \param[in] p4est     The forest
- * \param[in] model     the model
+ * \param[in] mpicomm   MPI communicator (collective function).
+ * \param[in] p4est     The forest is not modified.
+ * \param[in,out] model The model whose M and points variables change.
  */
 void
 p4est_gmt_communicate_points (sc_MPI_Comm mpicomm,

--- a/example/gmt/gmt_models.h
+++ b/example/gmt/gmt_models.h
@@ -47,20 +47,20 @@ typedef struct p4est_gmt_comm
   
   /** data used for sending */
   /* number of points that p receives in this iteration */
-  int num_incoming;
-  /* q -> {points that should be sent to q } */
+  size_t num_incoming;
+  /* q -> {points that are being sent to q } */
   sc_array_t **to_send;
-  /* Ranks receiving points from p */
+  /* ranks receiving points from p */
   sc_array_t *receivers;
-  /* Number of points each receiver gets from p */
+  /* number of points each receiver gets from p */
   sc_array_t *recvs_counts;
 
   /** data used for receiving */
-  /* Ranks sending points to p */
+  /* ranks sending points to p */
   sc_array_t *senders;
-  /* Number of points p gets from each sender */
+  /* number of points p gets from each sender */
   sc_array_t *senders_counts;
-  /* q -> offset to receive message from q at */
+  /* q -> byte offset to receive message from q at */
   size_t * offsets;
 } p4est_gmt_comm_t;
 
@@ -80,6 +80,7 @@ typedef struct p4est_gmt_model
   /** data for point communication */
   p4est_gmt_comm_t    own, resp;
   size_t              num_own, num_resp;
+  int                *last_procs;
 
   /** When not NULL, free whatever is stored in model->model_data. */
   p4est_gmt_destroy_data_t destroy_data;

--- a/example/gmt/gmt_models.h
+++ b/example/gmt/gmt_models.h
@@ -78,6 +78,10 @@ typedef struct p4est_gmt_model
   void               *points;
 
   /** data for point communication */
+  /** note: these fields are initialised as required during generic setup and
+   * by \ref p4est_gmt_communicate_points. Anyone implementing a model can
+   * safely ignore these.
+   */
   p4est_gmt_comm_t    own, resp;
   size_t              num_own, num_resp;
   int                *last_procs;
@@ -156,14 +160,25 @@ void                p4est_gmt_model_destroy (p4est_gmt_model_t * model);
 
 /** Send points to the processes whose domain they *may* overlap.
  * 
- * For use in distributed mode.
+ * Used in distributed mode so that points are moved to the appropriate
+ * processes before refinement. This function also handles updating the field
+ * model->M, as well as internal communication metadata for subsequent
+ * iterations.
+ * 
+ * To support distributed mode a model should (in setup) load a distinct
+ * subset of points on each process. Each process must set model->M as the
+ * number of points loaded on that process. A point must be represented by a
+ * struct of size model->point_size and points must be stored in the array
+ * model->points, which hence has size model->M * model->point_size. The
+ * intersection function model->intersect should be written so that an input
+ * of m refers to the mth point stored in model->points. 
  * 
  * \param[in] mpicomm   MPI communicator
  * \param[in] p4est     The forest
  * \param[in] model     the model
  */
 void
-p4est_gmt_communicate_points(sc_MPI_Comm mpicomm,
+p4est_gmt_communicate_points (sc_MPI_Comm mpicomm,
                          p4est_t *p4est,
                          p4est_gmt_model_t *model);
 


### PR DESCRIPTION
Introduced a distributed mode to the GMT example, which can be enabled with the `-d` flag. In this mode each process knows only a fraction of the points and at each iteration points are sent to the relevant processes before refinement. Since points are known by multiple processes we avoid duplication by designating a single owner of each point as _responsible_ for propagating it in the next iteration.

Currently the sphere model is the only model set up for distributed mode. However, the communication code is written in such a way that other models could add support without writing their own communication code. 

To support distributed mode a model should (in setup) load a distinct subset of points on each process. Each process must set `model->M` as the number of points loaded on that process. A point must be represented by a struct of size `model->point_size` and points must be stored in the array `model->points`, which hence has byte-size `model->M * model->point_size`. The intersection function `model->intersect` should be written so that an input of `m` refers to the `m`th point stored in `model->points`.

The communication code uses `p4est_search_partition`  with the model-specified intersection function to determine which process domains each point intersects. Points are then communicated to the relevant processes, and the array `model->points` is updated, along with the local point count `model->M`.