### PR TITLE
Update release notes

### DIFF
--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -26,6 +26,9 @@ This is the upcoming release with lots of small additions throughout.
  - Fix the warnings while generating documentation for p4est_connectivity.h.
  - Fix the warnings while generating documentation for p8est_connectivity.h.
  - Add more explicit documentation to the p?est_connectivity.h files.
+ - Fix the warnings while generating documentation for p4est_mesh.h.
+ - Fix the warnings while generating documentation for p8est_mesh.h.
+ - Add more explicit documentation to the p?est_mesh.h files.
 
 ### Functionality
 
@@ -34,6 +37,10 @@ This is the upcoming release with lots of small additions throughout.
  - Add three 2d connectivities (circle, drop and bowtie) into simple.
  - Integrate updated MPI I/O wrappers and CMake logic in libsc.
  - Reset quadrant data size to 0 in p{4,8}est_wrap_new_p4est.
+ - Add search_partition_gfp operating without a gfq array.
+ - Add a parameter struct for the p{4,8}est_wrap_t.
+ - Add a parameter struct for the p{4,8}est_mesh_t.
+ - Add an option to store edge-hanging corner neighbors in the mesh.
 
 ## 2.8.5
 

--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -32,7 +32,8 @@ This is the upcoming release with lots of small additions throughout.
  - Add two connectivities (2d bowtie and 3d drop) to stress the balance demo.
  - Add a new 3d connectivity (drop) into the simple example.
  - Add three 2d connectivities (circle, drop and bowtie) into simple.
- - Integrate updated MPI I/O wrappers and CMake logic in libsc
+ - Integrate updated MPI I/O wrappers and CMake logic in libsc.
+ - Reset quadrant data size to 0 in p{4,8}est_wrap_new_p4est.
 
 ## 2.8.5
 


### PR DESCRIPTION
# Update release notes

Proposed changes: The PR https://github.com/cburstedde/p4est/pull/252 changed the behavior of the function `p{4,8}est_wrap_new_p4est`. This PR adds this information to the release notes of the version 2.8.6.

Edit: @hannesbrandt  pushed his edits of the release notes to this PR to avoid merge conflicts.
