### PR TITLE
CMake option to use a system installed sc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,19 +18,17 @@ message(STATUS "p4est ${PROJECT_VERSION} "
 
 # --- external libs
 
-# Option to use an already installed SC library.
-if ( P4EST_USE_SYSTEM_SC )
-    find_package( SC REQUIRED PATHS /path/to/system/sc )
-else()
-    add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/sc )
-endif()
-
 # Skip `libsc` if already registered. This is useful when `p4est` is added as a
 # dependency by another software project which in turn already registered `libsc`.
 if(NOT TARGET SC::SC)
-  include(cmake/GitSubmodule.cmake)
-  git_submodule("${PROJECT_SOURCE_DIR}/sc")
-  add_subdirectory(sc)
+  # Option to use an already installed SC library.
+  if ( P4EST_USE_SYSTEM_SC )
+      find_package( SC REQUIRED PATHS /path/to/system/sc )
+  else()
+    include(cmake/GitSubmodule.cmake)
+    git_submodule("${PROJECT_SOURCE_DIR}/sc")
+    add_subdirectory(sc)
+  endif()
 endif()
 
 # --- configure p4est

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,13 @@ message(STATUS "p4est ${PROJECT_VERSION} "
 
 # --- external libs
 
+# Option to use an already installed SC library.
+if ( P4EST_USE_SYSTEM_SC )
+    find_package( SC REQUIRED PATHS /path/to/system/sc )
+else()
+    add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/sc )
+endif()
+
 # Skip `libsc` if already registered. This is useful when `p4est` is added as a
 # dependency by another software project which in turn already registered `libsc`.
 if(NOT TARGET SC::SC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ message(STATUS "p4est ${PROJECT_VERSION} "
 if(NOT TARGET SC::SC)
   # Option to use an already installed SC library.
   if ( P4EST_USE_SYSTEM_SC )
-      find_package( SC REQUIRED PATHS /path/to/system/sc )
+      find_package( SC REQUIRED )
   else()
     include(cmake/GitSubmodule.cmake)
     git_submodule("${PROJECT_SOURCE_DIR}/sc")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -5,6 +5,8 @@ option(P4EST_BUILD_TESTING "build p4est testing" on)
 
 option(enable-file-deprecated "use deprecated data file format" off)
 
+option( P4EST_USE_SYSTEM_SC "Use system-installed sc library" OFF )
+
 option(vtk_binary "VTK binary interface" on)
 if(vtk_binary)
   set(P4EST_ENABLE_VTK_BINARY 1)

--- a/doc/author_elsweijer.txt
+++ b/doc/author_elsweijer.txt
@@ -1,0 +1,1 @@
+I place my contributions to p4est under the FreeBSD license. Sandro Elsweijer (Sandro.Elsweijer@dlr.de)


### PR DESCRIPTION
# Add CMake option to use a system installed SC 

Proposed changes:
For our new t8code CMake CI we need the option to build p4est with a system installed SC version.
This option already exists in p4ests autotools build system but does not exist in the CMake build system.
This PR adds this option. The standard behavior of p4ests CMake build system is not altered since the standard policy is to use the SC which ships with p4est.
