### PR TITLE
Feature wrap partition

### DIFF
--- a/src/p4est_wrap.c
+++ b/src/p4est_wrap.c
@@ -666,6 +666,7 @@ p4est_wrap_adapt (p4est_wrap_t * pp)
                                      pp->num_refine_flags);
 
 
+  checksum_entry = 0;
   if ((have_zlib = p4est_have_zlib())) {
     /* store p4est checksum on entry to compare with results after balancing */
     global_num_entry = p4est->global_num_quadrants;

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -106,6 +106,7 @@ typedef struct p4est_wrap
   int                 weight_exponent;
   uint8_t            *flags, *temp_flags;
   p4est_locidx_t      num_refine_flags, inside_counter, num_replaced;
+  p4est_gloidx_t     *old_global_first_quadrant;
 
   /* for ghost and mesh use p4est_wrap_get_ghost, _mesh declared below */
   p4est_ghost_t      *ghost;

--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -106,6 +106,7 @@ typedef struct p8est_wrap
   int                 weight_exponent;
   uint8_t            *flags, *temp_flags;
   p4est_locidx_t      num_refine_flags, inside_counter, num_replaced;
+  p4est_gloidx_t     *old_global_first_quadrant;
 
   /* for ghost and mesh use p8est_wrap_get_ghost, _mesh declared below */
   p8est_ghost_t      *ghost;


### PR DESCRIPTION
This PR adds a member `old_global_first_quadrant` to the `p4est_wrap_t`.
It stores the global_first_quadrant array of the wrap's p4est before partitioning and can be used to organize data transfers with `transfer_fixed` and `transfer_custom` in between calls to `wrap_partition` and `wrap_adapt`.
