### PR TITLE
Check if libsc is already a known target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ message(STATUS "p4est ${PROJECT_VERSION} "
 
 # Skip `libsc` if already registered. This is useful when `p4est` is added as a
 # dependency by another software project which in turn already registered `libsc`.
-if(NOT TARGET sc)
+if(NOT TARGET SC::SC)
   include(cmake/GitSubmodule.cmake)
   git_submodule("${PROJECT_SOURCE_DIR}/sc")
   add_subdirectory(sc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,13 @@ message(STATUS "p4est ${PROJECT_VERSION} "
 
 # --- external libs
 
-include(cmake/GitSubmodule.cmake)
-git_submodule("${PROJECT_SOURCE_DIR}/sc")
-add_subdirectory(sc)
+# Skip `libsc` if already registered. This is useful when `p4est` is added as a
+# dependency by another software project which in turn already registered `libsc`.
+if(NOT TARGET sc)
+  include(cmake/GitSubmodule.cmake)
+  git_submodule("${PROJECT_SOURCE_DIR}/sc")
+  add_subdirectory(sc)
+endif()
 
 # --- configure p4est
 


### PR DESCRIPTION
# Check if libsc is already a known target.

Proposed changes:

This PR adds a check if libsc is already a known target in the CMake build system. If
this is the case, registering libsc is skipped.

This is useful for cases when p4est is included as dependency by other software projects, e.g. t8code,
which in turn also depends on libsc. If this check would not be there CMake registers libsc twice which
causes conflicts.
