### PR TITLE
CI: macOS: CMake: use Apple Silicon hardware

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -99,7 +99,9 @@ jobs:
           ./build/Testing/Temporary/LastTest.log
 
   mac:
-    runs-on: macos-latest
+    # macos-14 is to use Apple Silicon hardware
+    # https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
+    runs-on: macos-14
     name: CMake build on MacOS
     timeout-minutes: 60
 


### PR DESCRIPTION
Most Apple users now have Apple Silicon ARM64 CPU. Since Apple Silicon introduction, there have been several Apple Silicon-specific issues that needed tweaking. In Jan. 2024, GitHub Actions made Apple Silicon CI free to use so this PR uses that to help detect future issues.

Previously, GitHub Actions used macOS 13 on Intel CPU, which missed numerous issues our developers faced on their Apple Silicon laptops.