### PR TITLE
Feature transfer_search

### DIFF
--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -2163,7 +2163,7 @@ p4est_transfer_search_internal (p4est_transfer_internal_t *internal)
     errsend = 1;
     P4EST_LERRORF ("Rank %d would receive %lld points, which exceeds "
                    "P4EST_LOCIDX_MAX\n",
-                   rank, num_incoming);
+                   rank, (long long) num_incoming);
   }
   
   /* synchronise possible error of a process receiving too many points */

--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -1616,7 +1616,7 @@ transfer_search_point (p4est_t *p4est, p4est_topidx_t which_tree,
   int                 last_proc;
 
   /* point index */
-  size_t              pi = *(size_t *) point_index;
+  p4est_locidx_t      pi = *(p4est_locidx_t *) point_index;
 
   /* sanity checks */
   P4EST_ASSERT (internal != NULL);
@@ -1702,7 +1702,6 @@ compute_send_buffers (p4est_transfer_internal_t *internal,
 {
   sc_array_t *search_objects;
   p4est_transfer_search_t *c = internal->c;
-  p4est_intersect_t intersect = internal->intersect;
   p4est_transfer_meta_t *resp = internal->resp;
   p4est_transfer_meta_t *own = internal->own;
 
@@ -1724,9 +1723,9 @@ compute_send_buffers (p4est_transfer_internal_t *internal,
   }
 
     /* set up search objects for partition search */
-  search_objects = sc_array_new_count (sizeof (size_t), c->num_resp);
-  for (size_t zz = 0; zz < c->num_resp; ++zz) {
-    *(size_t *) sc_array_index (search_objects, zz) = zz;
+  search_objects = sc_array_new_count (sizeof (p4est_locidx_t), c->num_resp);
+  for (p4est_locidx_t il = 0; il < c->num_resp; ++il) {
+    *(p4est_locidx_t *) sc_array_index (search_objects, il) = il;
   }
 
   /* add points to the relevant send buffers (by partition search) */
@@ -2058,7 +2057,6 @@ p4est_transfer_search_internal (p4est_transfer_internal_t *internal)
   int                 err = 0;
   p4est_transfer_search_t *c = internal->c;
   const size_t        point_size = c->points->elem_size;
-  p4est_intersect_t intersect = internal->intersect;
   p4est_transfer_meta_t   resp;
   p4est_transfer_meta_t   own;
 

--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -2073,7 +2073,7 @@ p4est_transfer_search_internal (p4est_transfer_internal_t *internal)
 
   /* requests for sending to receivers */
   sc_MPI_Request     *send_req = NULL;
-  int                 num_send_reqs;
+  int                 num_send_reqs = -1;
   /* requests for receiving from senders */
   sc_MPI_Request     *recv_req = NULL;
   int                 num_recv_reqs;

--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -2088,9 +2088,6 @@ p4est_transfer_search_internal (p4est_transfer_internal_t *internal)
   /* use search_partition to put points in appropriate send buffers */
   compute_send_buffers (internal, num_procs);
 
-  /* free the points we received last iteration */
-  sc_array_destroy_null (&c->points);
-
   /* record which processes p is sending points to and how many points each
      process receives */
   /* note: an error is recorded here if p is attempting to send more than 
@@ -2127,13 +2124,12 @@ p4est_transfer_search_internal (p4est_transfer_internal_t *internal)
     sc_MPI_Allreduce (&errsend, &err, 1, sc_MPI_INT, sc_MPI_LOR, mpicomm);
   SC_CHECK_MPI (mpiret);
 
-  /* clean up and exit on message error */
+  /* if any process had an error we clean up and exit */
   if (err) {
     /* clean up send data */
     destroy_transfer_meta (&resp, num_procs);
     destroy_transfer_meta (&own, num_procs);
     P4EST_FREE (send_req);
-    send_req = NULL;
 
     /* return failure */
     return 1;
@@ -2150,15 +2146,44 @@ p4est_transfer_search_internal (p4est_transfer_internal_t *internal)
   P4EST_ASSERT (own.senders->elem_count == own.senders_counts->elem_count);
   P4EST_ASSERT (resp.senders->elem_count == resp.senders_counts->elem_count);
 
+  /* total number of points that we are receiving */
+  num_incoming = resp.num_incoming + own.num_incoming;
+
+  /* check that we do not receive more than P4EST_LOCIDX_MAX points */
+  if (num_incoming > (size_t) P4EST_LOCIDX_MAX) {
+    errsend = 1;
+    P4EST_LERRORF ("Rank %d would receive %ld points, which exceeds "
+                   "P4EST_LOCIDX_MAX\n",
+                   rank, num_incoming);
+  }
+  
+  /* synchronise possible error of a process receiving too many points */
+  mpiret =
+    sc_MPI_Allreduce (&errsend, &err, 1, sc_MPI_INT, sc_MPI_LOR, mpicomm);
+  SC_CHECK_MPI (mpiret);
+
+  /* if any process had an error we clean up and exit */
+  if (err) {
+    /* clean up send data */
+    destroy_transfer_meta (&resp, num_procs);
+    destroy_transfer_meta (&own, num_procs);
+    P4EST_FREE (send_req);
+
+    /* return failure */
+    return 1;
+  }
+
+  /* we delay changing c until all possible soft errors have been checked */
+  /* free the points we received last iteration */
+  sc_array_destroy_null (&c->points);
+  /* update count of points we are responsible for */
+  c->num_resp = resp.num_incoming;
+
   /* compute offsets for storing incoming points */
   compute_offsets (&own, point_size);
   compute_offsets (&resp, point_size);
 
-  /* update count of points we are responsible for */
-  c->num_resp = resp.num_incoming;
-
   /* allocate memory for incoming points */
-  num_incoming = resp.num_incoming + own.num_incoming;
   c->points = sc_array_new_count (point_size, num_incoming);
 
   /* total number of messages received */

--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -32,6 +32,7 @@
 #include <p4est_bits.h>
 #endif /* !P4_TO_P8 */
 #include <sc_search.h>
+#include <sc_notify.h>
 #ifdef P4EST_HAVE_ZLIB
 #include <zlib.h>
 #endif
@@ -1475,4 +1476,309 @@ p4est_transfer_items_end (p4est_transfer_context_t * tc)
   P4EST_ASSERT (tc->variable == 2);
 
   p4est_transfer_end (tc);
+}
+
+/** Communication metadata for \ref p4est_transfer_search. */
+typedef struct transfer_search_meta
+{
+  /** in the following p refers to the local rank, and q any rank **/
+  
+  /* data used for sending */
+  /* number of points that p receives in this iteration */
+  size_t num_incoming;
+  /* q -> {points that are being sent to q } */
+  sc_array_t **send_buffer;
+  /* ranks receiving points from p */
+  sc_array_t *receivers;
+  /* number of points each receiver gets from p */
+  sc_array_t *recvs_counts;
+
+  /* data used for receiving */
+  /* ranks sending points to p */
+  sc_array_t *senders;
+  /* number of points p gets from each sender */
+  sc_array_t *senders_counts;
+  /* q -> byte offset to receive message from q at */
+  size_t * offsets;
+} transfer_search_meta_t;
+
+/** safely init transfer search metadata */
+static void
+init_transfer_search_meta (transfer_search_meta_t *meta)
+{
+  meta->send_buffer = NULL;
+  meta->receivers = NULL;
+  meta->recvs_counts = NULL;
+  meta->senders = NULL;
+  meta->senders_counts = NULL;
+  meta->offsets = NULL;
+}
+
+/** context-free destruction of transfer_search metadata */
+static void 
+destroy_transfer_search_meta (transfer_search_meta_t *meta, int num_procs) 
+{
+  /* destroy send data */
+  if (meta->receivers != NULL) {
+    sc_array_destroy_null (&meta->receivers);
+  }
+  if (meta->recvs_counts != NULL) {
+    sc_array_destroy_null (&meta->recvs_counts);
+  }
+  if (meta->send_buffer != NULL) {
+    for (int q = 0; q < num_procs; q++) {
+      if (meta->send_buffer[q] != NULL) {
+        sc_array_destroy_null (&meta->send_buffer[q]);
+      }
+    }
+  P4EST_FREE (meta->send_buffer);
+  }
+
+  /* destroy receive data */
+  if (meta->senders != NULL) {
+    sc_array_destroy_null (&meta->senders);
+  }
+  if (meta->senders_counts != NULL) {
+    sc_array_destroy_null (&meta->senders_counts);
+  }
+  P4EST_FREE (meta->offsets);
+}
+
+/** Prepare outgoing buffers of points to propagate.
+ * 
+ * \param[in] c contains the points we are responsible for propagating
+ * \param[in] intersect defines point-quadrant intersection
+ * \param[out] resp We store send buffers for points that receiving processes
+ *                  are responsible for propagating.
+ * \param[out] own  We store send buffers for points that receiving processes
+ *                  are not responsible for propagating
+ * \param[in] num_procs number of MPI processes
+ */
+static void
+compute_send_buffers (p4est_transfer_search_t *c,
+                      p4est_intersect_t intersect,
+                      transfer_search_meta_t *resp,
+                      transfer_search_meta_t *own,
+                      int num_procs)
+{
+  /* TODO */
+}
+
+/** Update communication metadata with which processes p is sending points to
+ *  and how many points are being sent to each of these. 
+ * 
+ *  The output is stored in the fields meta->receivers and meta->recvs_counts.
+ *  We assume comm->to_send is already populated.
+ * 
+ * \param[in,out] meta communication metadata
+ * \param[in] point_size byte size of points
+ * \param[in] num_procs number of mpi processes
+ * \param[in] rank rank of the local process
+ */
+static int
+compute_receivers (transfer_search_meta_t *meta, 
+                    size_t point_size, int num_procs, int rank)
+{
+  /* TODO */
+}
+
+/** Post non-blocking sends for points in the given communication data.
+ * 
+ * To each rank q in meta->receivers we send the points stored at 
+ * meta->to_send[q]
+ * 
+ * \param[in]   meta        communication data
+ * \param[in]   mpicomm     MPI communicator
+ * \param[out]  req         request storage of same length as comm->receivers
+ * \param[in]   point_size  size of a single point
+ */
+static void
+post_sends (transfer_search_meta_t *meta,
+            sc_MPI_Comm mpicomm, sc_MPI_Request *req, size_t point_size)
+{
+  /* TODO */
+}
+
+/** Update communication metadata with total number of incoming points, and 
+ *  offsets to receive incoming points at. 
+ * 
+ *  The outputs are stored in the fields meta->num_incoming and meta->offsets.
+ *  We assume that meta->senders and meta->senders_counts are already
+ *  populated.
+ * 
+ * \param[in,out] meta communication metadata.
+ */
+static void
+compute_offsets (transfer_search_meta_t *meta, size_t point_size) {
+  /* TODO */
+}
+
+/** Post non-blocking receives for senders in the given communication data.
+ *  If there is a message for ourself then we copy it manually here rather
+ *  than receiving it through MPI.
+ * 
+ *  We expect to receive points from each sender in comm->senders. The number
+ *  of points each sender is sending is stored in comm->senders_counts (with
+ *  corresponding indexing). We receive each message at the offset stored in
+ *  comm->offsets (again with corresponding indexing).
+ * 
+ *  \param[in] meta communication data
+ *  \param[in,out] recv_buffer points to array where received points are stored
+ *  \param[out] req request storage of same length as comm->senders
+ *  \param[in] mpicomm MPI communicator
+ *  \param[in] point_size size of a single point
+*/
+static void
+post_receives (transfer_search_meta_t * meta,
+               char *recv_buffer,
+               sc_MPI_Request *req, sc_MPI_Comm mpicomm, size_t point_size)
+{
+  /* TODO */
+}
+
+int
+p4est_transfer_search (p4est_t *p4est, p4est_transfer_search_t *c, 
+                            p4est_intersect_t intersect)
+{
+  int                 mpiret;
+  int                 num_procs, rank;
+  sc_MPI_Comm         mpicomm = p4est->mpicomm;
+  int                 errsend = 0;
+  int                 err = 0;
+  const size_t        point_size = c->points->elem_size;      
+
+  /* Communication metadata */
+  /* not responsible */
+  transfer_search_meta_t   own;
+  /* responsible */
+  transfer_search_meta_t   resp;
+  /* requests for sending to receivers */
+  sc_MPI_Request     *send_req = NULL;
+  int                 num_send_reqs;
+  /* requests for receiving from senders */
+  sc_MPI_Request     *recv_req = NULL;
+  int                 num_recv_reqs;
+  /* number of incoming points */
+  size_t              num_incoming;
+
+  /* init metadata fields to NULL */
+  init_transfer_search_meta (&resp);
+  init_transfer_search_meta (&own);
+
+  /* get rank and total process count */
+  mpiret = sc_MPI_Comm_rank (mpicomm, &rank);
+  SC_CHECK_MPI (mpiret);
+  mpiret = sc_MPI_Comm_size (mpicomm, &num_procs);
+  SC_CHECK_MPI (mpiret);
+
+  /* use search_partition to put points in appropriate send buffers */
+  compute_send_buffers (c, intersect, &resp, &own, num_procs);
+
+  /* free the points we received last iteration */
+  sc_array_destroy_null (&c->points);
+
+  /* record which processes p is sending points to and how many points each
+     process receives */
+  /* note: an error is recorded here if p is attempting to send more than 
+     INT_MAX bytes in an own or resp message to another process. We defer
+     synchronising these errors until just before calling sc_notify_ext
+     to avoid creating an unnecessary synchronisation point */
+  errsend = compute_receivers (&resp, point_size, num_procs, rank);
+  errsend = errsend
+    || compute_receivers (&own, point_size, num_procs, rank);
+
+  /* if messages from this process are valid then continue optimistically */
+  if (!errsend) {
+    /* total number of messages this process will send */
+    /* conversion is safe as we don't expect 2*num_procs to overflow int */
+    num_send_reqs = own.receivers->elem_count + resp.receivers->elem_count;
+
+    /* initialise request array for outgoing messages */
+    send_req = P4EST_ALLOC (sc_MPI_Request, num_send_reqs);
+
+    /* post non-blocking sends */
+    post_sends (&resp, mpicomm, send_req, point_size);
+    post_sends (&own, mpicomm, send_req + resp.receivers->elem_count,
+                point_size);
+
+    /* initialize buffers for communication metadata */
+    own.senders = sc_array_new (sizeof (int));
+    resp.senders = sc_array_new (sizeof (int));
+    own.senders_counts = sc_array_new (sizeof (size_t));
+    resp.senders_counts = sc_array_new (sizeof (size_t));
+  }
+
+  /* synchronise possible message errors */
+  mpiret =
+    sc_MPI_Allreduce (&errsend, &err, 1, sc_MPI_INT, sc_MPI_LOR, mpicomm);
+  SC_CHECK_MPI (mpiret);
+
+  /* clean up and exit on message error */
+  if (err) {
+    /* clean up send data */
+    destroy_transfer_search_meta (&resp, num_procs);
+    destroy_transfer_search_meta (&own, num_procs);
+    P4EST_FREE (send_req);
+    send_req = NULL;
+
+    /* return failure */
+    return 1;
+  }
+
+  /* notify processes receiving points from p and determine processes sending
+     to p. Also exchange counts of points being sent. */
+  sc_notify_ext (own.receivers, own.senders, own.recvs_counts,
+                 own.senders_counts, mpicomm);
+  sc_notify_ext (resp.receivers, resp.senders, resp.recvs_counts,
+                 resp.senders_counts, mpicomm);
+
+  /* sanity checks */
+  P4EST_ASSERT (own.senders->elem_count == own.senders_counts->elem_count);
+  P4EST_ASSERT (resp.senders->elem_count == resp.senders_counts->elem_count);
+
+  /* compute offsets for storing incoming points */
+  compute_offsets (&own, point_size);
+  compute_offsets (&resp, point_size);
+
+  /* update count of points we are responsible for */
+  c->num_resp = resp.num_incoming;
+
+  /* allocate memory for incoming points */
+  num_incoming = resp.num_incoming + own.num_incoming;
+  c->points = sc_array_new_count (point_size, num_incoming);
+
+  /* total number of messages received */
+  num_recv_reqs = own.senders->elem_count + resp.senders->elem_count;
+
+  /* initialise request array for incoming messages */
+  recv_req = P4EST_ALLOC (sc_MPI_Request, num_recv_reqs);
+
+  /* post non-blocking receives */
+  post_receives (&resp, c->points->array, recv_req, mpicomm, point_size);
+  post_receives (&own,
+                 c->points->array + resp.num_incoming * point_size,
+                 recv_req + resp.senders->elem_count, 
+                 mpicomm,
+                 point_size);
+
+  /* wait for messages to send */
+  mpiret =
+    sc_MPI_Waitall (num_send_reqs, send_req, sc_MPI_STATUSES_IGNORE);
+  SC_CHECK_MPI (mpiret);
+
+  /* TODO: we could destroy send/receive data independently? */
+
+  /* Wait to receive messages */
+  mpiret =
+    sc_MPI_Waitall (num_recv_reqs, recv_req, sc_MPI_STATUSES_IGNORE);
+  SC_CHECK_MPI (mpiret);
+
+  /* clean up communication metadata */
+  destroy_transfer_search_meta (&resp, num_procs);
+  destroy_transfer_search_meta (&own, num_procs);
+  P4EST_FREE (send_req);
+  P4EST_FREE (recv_req);
+
+  /* return success */
+  return 0;
 }

--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -1504,7 +1504,7 @@ typedef struct p4est_transfer_meta
   size_t * offsets;
 } p4est_transfer_meta_t;
 
-/** safely init transfer search metadata */
+/** Safely NULL-init transfer search metadata */
 static void
 init_transfer_meta (p4est_transfer_meta_t *meta)
 {
@@ -1516,7 +1516,7 @@ init_transfer_meta (p4est_transfer_meta_t *meta)
   meta->offsets = NULL;
 }
 
-/** context-free destruction of transfer_search metadata */
+/** Context-free destruction of transfer_search metadata */
 static void 
 destroy_transfer_meta (p4est_transfer_meta_t *meta, int num_procs) 
 {
@@ -1566,12 +1566,15 @@ typedef struct transfer_search_internal
 
   /* p4est data - NULL if running gfx/gfp */
   p4est_t *p4est;
+
+  /* data needed if we do not have a full p4est */
   /* global first quadrant array - NULL if running gfp */
   const p4est_gloidx_t *gfq;
   /* global first position array */
   const p4est_quadrant_t *gfp;
   int nmemb;
   p4est_topidx_t num_trees;
+  sc_MPI_Comm mpicomm;
 }
 transfer_search_internal_t;
 
@@ -1590,16 +1593,7 @@ static int
 transfer_search_point (p4est_t *p4est, p4est_topidx_t which_tree,
                        p4est_quadrant_t *quadrant, int pfirst, int plast,
                        void *point_index)
-{
-  /* from the context we need the following:
-      -an intersection function
-      -an array of last_procs
-      -own and resp
-      -the points array (since point actually only points to an index)
-
-    all these are known by search_transfer, so we can build an internal context
-  */
-  
+{  
   /* context */
   transfer_search_internal_t *internal =
       (transfer_search_internal_t *) p4est->user_pointer;
@@ -1777,7 +1771,36 @@ static int
 compute_receivers (p4est_transfer_meta_t *meta, 
                     size_t point_size, int num_procs, int rank)
 {
-  /* TODO */
+  int                 err = 0;
+  
+  /* initialize receivers and receiver counts */
+  meta->receivers = sc_array_new (sizeof (int));
+  meta->recvs_counts = sc_array_new (sizeof (size_t));
+
+  /* compute receivers and counts */
+  for (int q = 0; q < num_procs; q++) {
+    if (meta->send_buffers[q] != NULL) {
+      /* check that the number of points communicated will not overflow int */
+      if (meta->send_buffers[q]->elem_count * point_size > (size_t) INT_MAX) {
+        P4EST_LERRORF ("Message of %lld points from rank %d to rank %d is "
+                       "too large.\n",
+                       (long long) meta->send_buffers[q]->elem_count, rank, q);
+        err = 1;
+        break;
+      }
+
+      /* add q to receivers */
+      *(int *) sc_array_push (meta->receivers) = q;
+
+      /* record how many points p is sending to q */
+      *(size_t *) sc_array_push (meta->recvs_counts) =
+        meta->send_buffers[q]->elem_count;
+    }
+  }
+  P4EST_ASSERT (meta->receivers->elem_count ==
+                meta->recvs_counts->elem_count);
+
+  return err;
 }
 
 /** Post non-blocking sends for points in the given communication data.
@@ -1794,7 +1817,30 @@ static void
 post_sends (p4est_transfer_meta_t *meta,
             sc_MPI_Comm mpicomm, sc_MPI_Request *req, size_t point_size)
 {
-  /* TODO */
+  int                 mpiret;
+  int                 q;
+  int                 rank;
+
+  /* get rank */
+  mpiret = sc_MPI_Comm_rank (mpicomm, &rank);
+  SC_CHECK_MPI (mpiret);
+
+  /* for each receiver q */
+  for (int i = 0; i < (int) meta->receivers->elem_count; i++) {
+    q = *(int *) sc_array_index_int (meta->receivers, i);
+
+    if (q != rank) {
+      /* post non-blocking send of points to q */
+      mpiret = sc_MPI_Isend (sc_array_index (meta->send_buffers[q], 0),
+                             meta->send_buffers[q]->elem_count * point_size,
+                             sc_MPI_BYTE, q, 0, mpicomm, req + i);
+      SC_CHECK_MPI (mpiret);
+    }
+    else {
+      /* we do not send a message to ourself with MPI; copy is faster */
+      req[i] = sc_MPI_REQUEST_NULL;
+    }
+  }
 }
 
 /** Update communication metadata with total number of incoming points, and 
@@ -1808,21 +1854,30 @@ post_sends (p4est_transfer_meta_t *meta,
  */
 static void
 compute_offsets (p4est_transfer_meta_t *meta, size_t point_size) {
-  /* TODO */
+  /* initialize offset array */
+  meta->num_incoming = 0;
+  meta->offsets = P4EST_ALLOC (size_t, meta->senders->elem_count);
+
+  /* compute offsets */
+  for (int i = 0; i < (int) meta->senders->elem_count; i++) {
+    meta->offsets[i] = meta->num_incoming * point_size;
+    meta->num_incoming +=
+      *(size_t *) sc_array_index_int (meta->senders_counts, i);
+  }
 }
 
 /** Post non-blocking receives for senders in the given communication data.
  *  If there is a message for ourself then we copy it manually here rather
  *  than receiving it through MPI.
  * 
- *  We expect to receive points from each sender in comm->senders. The number
- *  of points each sender is sending is stored in comm->senders_counts (with
+ *  We expect to receive points from each sender in meta->senders. The number
+ *  of points each sender is sending is stored in meta->senders_counts (with
  *  corresponding indexing). We receive each message at the offset stored in
- *  comm->offsets (again with corresponding indexing).
+ *  meta->offsets (again with corresponding indexing).
  * 
  *  \param[in] meta communication data
  *  \param[in,out] recv_buffer points to array where received points are stored
- *  \param[out] req request storage of same length as comm->senders
+ *  \param[out] req request storage of same length as meta->senders
  *  \param[in] mpicomm MPI communicator
  *  \param[in] point_size size of a single point
 */
@@ -1831,9 +1886,44 @@ post_receives (p4est_transfer_meta_t * meta,
                char *recv_buffer,
                sc_MPI_Request *req, sc_MPI_Comm mpicomm, size_t point_size)
 {
-  /* TODO */
-}
+  int                 mpiret;
+  int                 q;
+  int                 rank;
+  void               *self_dest = NULL;
 
+  /* get rank */
+  mpiret = sc_MPI_Comm_rank (mpicomm, &rank);
+  SC_CHECK_MPI (mpiret);
+
+  /* for each sender q */
+  for (int i = 0; i < (int) meta->senders->elem_count; i++) {
+    q = *(int *) sc_array_index_int (meta->senders, i);
+
+    if (q != rank) {
+      /* post non-blocking receive for points from q */
+      mpiret = sc_MPI_Irecv (((char *) recv_buffer) + meta->offsets[i],
+                             (*(size_t *)
+                              sc_array_index_int (meta->senders_counts,
+                                                  i)) * point_size,
+                             sc_MPI_BYTE, q, 0, mpicomm, req + i);
+      SC_CHECK_MPI (mpiret);
+    }
+    else {
+      /* we do not receive a message from ourself with MPI; copy is faster */
+      req[i] = sc_MPI_REQUEST_NULL;
+      /* set receive buffer */
+      self_dest = ((char *) recv_buffer) + meta->offsets[i];
+    }
+  }
+  /* receive requests have been posted */
+
+  /* if the message to ourself was non-empty */
+  if (self_dest != NULL) {
+    /* copy message to self manually rather than post receive request */
+    memcpy (self_dest, sc_array_index (meta->send_buffers[rank], 0),
+            meta->send_buffers[rank]->elem_count * point_size);
+  }
+}
 
 /** Central execution pathway for p4est_transfer_search, 
  * p4est_transfer_search_gfx and p4est_transfer_search_gfp.
@@ -1857,6 +1947,7 @@ p4est_transfer_search (p4est_t *p4est, p4est_transfer_search_t *c,
   internal.c = c;
   internal.intersect = intersect;
   internal.p4est = p4est;
+  internal.mpicomm = p4est->mpicomm;
 
   /* Safe init for variables that are set later */
   internal.resp = NULL;
@@ -1889,6 +1980,7 @@ p4est_transfer_search_gfx (const p4est_gloidx_t *gfq,
                             const p4est_quadrant_t *gfp,
                             int nmemb, p4est_topidx_t num_trees,
                             void *user_pointer,
+                            sc_MPI_Comm mpicomm,
                             p4est_transfer_search_t *c,
                             p4est_intersect_t intersect)
 {
@@ -1897,6 +1989,7 @@ p4est_transfer_search_gfx (const p4est_gloidx_t *gfq,
   internal.c = c;
   internal.intersect = intersect;
   internal.user_pointer = user_pointer;
+  internal.mpicomm = mpicomm;
 
   /* Safe init for variables that are set later */
   internal.resp = NULL;
@@ -1920,6 +2013,7 @@ int
 p4est_transfer_search_gfp (const p4est_quadrant_t *gfp, int nmemb,
                             p4est_topidx_t num_trees,
                             void *user_pointer,
+                            sc_MPI_Comm mpicomm,
                             p4est_transfer_search_t *c,
                             p4est_intersect_t intersect)
 {
@@ -1928,6 +2022,7 @@ p4est_transfer_search_gfp (const p4est_quadrant_t *gfp, int nmemb,
   internal.c = c;
   internal.intersect = intersect;
   internal.user_pointer = user_pointer;
+  internal.mpicomm = mpicomm;
 
   /* Safe init for variables that are set later */
   internal.resp = NULL;
@@ -1952,26 +2047,21 @@ p4est_transfer_search_gfp (const p4est_quadrant_t *gfp, int nmemb,
 int 
 p4est_transfer_search_internal (transfer_search_internal_t *internal)
 {
-  /* TODO */
-  return 0;
-}
-
-#if 0
-int 
-p4est_transfer_search_internal (transfer_search_internal_t *internal);
-{
   int                 mpiret;
   int                 num_procs, rank;
-  sc_MPI_Comm         mpicomm = p4est->mpicomm;
+  sc_MPI_Comm         mpicomm = internal->mpicomm;
   int                 errsend = 0;
   int                 err = 0;
-  const size_t        point_size = c->points->elem_size;      
-
-  /* Communication metadata */
-  /* not responsible */
-  p4est_transfer_meta_t   own;
-  /* responsible */
+  p4est_transfer_search_t *c = internal->c;
+  const size_t        point_size = c->points->elem_size;
+  p4est_intersect_t intersect = internal->intersect;
   p4est_transfer_meta_t   resp;
+  p4est_transfer_meta_t   own;
+
+  /* Point context to communication metadata */
+  internal->resp = &resp;
+  internal->own = &own;
+
   /* requests for sending to receivers */
   sc_MPI_Request     *send_req = NULL;
   int                 num_send_reqs;
@@ -1981,19 +2071,18 @@ p4est_transfer_search_internal (transfer_search_internal_t *internal);
   /* number of incoming points */
   size_t              num_incoming;
 
-  /* init metadata fields to NULL */
+  /* Init metadata fields to NULL */
   init_transfer_meta (&resp);
   init_transfer_meta (&own);
 
-  /* get rank and total process count */
+  /* Get rank and total process count */
   mpiret = sc_MPI_Comm_rank (mpicomm, &rank);
   SC_CHECK_MPI (mpiret);
   mpiret = sc_MPI_Comm_size (mpicomm, &num_procs);
   SC_CHECK_MPI (mpiret);
   
-  /* TODO: init internal */
   /* use search_partition to put points in appropriate send buffers */
-  compute_send_buffers (c, intersect, &resp, &own, num_procs);
+  compute_send_buffers (internal, num_procs);
 
   /* free the points we received last iteration */
   sc_array_destroy_null (&c->points);
@@ -2103,5 +2192,3 @@ p4est_transfer_search_internal (transfer_search_internal_t *internal);
   /* return success */
   return 0;
 }
-
-#endif

--- a/src/p4est_communication.c
+++ b/src/p4est_communication.c
@@ -2161,7 +2161,7 @@ p4est_transfer_search_internal (p4est_transfer_internal_t *internal)
   /* check that we do not receive more than P4EST_LOCIDX_MAX points */
   if (num_incoming > (size_t) P4EST_LOCIDX_MAX) {
     errsend = 1;
-    P4EST_LERRORF ("Rank %d would receive %ld points, which exceeds "
+    P4EST_LERRORF ("Rank %d would receive %lld points, which exceeds "
                    "P4EST_LOCIDX_MAX\n",
                    rank, num_incoming);
   }

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -586,16 +586,14 @@ void                p4est_transfer_end (p4est_transfer_context_t * tc);
 typedef int         (*p4est_intersect_t) (p4est_topidx_t which_tree,
                                           p4est_quadrant_t *quadrant,
                                           void *point, void *user);
-/* TODO: does this function need a p4est? Does it need a user pointer? */
-/* TODO: finish point callback, then fill out the rest of the template */
 
 /** The points being exchanged in \ref p4est_transfer_search. */
 typedef struct p4est_transfer_search {
   /* The points to exchange */
   sc_array_t *points;
 
-  /* Process is responsible for propagating the first num_resp points that it
-   * knows. The remaining points are additionally known to other processes
+  /* Each process is responsible for propagating the first num_resp points that
+   * it knows. The remaining points are additionally known to other processes
    * which are responsible for their propagation. */
   p4est_locidx_t num_resp;
 
@@ -639,7 +637,7 @@ void p4est_transfer_search_destroy (p4est_transfer_search_t *c);
  * communication.
  * 
  * \param [in] p4est     The forest we search with. Its user_pointer is passed
- *                      to the intersection callback.
+ *                       to the intersection callback.
  * \param [in,out] c     Points and propagation responsibilities.
  * \param [in] intersect Intersection callback.
  */

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -603,7 +603,7 @@ typedef struct p4est_transfer_search {
 
 /** Destroy a \ref p4est_transfer_search_t structure
  * 
- * \param[in,out] c the structure to destroy
+ * \param [in,out] c the structure to destroy
  */
 void p4est_transfer_search_destroy (p4est_transfer_search_t *c);
 
@@ -638,10 +638,10 @@ void p4est_transfer_search_destroy (p4est_transfer_search_t *c);
  * subdivision if they modify the array of points between rounds of
  * communication.
  * 
- * \param[in] p4est     The forest we search with. Its user_pointer is passed
+ * \param [in] p4est     The forest we search with. Its user_pointer is passed
  *                      to the intersection callback.
- * \param[in,out] c     Points and propagation responsibilities.
- * \param[in] intersect Intersection callback.
+ * \param [in,out] c     Points and propagation responsibilities.
+ * \param [in] intersect Intersection callback.
  */
 int
 p4est_transfer_search (p4est_t *p4est, p4est_transfer_search_t *c, 
@@ -658,14 +658,16 @@ p4est_transfer_search (p4est_t *p4est, p4est_transfer_search_t *c,
  * \param [in] nmemb        Number of processors encoded in \a gfq (plus one).
  * \param [in] num_trees    Tree number must match the contents of \a gfq.
  * \param [in] user_pointer Passed to the intersection callback.
- * \param[in,out] c         Points and propagation responsibilities.
- * \param[in] intersect     Intersection callback.
+ * \param [in] mpicomm      Function is collective over the communicator.
+ * \param [in,out] c        Points and propagation responsibilities.
+ * \param [in] intersect    Intersection callback.
  */
 int
 p4est_transfer_search_gfx (const p4est_gloidx_t *gfq,
                             const p4est_quadrant_t *gfp,
                             int nmemb, p4est_topidx_t num_trees,
                             void *user_pointer,
+                            sc_MPI_Comm mpicomm,
                             p4est_transfer_search_t *c,
                             p4est_intersect_t intersect);
 
@@ -684,13 +686,15 @@ p4est_transfer_search_gfx (const p4est_gloidx_t *gfq,
  * \param [in] nmemb        Number of processors encoded in \a gfq (plus one).
  * \param [in] num_trees    Tree number must match the contents of \a gfq.
  * \param [in] user_pointer Passed to the intersection callback.
- * \param[in,out] c         Points and propagation responsibilities.
- * \param[in] intersect     Intersection callback.
+ * \param [in] sc_MPI_Comm  Function is collective over the communicator.
+ * \param [in,out] c        Points and propagation responsibilities.
+ * \param [in] intersect    Intersection callback.
  */
 int
 p4est_transfer_search_gfp (const p4est_quadrant_t *gfp, int nmemb,
                             p4est_topidx_t num_trees,
                             void *user_pointer,
+                            sc_MPI_Comm mpicomm,
                             p4est_transfer_search_t *c,
                             p4est_intersect_t intersect);
 

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -588,15 +588,16 @@ typedef int         (*p4est_comm_intersect_t) (p4est_t * p4est,
                                           p4est_quadrant_t * quadrant,
                                           void *point);
 
+/** The points being exchanged in \ref p4est_gmt_comm_points. */
 typedef struct p4est_comm_points_t {
-  /* the points to exchange */
+  /* The points to exchange */
   sc_array_t *points;
 
-  /* process is responsible for propagating the first num_resp points */
+  /* Process is responsible for propagating the first num_resp points. 
+   * The remaining points are known to other processes which are responsible
+   * for their propagation. */
   p4est_locidx_t num_resp;
 
-  /* intersection test callback function */
-  p4est_comm_intersect_t intersect;
 } p4est_comm_points_t;
 
 /** Destroy a \ref p4est_comm_points_t structure
@@ -605,14 +606,44 @@ typedef struct p4est_comm_points_t {
  */
 void p4est_comm_points_destroy (p4est_comm_points_t *c);
 
-/** Send points to the processes whose domain they *may* overlap. 
- * A return value of 0 indicates success.
+/** Collective, point-to-point communication for maintaining distributed
+ * collections of points. After communication, points are stored (only) on the
+ * processes whose domains they intersect. A return value of 0 indicates
+ * success. An error is returned if TODO
  * 
- * \param[in] p4est     The forest is not modified.
- * \param[in,out] c The model whose M and points variables change.
+ * Intended to be called in an alternating fashion with functions modifying
+ * the mesh or partition based on the collection of points. An example
+ * application is distributed search-based refinement, where at each iteration
+ * quadrants intersecting points are refined.
+ * 
+ * Points can be instances of an arbitrary struct. Point-quadrant intersection
+ * is specified by a user supplied callback function. A single point may
+ * intersect multiple process domains, and after communication will be known
+ * to each of these processes.
+ * 
+ * Each process is responsible for propagating a subset of the points it
+ * knows. Before communication, exactly one process should be responsible for
+ * propagating each point. The intersecting processes for each point are
+ * determined - by the responsible process - with \ref p4est_search_partition.
+ * Points are then communicated to the relevant processes. Points known to a
+ * process before communication that do not intersect its domain are
+ * forgotten. The algorithm ensures that after communication exactly one
+ * process is responsible for the propagation of each point. This is
+ * the process with the lowest rank among processes intersecting the point.
+ * 
+ * The points that a process is responsible for propagating are stored in a
+ * subarray of the array of known points, as described in 
+ * \ref p4est_comm_points_t. Users should take care to maintain this
+ * subdivision if they modify the array of points between rounds of
+ * communication.
+ * 
+ * \param[in] p4est The forest is not modified.
+ * \param[in,out] c Points and propagation responsibilities
+ * \param[in] intersect Intersection callback
  */
 int
-p4est_gmt_comm_points (p4est_t *p4est, p4est_comm_points_t *c);
+p4est_gmt_comm_points (p4est_t *p4est, p4est_comm_points_t *c, 
+                        p4est_comm_intersect_t intersect);
 
 SC_EXTERN_C_END;
 

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -642,7 +642,7 @@ void p4est_comm_points_destroy (p4est_comm_points_t *c);
  * \param[in] intersect Intersection callback
  */
 int
-p4est_gmt_comm_points (p4est_t *p4est, p4est_comm_points_t *c, 
+p4est_comm_points (p4est_t *p4est, p4est_comm_points_t *c, 
                         p4est_comm_intersect_t intersect);
 
 SC_EXTERN_C_END;

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -575,6 +575,45 @@ void                p4est_transfer_items_end (p4est_transfer_context_t * tc);
  */
 void                p4est_transfer_end (p4est_transfer_context_t * tc);
 
+/** Callback function for p4est_comm_points.
+ * Return true when \a point intersects \a quadrant.
+ * 
+ * \param[in] p4est the forest
+ * \param[in] which_tree tree containing quadrant
+ * \param[in] quadrant the quadrant
+ * \param[in] point the point
+*/
+typedef int         (*p4est_comm_intersect_t) (p4est_t * p4est,
+                                          p4est_topidx_t which_tree,
+                                          p4est_quadrant_t * quadrant,
+                                          void *point);
+
+typedef struct p4est_comm_points_t {
+  /* the points to exchange */
+  sc_array_t *points;
+
+  /* process is responsible for propagating the first num_resp points */
+  p4est_locidx_t num_resp;
+
+  /* intersection test callback function */
+  p4est_comm_intersect_t intersect;
+} p4est_comm_points_t;
+
+/** Destroy a \ref p4est_comm_points_t structure
+ * 
+ * \param[in,out] c the structure to destroy
+ */
+void p4est_comm_points_destroy (p4est_comm_points_t *c);
+
+/** Send points to the processes whose domain they *may* overlap. 
+ * A return value of 0 indicates success.
+ * 
+ * \param[in] p4est     The forest is not modified.
+ * \param[in,out] c The model whose M and points variables change.
+ */
+int
+p4est_gmt_comm_points (p4est_t *p4est, p4est_comm_points_t *c);
+
 SC_EXTERN_C_END;
 
 #endif /* !P4EST_COMMUNICATION_H */

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -578,15 +578,16 @@ void                p4est_transfer_end (p4est_transfer_context_t * tc);
 /** Callback function for \ref p4est_transfer_search.
  * Return true when \a point intersects \a quadrant.
  * 
- * \param[in] p4est the forest
- * \param[in] which_tree tree containing quadrant
- * \param[in] quadrant the quadrant
- * \param[in] point the point
+ * \param[in] which_tree Tree containing quadrant
+ * \param[in] quadrant The quadrant
+ * \param[in] point The point
+ * \param[in] user Optional user defined context
 */
-typedef int         (*p4est_intersect_t) (p4est_t * p4est,
-                                          p4est_topidx_t which_tree,
-                                          p4est_quadrant_t * quadrant,
-                                          void *point);
+typedef int         (*p4est_intersect_t) (p4est_topidx_t which_tree,
+                                          p4est_quadrant_t *quadrant,
+                                          void *point, void *user);
+/* TODO: does this function need a p4est? Does it need a user pointer? */
+/* TODO: finish point callback, then fill out the rest of the template */
 
 /** The points being exchanged in \ref p4est_transfer_search. */
 typedef struct p4est_transfer_search {
@@ -644,6 +645,18 @@ void p4est_transfer_search_destroy (p4est_transfer_search_t *c);
 int
 p4est_transfer_search (p4est_t *p4est, p4est_transfer_search_t *c, 
                         p4est_intersect_t intersect);
+
+/* TODO: a transfer search that does not use an explicit p4est:
+  - pass user context to intersection via a dummy p4est
+  - user context needs to be stored inside internal context
+  - are we passing internal context in another dummy p4est?
+      - internal context can be passed via the user pointer of the p4est-free
+        search_partition
+
+  - see the way it is done for search_partition
+    - first write an internal version that takes the dummy p4est, then
+      reference this in the others.
+ */
 
 SC_EXTERN_C_END;
 

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -575,7 +575,7 @@ void                p4est_transfer_items_end (p4est_transfer_context_t * tc);
  */
 void                p4est_transfer_end (p4est_transfer_context_t * tc);
 
-/** Callback function for p4est_comm_points.
+/** Callback function for p4est_transfer_search.
  * Return true when \a point intersects \a quadrant.
  * 
  * \param[in] p4est the forest
@@ -588,8 +588,8 @@ typedef int         (*p4est_comm_intersect_t) (p4est_t * p4est,
                                           p4est_quadrant_t * quadrant,
                                           void *point);
 
-/** The points being exchanged in \ref p4est_gmt_comm_points. */
-typedef struct p4est_comm_points_t {
+/** The points being exchanged in \ref p4est_gmt_transfer_search. */
+typedef struct p4est_transfer_search_t {
   /* The points to exchange */
   sc_array_t *points;
 
@@ -598,16 +598,16 @@ typedef struct p4est_comm_points_t {
    * for their propagation. */
   p4est_locidx_t num_resp;
 
-} p4est_comm_points_t;
+} p4est_transfer_search_t;
 
-/** Destroy a \ref p4est_comm_points_t structure
+/** Destroy a \ref p4est_transfer_search_t structure
  * 
  * \param[in,out] c the structure to destroy
  */
-void p4est_comm_points_destroy (p4est_comm_points_t *c);
+void p4est_transfer_search_destroy (p4est_transfer_search_t *c);
 
-/** Collective, point-to-point communication for maintaining distributed
- * collections of points. After communication, points are stored (only) on the
+/** Collective, point-to-point transfer for maintaining distributed
+ * collection of points. After communication, points are stored (only) on the
  * processes whose domains they intersect. A return value of 0 indicates
  * success. An error is returned if TODO
  * 
@@ -633,7 +633,7 @@ void p4est_comm_points_destroy (p4est_comm_points_t *c);
  * 
  * The points that a process is responsible for propagating are stored in a
  * subarray of the array of known points, as described in 
- * \ref p4est_comm_points_t. Users should take care to maintain this
+ * \ref p4est_transfer_search_t. Users should take care to maintain this
  * subdivision if they modify the array of points between rounds of
  * communication.
  * 
@@ -642,7 +642,7 @@ void p4est_comm_points_destroy (p4est_comm_points_t *c);
  * \param[in] intersect Intersection callback
  */
 int
-p4est_comm_points (p4est_t *p4est, p4est_comm_points_t *c, 
+p4est_transfer_search (p4est_t *p4est, p4est_transfer_search_t *c, 
                         p4est_comm_intersect_t intersect);
 
 SC_EXTERN_C_END;

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -582,7 +582,7 @@ void                p4est_transfer_end (p4est_transfer_context_t * tc);
  * \param[in] quadrant The quadrant
  * \param[in] point The point
  * \param[in] user Optional user defined context
-*/
+ */
 typedef int         (*p4est_intersect_t) (p4est_topidx_t which_tree,
                                           p4est_quadrant_t *quadrant,
                                           void *point, void *user);
@@ -638,25 +638,61 @@ void p4est_transfer_search_destroy (p4est_transfer_search_t *c);
  * subdivision if they modify the array of points between rounds of
  * communication.
  * 
- * \param[in] p4est The forest is not modified.
- * \param[in,out] c Points and propagation responsibilities
- * \param[in] intersect Intersection callback
+ * \param[in] p4est     The forest we search with. Its user_pointer is passed
+ *                      to the intersection callback.
+ * \param[in,out] c     Points and propagation responsibilities.
+ * \param[in] intersect Intersection callback.
  */
 int
 p4est_transfer_search (p4est_t *p4est, p4est_transfer_search_t *c, 
                         p4est_intersect_t intersect);
 
-/* TODO: a transfer search that does not use an explicit p4est:
-  - pass user context to intersection via a dummy p4est
-  - user context needs to be stored inside internal context
-  - are we passing internal context in another dummy p4est?
-      - internal context can be passed via the user pointer of the p4est-free
-        search_partition
-
-  - see the way it is done for search_partition
-    - first write an internal version that takes the dummy p4est, then
-      reference this in the others.
+/** The same as \ref p4est_transfer_search, except that we search with a
+ * partition, rather than an explicit p4est. The partition can be that of any
+ * p4est, not necessarily known to the caller.
+ * 
+ * This function is collective.
+ * 
+ * \param [in] gfq          Partition offsets to traverse.  Length \a nmemb + 1.
+ * \param [in] gfp          Partition position to traverse.  Length \a nmemb + 1.
+ * \param [in] nmemb        Number of processors encoded in \a gfq (plus one).
+ * \param [in] num_trees    Tree number must match the contents of \a gfq.
+ * \param [in] user_pointer Passed to the intersection callback.
+ * \param[in,out] c         Points and propagation responsibilities.
+ * \param[in] intersect     Intersection callback.
  */
+int
+p4est_transfer_search_gfx (const p4est_gloidx_t *gfq,
+                            const p4est_quadrant_t *gfp,
+                            int nmemb, p4est_topidx_t num_trees,
+                            void *user_pointer,
+                            p4est_transfer_search_t *c,
+                            p4est_intersect_t intersect);
+
+/** The same as \ref p4est_transfer_search, except that we search with a
+ * partition, rather than an explicit p4est. The partition can be that of any
+ * p4est, not necessarily known to the caller.
+ * 
+ * This function is similar to \ref p4est_transfer_search_gfx, but does not
+ * require the \ref p4est_gloidx_t array gfq. If gfq is available, using
+ * \ref p4est_transfer_search_gfx is recommended, because it is slightly
+ * faster.
+ * 
+ * This function is collective.
+ * 
+ * \param [in] gfp          Partition position to traverse.  Length \a nmemb + 1.
+ * \param [in] nmemb        Number of processors encoded in \a gfq (plus one).
+ * \param [in] num_trees    Tree number must match the contents of \a gfq.
+ * \param [in] user_pointer Passed to the intersection callback.
+ * \param[in,out] c         Points and propagation responsibilities.
+ * \param[in] intersect     Intersection callback.
+ */
+int
+p4est_transfer_search_gfp (const p4est_quadrant_t *gfp, int nmemb,
+                            p4est_topidx_t num_trees,
+                            void *user_pointer,
+                            p4est_transfer_search_t *c,
+                            p4est_intersect_t intersect);
 
 SC_EXTERN_C_END;
 

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -608,15 +608,14 @@ void p4est_transfer_search_destroy (p4est_transfer_search_t *c);
 /** Collective, point-to-point transfer for maintaining distributed
  * collection of points. After communication, points are stored (only) on the
  * processes whose domains they intersect. A return value of 0 indicates
- * success. An error is returned if TODO
- * 
- * Intended to be called in an alternating fashion with functions modifying
- * the mesh or partition based on the collection of points. An example
- * application is distributed search-based refinement, where at each iteration
- * quadrants intersecting points are refined.
+ * success. An nonzero value is returned to indicate error. Errors occurs when
+ * the number of bytes transferred in any single message would exceed 
+ * INT_MAX (2GB on most machines), or if any process would receive more than
+ * P4EST_LOCIDX_MAX points in total. Error/success is collective. If an error
+ * does occur then the contents of \a c are not modified.
  * 
  * Points can be instances of an arbitrary struct. Point-quadrant intersection
- * is specified by a user supplied callback function. A single point may
+ * is specified by the user supplied callback \a intersect. A single point may
  * intersect multiple process domains, and after communication will be known
  * to each of these processes.
  * 

--- a/src/p4est_communication.h
+++ b/src/p4est_communication.h
@@ -575,7 +575,7 @@ void                p4est_transfer_items_end (p4est_transfer_context_t * tc);
  */
 void                p4est_transfer_end (p4est_transfer_context_t * tc);
 
-/** Callback function for p4est_transfer_search.
+/** Callback function for \ref p4est_transfer_search.
  * Return true when \a point intersects \a quadrant.
  * 
  * \param[in] p4est the forest
@@ -583,19 +583,19 @@ void                p4est_transfer_end (p4est_transfer_context_t * tc);
  * \param[in] quadrant the quadrant
  * \param[in] point the point
 */
-typedef int         (*p4est_comm_intersect_t) (p4est_t * p4est,
+typedef int         (*p4est_intersect_t) (p4est_t * p4est,
                                           p4est_topidx_t which_tree,
                                           p4est_quadrant_t * quadrant,
                                           void *point);
 
-/** The points being exchanged in \ref p4est_gmt_transfer_search. */
-typedef struct p4est_transfer_search_t {
+/** The points being exchanged in \ref p4est_transfer_search. */
+typedef struct p4est_transfer_search {
   /* The points to exchange */
   sc_array_t *points;
 
-  /* Process is responsible for propagating the first num_resp points. 
-   * The remaining points are known to other processes which are responsible
-   * for their propagation. */
+  /* Process is responsible for propagating the first num_resp points that it
+   * knows. The remaining points are additionally known to other processes
+   * which are responsible for their propagation. */
   p4est_locidx_t num_resp;
 
 } p4est_transfer_search_t;
@@ -643,7 +643,7 @@ void p4est_transfer_search_destroy (p4est_transfer_search_t *c);
  */
 int
 p4est_transfer_search (p4est_t *p4est, p4est_transfer_search_t *c, 
-                        p4est_comm_intersect_t intersect);
+                        p4est_intersect_t intersect);
 
 SC_EXTERN_C_END;
 

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -172,6 +172,8 @@
 #define p4est_build_t                   p8est_build_t
 #define p4est_transfer_comm_t           p8est_transfer_comm_t
 #define p4est_transfer_context_t        p8est_transfer_context_t
+#define p4est_transfer_search_t         p8est_transfer_search_t
+#define p4est_intersect_t               p8est_intersect_t
 #define p4est_mesh_t                    p8est_mesh_t
 #define p4est_mesh_face_neighbor_t      p8est_mesh_face_neighbor_t
 #define p4est_wrap_t                    p8est_wrap_t
@@ -486,6 +488,8 @@
 #define p4est_transfer_items_begin      p8est_transfer_items_begin
 #define p4est_transfer_items_end        p8est_transfer_items_end
 #define p4est_transfer_end              p8est_transfer_end
+#define p4est_transfer_search           p8est_transfer_search
+#define p4est_transfer_search_destroy   p8est_transfer_search_destroy
 
 /* functions in p4est_io */
 #define p4est_deflate_quadrants         p8est_deflate_quadrants

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -489,6 +489,8 @@
 #define p4est_transfer_items_end        p8est_transfer_items_end
 #define p4est_transfer_end              p8est_transfer_end
 #define p4est_transfer_search           p8est_transfer_search
+#define p4est_transfer_search_gfx       p8est_transfer_search_gfx
+#define p4est_transfer_search_gfp       p8est_transfer_search_gfp
 #define p4est_transfer_search_destroy   p8est_transfer_search_destroy
 
 /* functions in p4est_io */

--- a/src/p8est_communication.h
+++ b/src/p8est_communication.h
@@ -625,10 +625,10 @@ void p8est_transfer_search_destroy (p8est_transfer_search_t *c);
  * subdivision if they modify the array of points between rounds of
  * communication.
  * 
- * \param[in] p8est     The forest we search with. Its user_pointer is passed
- *                      to the intersection callback.
- * \param[in,out] c     Points and propagation responsibilities.
- * \param[in] intersect Intersection callback.
+ * \param [in] p8est     The forest we search with. Its user_pointer is passed
+ *                       to the intersection callback.
+ * \param [in,out] c     Points and propagation responsibilities.
+ * \param [in] intersect Intersection callback.
  */
 int
 p8est_transfer_search (p8est_t *p8est, p8est_transfer_search_t *c, 
@@ -645,14 +645,16 @@ p8est_transfer_search (p8est_t *p8est, p8est_transfer_search_t *c,
  * \param [in] nmemb        Number of processors encoded in \a gfq (plus one).
  * \param [in] num_trees    Tree number must match the contents of \a gfq.
  * \param [in] user_pointer Passed to the intersection callback.
- * \param[in,out] c         Points and propagation responsibilities.
- * \param[in] intersect     Intersection callback.
+ * \param [in] sc_MPI_Comm  Function is collective over the communicator.
+ * \param [in,out] c        Points and propagation responsibilities.
+ * \param [in] intersect    Intersection callback.
  */
 int
 p8est_transfer_search_gfx (const p4est_gloidx_t *gfq,
                             const p8est_quadrant_t *gfp,
                             int nmemb, p4est_topidx_t num_trees,
                             void *user_pointer,
+                            sc_MPI_Comm mpicomm,
                             p8est_transfer_search_t *c,
                             p8est_intersect_t intersect);
 
@@ -671,13 +673,15 @@ p8est_transfer_search_gfx (const p4est_gloidx_t *gfq,
  * \param [in] nmemb        Number of processors encoded in \a gfq (plus one).
  * \param [in] num_trees    Tree number must match the contents of \a gfq.
  * \param [in] user_pointer Passed to the intersection callback.
- * \param[in,out] c         Points and propagation responsibilities.
- * \param[in] intersect     Intersection callback.
+ * \param [in] sc_MPI_Comm  Function is collective over the communicator.
+ * \param [in,out] c        Points and propagation responsibilities.
+ * \param [in] intersect    Intersection callback.
  */
 int
 p8est_transfer_search_gfp (const p8est_quadrant_t *gfp, int nmemb,
                             p4est_topidx_t num_trees,
                             void *user_pointer,
+                            sc_MPI_Comm mpicomm,
                             p8est_transfer_search_t *c,
                             p8est_intersect_t intersect);
 

--- a/src/p8est_communication.h
+++ b/src/p8est_communication.h
@@ -625,13 +625,61 @@ void p8est_transfer_search_destroy (p8est_transfer_search_t *c);
  * subdivision if they modify the array of points between rounds of
  * communication.
  * 
- * \param[in] p8est The forest is not modified.
- * \param[in,out] c Points and propagation responsibilities
- * \param[in] intersect Intersection callback
+ * \param[in] p8est     The forest we search with. Its user_pointer is passed
+ *                      to the intersection callback.
+ * \param[in,out] c     Points and propagation responsibilities.
+ * \param[in] intersect Intersection callback.
  */
 int
 p8est_transfer_search (p8est_t *p8est, p8est_transfer_search_t *c, 
                         p8est_intersect_t intersect);
+
+/** The same as \ref p8est_transfer_search, except that we search with a
+ * partition, rather than an explicit p8est. The partition can be that of any
+ * p8est, not necessarily known to the caller.
+ * 
+ * This function is collective.
+ * 
+ * \param [in] gfq          Partition offsets to traverse.  Length \a nmemb + 1.
+ * \param [in] gfp          Partition position to traverse.  Length \a nmemb + 1.
+ * \param [in] nmemb        Number of processors encoded in \a gfq (plus one).
+ * \param [in] num_trees    Tree number must match the contents of \a gfq.
+ * \param [in] user_pointer Passed to the intersection callback.
+ * \param[in,out] c         Points and propagation responsibilities.
+ * \param[in] intersect     Intersection callback.
+ */
+int
+p8est_transfer_search_gfx (const p4est_gloidx_t *gfq,
+                            const p8est_quadrant_t *gfp,
+                            int nmemb, p4est_topidx_t num_trees,
+                            void *user_pointer,
+                            p8est_transfer_search_t *c,
+                            p8est_intersect_t intersect);
+
+/** The same as \ref p8est_transfer_search, except that we search with a
+ * partition, rather than an explicit p8est. The partition can be that of any
+ * p8est, not necessarily known to the caller.
+ * 
+ * This function is similar to \ref p8est_transfer_search_gfx, but does not
+ * require the \ref p4est_gloidx_t array gfq. If gfq is available, using
+ * \ref p8est_transfer_search_gfx is recommended, because it is slightly
+ * faster.
+ * 
+ * This function is collective.
+ * 
+ * \param [in] gfp          Partition position to traverse.  Length \a nmemb + 1.
+ * \param [in] nmemb        Number of processors encoded in \a gfq (plus one).
+ * \param [in] num_trees    Tree number must match the contents of \a gfq.
+ * \param [in] user_pointer Passed to the intersection callback.
+ * \param[in,out] c         Points and propagation responsibilities.
+ * \param[in] intersect     Intersection callback.
+ */
+int
+p8est_transfer_search_gfp (const p8est_quadrant_t *gfp, int nmemb,
+                            p4est_topidx_t num_trees,
+                            void *user_pointer,
+                            p8est_transfer_search_t *c,
+                            p8est_intersect_t intersect);
 
 SC_EXTERN_C_END;
 

--- a/src/p8est_communication.h
+++ b/src/p8est_communication.h
@@ -567,15 +567,14 @@ void                p8est_transfer_end (p8est_transfer_context_t * tc);
 /** Callback function for \ref p8est_transfer_search.
  * Return true when \a point intersects \a quadrant.
  * 
- * \param[in] p8est the forest
- * \param[in] which_tree tree containing quadrant
- * \param[in] quadrant the quadrant
- * \param[in] point the point
+ * \param[in] which_tree Tree containing quadrant
+ * \param[in] quadrant The quadrant
+ * \param[in] point The point
+ * \param[in] user Optional user defined context
 */
-typedef int         (*p8est_intersect_t) (p8est_t * p8est,
-                                          p4est_topidx_t which_tree,
+typedef int         (*p8est_intersect_t) (p4est_topidx_t which_tree,
                                           p8est_quadrant_t * quadrant,
-                                          void *point);
+                                          void *point, void *user);
 
 /** The points being exchanged in \ref p8est_transfer_search. */
 typedef struct p8est_transfer_search_t {

--- a/src/p8est_communication.h
+++ b/src/p8est_communication.h
@@ -597,15 +597,14 @@ void p8est_transfer_search_destroy (p8est_transfer_search_t *c);
 /** Collective, point-to-point transfer for maintaining distributed
  * collection of points. After communication, points are stored (only) on the
  * processes whose domains they intersect. A return value of 0 indicates
- * success. An error is returned if TODO
- * 
- * Intended to be called in an alternating fashion with functions modifying
- * the mesh or partition based on the collection of points. An example
- * application is distributed search-based refinement, where at each iteration
- * quadrants intersecting points are refined.
+ * success. An nonzero value is returned to indicate error. Errors occurs when
+ * the number of bytes transferred in any single message would exceed 
+ * INT_MAX (2GB on most machines), or if any process would receive more than
+ * P4EST_LOCIDX_MAX points in total. Error/success is collective. If an error
+ * does occur then the contents of \a c are not modified.
  * 
  * Points can be instances of an arbitrary struct. Point-quadrant intersection
- * is specified by a user supplied callback function. A single point may
+ * is specified by the user supplied callback \a intersect. A single point may
  * intersect multiple process domains, and after communication will be known
  * to each of these processes.
  * 


### PR DESCRIPTION
This is an abstracted version of the algorithm I wrote for the GMT example.

`p4est_transfer_search` is a collective, point-to-point transfer for maintaining a distributed collection of points. After communication, points are stored (only) on the processes whose domains they intersect. 

Points can be instances of an arbitrary struct. Point-quadrant intersection is specified by a user supplied callback. A single point may intersect multiple process domains, and after communication will be known to each of these processes.

Each process is responsible for propagating a subset of the points it knows. Before communication, exactly one process should be responsible for propagating each point. The intersecting processes for each point are determined - by the responsible process - with `p4est_search_partition`. Points are then communicated to the relevant processes. Points known to a process before communication that do not intersect its domain are forgotten. The algorithm ensures that after communication exactly one process is responsible for the propagation of each point. This is the process with the lowest rank among processes intersecting the point.

I have rewritten my portion of the GMT example to use this abstracted version. This rewrite breaks the other parts of the example, due to intersection callbacks having a different type. The rewrite can be found here: https://github.com/ljcarlin/p4est/tree/feature-gmt