### PR TITLE
Newly adapted quadrants in wrap

### DIFF
--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -613,8 +613,6 @@
 #define p4est_wrap_destroy              p8est_wrap_destroy
 #define p4est_wrap_set_hollow           p8est_wrap_set_hollow
 #define p4est_wrap_set_coarsen_delay    p8est_wrap_set_coarsen_delay
-#define p4est_wrap_set_partitioning     p8est_wrap_set_partitioning
-#define p4est_wrap_set_store_adapted    p8est_wrap_set_store_adapted
 #define p4est_wrap_get_ghost            p8est_wrap_get_ghost
 #define p4est_wrap_get_mesh             p8est_wrap_get_mesh
 #define p4est_wrap_mark_refine          p8est_wrap_mark_refine

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -614,6 +614,7 @@
 #define p4est_wrap_set_hollow           p8est_wrap_set_hollow
 #define p4est_wrap_set_coarsen_delay    p8est_wrap_set_coarsen_delay
 #define p4est_wrap_set_partitioning     p8est_wrap_set_partitioning
+#define p4est_wrap_set_store_adapted    p8est_wrap_set_store_adapted
 #define p4est_wrap_get_ghost            p8est_wrap_get_ghost
 #define p4est_wrap_get_mesh             p8est_wrap_get_mesh
 #define p4est_wrap_mark_refine          p8est_wrap_mark_refine

--- a/src/p4est_wrap.c
+++ b/src/p4est_wrap.c
@@ -865,11 +865,9 @@ p4est_wrap_adapt (p4est_wrap_t * pp)
           qz++;
         }
       }
-      P4EST_ASSERT (zz == tquadrants->elem_count
-                    || pp->params.partition_for_coarsening == 0);
+      P4EST_ASSERT (zz == tquadrants->elem_count);
     }
-    P4EST_ASSERT (qz == quad_levels->elem_count
-                  || pp->params.partition_for_coarsening == 0);
+    P4EST_ASSERT (qz == quad_levels->elem_count);
   }
   sc_array_destroy (quad_levels);
 

--- a/src/p4est_wrap.c
+++ b/src/p4est_wrap.c
@@ -596,30 +596,6 @@ p4est_wrap_set_partitioning (p4est_wrap_t *pp, int partition_for_coarsening)
   pp->params.partition_for_coarsening = partition_for_coarsening;
 }
 
-void
-p4est_wrap_set_store_adapted (p4est_wrap_t * pp, int store_adapted)
-{
-  P4EST_ASSERT (pp != NULL);
-
-  if (pp->params.store_adapted == store_adapted) {
-    return;                     /* nothing to do */
-  }
-
-  if (store_adapted) {
-    P4EST_ASSERT (pp->newly_refined == NULL);
-    pp->newly_refined = sc_array_new (sizeof (p4est_locidx_t));
-    P4EST_ASSERT (pp->newly_coarsened == NULL);
-    pp->newly_coarsened = sc_array_new (sizeof (p4est_locidx_t));
-  }
-  else {
-    P4EST_ASSERT (pp->newly_refined != NULL);
-    sc_array_destroy_null (&pp->newly_refined);
-    P4EST_ASSERT (pp->newly_coarsened != NULL);
-    sc_array_destroy_null (&pp->newly_coarsened);
-  }
-  pp->params.store_adapted = store_adapted;
-}
-
 p4est_ghost_t      *
 p4est_wrap_get_ghost (p4est_wrap_t * pp)
 {

--- a/src/p4est_wrap.c
+++ b/src/p4est_wrap.c
@@ -732,6 +732,8 @@ p4est_wrap_adapt (p4est_wrap_t * pp)
 
   quad_levels = sc_array_new (sizeof (int8_t));
   if (pp->params.store_adapted) {
+    P4EST_ASSERT (p4est_is_balanced (pp->p4est, pp->params.mesh_params.btype));
+
     /* store p4est levels to compare with future adapted version */
     sc_array_resize (quad_levels, p4est->local_num_quadrants);
 

--- a/src/p4est_wrap.c
+++ b/src/p4est_wrap.c
@@ -589,13 +589,6 @@ p4est_wrap_set_coarsen_delay (p4est_wrap_t * pp,
   }
 }
 
-void
-p4est_wrap_set_partitioning (p4est_wrap_t *pp, int partition_for_coarsening)
-{
-  P4EST_ASSERT (pp != NULL);
-  pp->params.partition_for_coarsening = partition_for_coarsening;
-}
-
 p4est_ghost_t      *
 p4est_wrap_get_ghost (p4est_wrap_t * pp)
 {

--- a/src/p4est_wrap.c
+++ b/src/p4est_wrap.c
@@ -489,6 +489,8 @@ p4est_wrap_destroy (p4est_wrap_t * pp)
     p4est_ghost_destroy (pp->ghost);
   }
 
+  P4EST_ASSERT (pp->params.store_adapted ||
+                (pp->newly_refined == NULL && pp->newly_coarsened == NULL));
   if (pp->params.store_adapted) {
     P4EST_ASSERT (pp->newly_refined != NULL &&
                   pp->newly_refined->elem_size == sizeof (p4est_locidx_t));
@@ -599,6 +601,30 @@ p4est_wrap_set_partitioning (p4est_wrap_t *pp, int partition_for_coarsening)
 {
   P4EST_ASSERT (pp != NULL);
   pp->params.partition_for_coarsening = partition_for_coarsening;
+}
+
+void
+p4est_wrap_set_store_adapted (p4est_wrap_t * pp, int store_adapted)
+{
+  P4EST_ASSERT (pp != NULL);
+
+  if (pp->params.store_adapted == store_adapted) {
+    return;                     /* nothing to do */
+  }
+
+  if (store_adapted) {
+    P4EST_ASSERT (pp->newly_refined == NULL);
+    pp->newly_refined = sc_array_new (sizeof (p4est_locidx_t));
+    P4EST_ASSERT (pp->newly_coarsened == NULL);
+    pp->newly_coarsened = sc_array_new (sizeof (p4est_locidx_t));
+  }
+  else {
+    P4EST_ASSERT (pp->newly_refined != NULL);
+    sc_array_destroy_null (&pp->newly_refined);
+    P4EST_ASSERT (pp->newly_coarsened != NULL);
+    sc_array_destroy_null (&pp->newly_coarsened);
+  }
+  pp->params.store_adapted = store_adapted;
 }
 
 p4est_ghost_t      *

--- a/src/p4est_wrap.c
+++ b/src/p4est_wrap.c
@@ -321,11 +321,9 @@ p4est_wrap_new_copy (p4est_wrap_t * source, size_t data_size,
   }
 
   /* copy newly_adapted arrays if set */
-  P4EST_ASSERT (source->params.store_adapted ||
-                (source->newly_refined == NULL &&
-                 source->newly_coarsened == NULL));
-  if (pp->params.store_adapted && source->newly_refined != NULL) {
-    P4EST_ASSERT (source->newly_coarsened != NULL);
+  P4EST_ASSERT ((source->newly_refined == NULL) ==
+                (source->newly_coarsened == NULL));
+  if (source->newly_refined != NULL) {
     P4EST_ASSERT (source->newly_refined->elem_size ==
                   sizeof (p4est_locidx_t));
     P4EST_ASSERT (source->newly_coarsened->elem_size ==
@@ -483,10 +481,8 @@ p4est_wrap_destroy (p4est_wrap_t * pp)
     p4est_ghost_destroy (pp->ghost);
   }
 
-  P4EST_ASSERT (pp->params.store_adapted ||
-                (pp->newly_refined == NULL && pp->newly_coarsened == NULL));
-  if (pp->params.store_adapted && pp->newly_refined != NULL) {
-    P4EST_ASSERT (pp->newly_coarsened != NULL);
+  P4EST_ASSERT ((pp->newly_refined == NULL) == (pp->newly_coarsened == NULL));
+  if (pp->newly_refined != NULL) {
     P4EST_ASSERT (pp->newly_refined->elem_size == sizeof (p4est_locidx_t));
     P4EST_ASSERT (pp->newly_coarsened->elem_size == sizeof (p4est_locidx_t));
     sc_array_destroy (pp->newly_refined);
@@ -793,14 +789,14 @@ p4est_wrap_adapt (p4est_wrap_t * pp)
 #endif
   pp->num_refine_flags = 0;
 
+  /* update newly_adapted arrays */
+  P4EST_ASSERT ((pp->newly_refined == NULL) == (pp->newly_coarsened == NULL));
+  if (pp->newly_refined != NULL) {
+    /* delete previous newly_adapted arrays, if there are any */
+    sc_array_destroy_null (&pp->newly_refined);
+    sc_array_destroy_null (&pp->newly_coarsened);
+  }
   if (pp->params.store_adapted) {
-    /* delete previous newly_adapted entries, if there are any */
-    if (pp->newly_refined != NULL) {
-      P4EST_ASSERT (pp->newly_coarsened != NULL);
-      sc_array_destroy_null (&pp->newly_refined);
-      sc_array_destroy_null (&pp->newly_coarsened);
-    }
-
     pp->newly_refined = sc_array_new (sizeof (p4est_locidx_t));
     pp->newly_coarsened = sc_array_new (sizeof (p4est_locidx_t));
 

--- a/src/p4est_wrap.c
+++ b/src/p4est_wrap.c
@@ -710,7 +710,8 @@ p4est_wrap_adapt (p4est_wrap_t * pp)
   p4est_t            *p4est = pp->p4est;
   sc_array_t         *quad_levels;
   int8_t             *level;
-  size_t              tt, qz, zz;
+  size_t              qz, zz;
+  p4est_topidx_t      tt;
   p4est_tree_t       *tree;
   sc_array_t         *tquadrants;
   p4est_quadrant_t   *quadrant;
@@ -740,7 +741,7 @@ p4est_wrap_adapt (p4est_wrap_t * pp)
       tree = p4est_tree_array_index (p4est->trees, tt);
       tquadrants = &tree->quadrants;
       for (zz = 0; zz < tquadrants->elem_count; ++zz, ++qz) {
-        level = sc_array_index (quad_levels, qz);
+        level = (int8_t *) sc_array_index (quad_levels, qz);
         quadrant = p4est_quadrant_array_index (tquadrants, zz);
         *level = quadrant->level;
       }

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -302,21 +302,6 @@ void                p4est_wrap_set_coarsen_delay (p4est_wrap_t * pp,
                                                   int coarsen_delay,
                                                   int coarsen_affect);
 
-/** Set a parameter that ensures future partitions allow one level of coarsening.
- * The partition_for_coarsening parameter is passed to \ref p4est_partition_ext
- * in \ref p4est_wrap_partition.
- * If not zero, all future calls to \ref p4est_wrap_partition will partition
- * in a manner that allows one level of coarsening. This function does not
- * automatically repartition the mesh, when switching partition_for_coarsening
- * to a non-zero value.
- * \param [in,out] pp           A valid p4est_wrap structure.
- * \param [in] partition_for_coarsening Boolean:  If true, all future partitions
- *                              of the wrap allow one level of coarsening.
- *                              Suggested default: 1.
- */
-void                p4est_wrap_set_partitioning (p4est_wrap_t *pp,
-                                                 int partition_for_coarsening);
-
 /** Return the appropriate ghost layer.
  * This function is necessary since two versions may exist simultaneously
  * after refinement and before partition/complete.

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -116,7 +116,10 @@ typedef struct p4est_wrap
    * was directly after completion of \ref p4est_wrap_adapt. So, they are not
    * updated in \ref p4est_wrap_partition. Newly_refined only stores newly
    * refined quadrants with child id 0. */
-  sc_array_t         *newly_refined, *newly_coarsened;
+  sc_array_t         *newly_refined; /**< Indices of quadrants refined during
+                                          most recent \ref p4est_wrap_adapt */
+  sc_array_t         *newly_coarsened; /**< Indices of quadrants coarsened during
+                                            most recent \ref p4est_wrap_adapt */
 
   /* anything below here is considered private und should not be touched */
   int                 weight_exponent;

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -112,6 +112,14 @@ typedef struct p4est_wrap
   uint8_t            *flags, *temp_flags;
   p4est_locidx_t      num_refine_flags, inside_counter, num_replaced;
   p4est_gloidx_t     *old_global_first_quadrant;
+
+  /* These arrays are initialized during wrap creation, if \a params.store_adapted
+   * evaluates to true and contain the indices  of the quadrants refined during
+   * the last call to \ref p4est_wrap_adapt.
+   * At every time they index into the local quadrants of the p4est as it was
+   * directly  after completion of \ref p4est_wrap_adapt. So, they are not
+   * updated in \ref p4est_wrap_partition. Newly_refined only stores newly
+   * refined quadrants with child id 0. */
   sc_array_t         *newly_refined, *newly_coarsened;
 
   /* for ghost and mesh use p4est_wrap_get_ghost, _mesh declared below */

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -111,8 +111,9 @@ typedef struct p4est_wrap
    * quadrants refined and coarsened during the most recent call to
    * \ref p4est_wrap_adapt. The wrap's \a p4est has to be balanced when entering
    * the adaptation, to avoid multi-level refinement.
+   * The arrays are allocated during the first call of \ref p4est_wrap_adapt.
    * At every time the arrays index into the local quadrants of the p4est as it
-   * was directly  after completion of \ref p4est_wrap_adapt. So, they are not
+   * was directly after completion of \ref p4est_wrap_adapt. So, they are not
    * updated in \ref p4est_wrap_partition. Newly_refined only stores newly
    * refined quadrants with child id 0. */
   sc_array_t         *newly_refined, *newly_coarsened;

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -76,10 +76,10 @@ typedef struct
                                                      of coarsening when calling
                                                      \ref p4est_wrap_partition. */
   int                 store_adapted;    /**< Boolean: If true, the indices of
-                                             newly adapted quadrants are stored
-                                             in the \ref newly_refined and
-                                             \ref newly_coarsened array of the
-                                             wrap. */
+                                             most recently adapted quadrants are
+                                             stored in the \ref newly_refined
+                                             and \ref newly_coarsened array of
+                                             the wrap. */
   void               *user_pointer;     /**< Set the user pointer in
                                              \ref p4est_wrap_t. Subsequently, we
                                              will never access it. */
@@ -108,7 +108,7 @@ typedef struct p4est_wrap
   p4est_t            *p4est;    /**< p4est->user_pointer is used internally */
 
   /* If \a params.store_adapted is true, these arrays store the indices of the
-   * quadrants refined and coarsened during the last call to
+   * quadrants refined and coarsened during the most recent call to
    * \ref p4est_wrap_adapt. The wrap's \a p4est has to be balanced when entering
    * the adaptation, to avoid multi-level refinement.
    * At every time the arrays index into the local quadrants of the p4est as it
@@ -318,8 +318,9 @@ void                p4est_wrap_set_partitioning (p4est_wrap_t *pp,
 
 /** Set a parameter that stores indices of newly adapted quadrants.
  * If positive, the local quadrant indices of all quadrants refined or coarsened
- * during the last call to \ref p4est_wrap_adapt (on entry the wrap's p8est has
- * to be balanced) are stored in \a newly_refined and \a newly_coarsened.
+ * during the most recent call to \ref p4est_wrap_adapt (on entry the wrap's
+ * p4est has to be balanced) are stored in \a newly_refined and
+ * \a newly_coarsened.
  * \param [in,out] pp           A valid p4est_wrap structure.
  * \param [in] store_adapted    Boolean: If true, the indices of newly adapted
  *                              quadrants are stored in future adaptations.

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -107,11 +107,12 @@ typedef struct p4est_wrap
   int                 p4est_children;
   p4est_t            *p4est;    /**< p4est->user_pointer is used internally */
 
-  /* These arrays are initialized during wrap creation, if \a params.store_adapted
-   * evaluates to true and contain the indices  of the quadrants refined during
-   * the last call to \ref p4est_wrap_adapt.
-   * At every time they index into the local quadrants of the p4est as it was
-   * directly  after completion of \ref p4est_wrap_adapt. So, they are not
+  /* If \a params.store_adapted is true, these arrays store the indices of the
+   * quadrants refined and coarsened during the last call to
+   * \ref p4est_wrap_adapt. The wrap's \a p4est has to be balanced when entering
+   * the adaptation, to avoid multi-level refinement.
+   * At every time the arrays index into the local quadrants of the p4est as it
+   * was directly  after completion of \ref p4est_wrap_adapt. So, they are not
    * updated in \ref p4est_wrap_partition. Newly_refined only stores newly
    * refined quadrants with child id 0. */
   sc_array_t         *newly_refined, *newly_coarsened;
@@ -317,8 +318,8 @@ void                p4est_wrap_set_partitioning (p4est_wrap_t *pp,
 
 /** Set a parameter that stores indices of newly adapted quadrants.
  * If positive, the local quadrant indices of all quadrants refined or coarsened
- * during the last call to \ref p4est_wrap_adapt are stored in \a newly_refined
- * and \a newly_coarsened.
+ * during the last call to \ref p4est_wrap_adapt (on entry the wrap's p8est has
+ * to be balanced) are stored in \a newly_refined and \a newly_coarsened.
  * \param [in,out] pp           A valid p4est_wrap structure.
  * \param [in] store_adapted    Boolean: If true, the indices of newly adapted
  *                              quadrants are stored in future adaptations.

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -107,12 +107,6 @@ typedef struct p4est_wrap
   int                 p4est_children;
   p4est_t            *p4est;    /**< p4est->user_pointer is used internally */
 
-  /* anything below here is considered private und should not be touched */
-  int                 weight_exponent;
-  uint8_t            *flags, *temp_flags;
-  p4est_locidx_t      num_refine_flags, inside_counter, num_replaced;
-  p4est_gloidx_t     *old_global_first_quadrant;
-
   /* These arrays are initialized during wrap creation, if \a params.store_adapted
    * evaluates to true and contain the indices  of the quadrants refined during
    * the last call to \ref p4est_wrap_adapt.
@@ -121,6 +115,12 @@ typedef struct p4est_wrap
    * updated in \ref p4est_wrap_partition. Newly_refined only stores newly
    * refined quadrants with child id 0. */
   sc_array_t         *newly_refined, *newly_coarsened;
+
+  /* anything below here is considered private und should not be touched */
+  int                 weight_exponent;
+  uint8_t            *flags, *temp_flags;
+  p4est_locidx_t      num_refine_flags, inside_counter, num_replaced;
+  p4est_gloidx_t     *old_global_first_quadrant;
 
   /* for ghost and mesh use p4est_wrap_get_ghost, _mesh declared below */
   p4est_ghost_t      *ghost;
@@ -314,6 +314,17 @@ void                p4est_wrap_set_coarsen_delay (p4est_wrap_t * pp,
  */
 void                p4est_wrap_set_partitioning (p4est_wrap_t *pp,
                                                  int partition_for_coarsening);
+
+/** Set a parameter that stores indices of newly adapted quadrants.
+ * If positive, the local quadrant indices of all quadrants refined or coarsened
+ * during the last call to \ref p4est_wrap_adapt are stored in \a newly_refined
+ * and \a newly_coarsened.
+ * \param [in,out] pp           A valid p4est_wrap structure.
+ * \param [in] store_adapted    Boolean: If true, the indices of newly adapted
+ *                              quadrants are stored in future adaptations.
+ */
+void                p4est_wrap_set_store_adapted (p4est_wrap_t *pp,
+                                                  int store_adapted);
 
 /** Return the appropriate ghost layer.
  * This function is necessary since two versions may exist simultaneously

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -317,18 +317,6 @@ void                p4est_wrap_set_coarsen_delay (p4est_wrap_t * pp,
 void                p4est_wrap_set_partitioning (p4est_wrap_t *pp,
                                                  int partition_for_coarsening);
 
-/** Set a parameter that stores indices of newly adapted quadrants.
- * If positive, the local quadrant indices of all quadrants refined or coarsened
- * during the most recent call to \ref p4est_wrap_adapt (on entry the wrap's
- * p4est has to be balanced) are stored in \a newly_refined and
- * \a newly_coarsened.
- * \param [in,out] pp           A valid p4est_wrap structure.
- * \param [in] store_adapted    Boolean: If true, the indices of newly adapted
- *                              quadrants are stored in future adaptations.
- */
-void                p4est_wrap_set_store_adapted (p4est_wrap_t *pp,
-                                                  int store_adapted);
-
 /** Return the appropriate ghost layer.
  * This function is necessary since two versions may exist simultaneously
  * after refinement and before partition/complete.

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -75,6 +75,11 @@ typedef struct
                                                      modified to allow one level
                                                      of coarsening when calling
                                                      \ref p4est_wrap_partition. */
+  int                 store_adapted;    /**< Boolean: If true, the indices of
+                                             newly adapted quadrants are stored
+                                             in the \ref newly_refined and
+                                             \ref newly_coarsened array of the
+                                             wrap. */
   void               *user_pointer;     /**< Set the user pointer in
                                              \ref p4est_wrap_t. Subsequently, we
                                              will never access it. */
@@ -107,6 +112,7 @@ typedef struct p4est_wrap
   uint8_t            *flags, *temp_flags;
   p4est_locidx_t      num_refine_flags, inside_counter, num_replaced;
   p4est_gloidx_t     *old_global_first_quadrant;
+  sc_array_t         *newly_refined, *newly_coarsened;
 
   /* for ghost and mesh use p4est_wrap_get_ghost, _mesh declared below */
   p4est_ghost_t      *ghost;

--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -112,6 +112,14 @@ typedef struct p8est_wrap
   uint8_t            *flags, *temp_flags;
   p4est_locidx_t      num_refine_flags, inside_counter, num_replaced;
   p4est_gloidx_t     *old_global_first_quadrant;
+
+  /* These arrays are initialized during wrap creation, if \a params.store_adapted
+   * evaluates to true and contain the indices  of the quadrants refined during
+   * the last call to \ref p4est_wrap_adapt.
+   * At every time they index into the local quadrants of the p4est as it was
+   * directly  after completion of \ref p4est_wrap_adapt. So, they are not
+   * updated in \ref p4est_wrap_partition. Newly_refined only stores newly
+   * refined quadrants with child id 0. */
   sc_array_t         *newly_refined, *newly_coarsened;
 
   /* for ghost and mesh use p8est_wrap_get_ghost, _mesh declared below */

--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -302,18 +302,6 @@ void                p8est_wrap_set_coarsen_delay (p8est_wrap_t * pp,
 void                p8est_wrap_set_partitioning (p8est_wrap_t *pp,
                                                  int partition_for_coarsening);
 
-/** Set a parameter that stores indices of newly adapted quadrants.
- * If positive, the local quadrant indices of all quadrants refined or coarsened
- * during the most recent call to \ref p8est_wrap_adapt (on entry the wrap's
- * p8est has to be balanced) are stored in \a newly_refined and
- * \a newly_coarsened.
- * \param [in,out] pp           A valid p4est_wrap structure.
- * \param [in] store_adapted    Boolean: If true, the indices of newly adapted
- *                              quadrants are stored in future adaptations.
- */
-void                p8est_wrap_set_store_adapted (p8est_wrap_t *pp,
-                                                  int store_adapted);
-
 /** Return the appropriate ghost layer.
  * This function is necessary since two versions may exist simultaneously
  * after refinement and before partition/complete.

--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -116,7 +116,10 @@ typedef struct p8est_wrap
    * was directly after completion of \ref p8est_wrap_adapt. So, they are not
    * updated in \ref p8est_wrap_partition. Newly_refined only stores newly
    * refined quadrants with child id 0. */
-  sc_array_t         *newly_refined, *newly_coarsened;
+  sc_array_t         *newly_refined; /**< Indices of quadrants refined during
+                                          most recent \ref p8est_wrap_adapt */
+  sc_array_t         *newly_coarsened; /**< Indices of quadrants coarsened during
+                                            most recent \ref p8est_wrap_adapt */
 
   /* anything below here is considered private und should not be touched */
   int                 weight_exponent;

--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -75,6 +75,11 @@ typedef struct
                                                      modified to allow one level
                                                      of coarsening when calling
                                                      \ref p8est_wrap_partition. */
+  int                 store_adapted;    /**< Boolean: If true, the indices of
+                                             newly adapted quadrants are stored
+                                             in the \ref newly_refined and
+                                             \ref newly_coarsened array of the
+                                             wrap. */
   void               *user_pointer;     /**< Set the user pointer in
                                              \ref p8est_wrap_t. Subsequently, we
                                              will never access it. */
@@ -107,6 +112,7 @@ typedef struct p8est_wrap
   uint8_t            *flags, *temp_flags;
   p4est_locidx_t      num_refine_flags, inside_counter, num_replaced;
   p4est_gloidx_t     *old_global_first_quadrant;
+  sc_array_t         *newly_refined, *newly_coarsened;
 
   /* for ghost and mesh use p8est_wrap_get_ghost, _mesh declared below */
   p8est_ghost_t      *ghost;

--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -107,12 +107,6 @@ typedef struct p8est_wrap
   int                 p4est_children;
   p8est_t            *p4est;    /**< p4est->user_pointer is used internally */
 
-  /* anything below here is considered private und should not be touched */
-  int                 weight_exponent;
-  uint8_t            *flags, *temp_flags;
-  p4est_locidx_t      num_refine_flags, inside_counter, num_replaced;
-  p4est_gloidx_t     *old_global_first_quadrant;
-
   /* These arrays are initialized during wrap creation, if \a params.store_adapted
    * evaluates to true and contain the indices  of the quadrants refined during
    * the last call to \ref p4est_wrap_adapt.
@@ -121,6 +115,12 @@ typedef struct p8est_wrap
    * updated in \ref p4est_wrap_partition. Newly_refined only stores newly
    * refined quadrants with child id 0. */
   sc_array_t         *newly_refined, *newly_coarsened;
+
+  /* anything below here is considered private und should not be touched */
+  int                 weight_exponent;
+  uint8_t            *flags, *temp_flags;
+  p4est_locidx_t      num_refine_flags, inside_counter, num_replaced;
+  p4est_gloidx_t     *old_global_first_quadrant;
 
   /* for ghost and mesh use p8est_wrap_get_ghost, _mesh declared below */
   p8est_ghost_t      *ghost;
@@ -299,6 +299,17 @@ void                p8est_wrap_set_coarsen_delay (p8est_wrap_t * pp,
  */
 void                p8est_wrap_set_partitioning (p8est_wrap_t *pp,
                                                  int partition_for_coarsening);
+
+/** Set a parameter that stores indices of newly adapted quadrants.
+ * If positive, the local quadrant indices of all quadrants refined or coarsened
+ * during the last call to \ref p8est_wrap_adapt are stored in \a newly_refined
+ * and \a newly_coarsened.
+ * \param [in,out] pp           A valid p4est_wrap structure.
+ * \param [in] store_adapted    Boolean: If true, the indices of newly adapted
+ *                              quadrants are stored in future adaptations.
+ */
+void                p8est_wrap_set_store_adapted (p8est_wrap_t *pp,
+                                                  int store_adapted);
 
 /** Return the appropriate ghost layer.
  * This function is necessary since two versions may exist simultaneously

--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -287,21 +287,6 @@ void                p8est_wrap_set_coarsen_delay (p8est_wrap_t * pp,
                                                   int coarsen_delay,
                                                   int coarsen_affect);
 
-/** Set a parameter that ensures future partitions allow one level of coarsening.
- * The partition_for_coarsening parameter is passed to \ref p8est_partition_ext
- * in \ref p8est_wrap_partition.
- * If not zero, all future calls to \ref p8est_wrap_partition will partition
- * in a manner that allows one level of coarsening. This function does not
- * automatically repartition the mesh, when switching partition_for_coarsening
- * to a non-zero value.
- * \param [in,out] pp           A valid p8est_wrap structure.
- * \param [in] partition_for_coarsening Boolean:  If true, all future partitions
- *                              of the wrap allow one level of coarsening.
- *                              Suggested default: 1.
- */
-void                p8est_wrap_set_partitioning (p8est_wrap_t *pp,
-                                                 int partition_for_coarsening);
-
 /** Return the appropriate ghost layer.
  * This function is necessary since two versions may exist simultaneously
  * after refinement and before partition/complete.

--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -76,10 +76,10 @@ typedef struct
                                                      of coarsening when calling
                                                      \ref p8est_wrap_partition. */
   int                 store_adapted;    /**< Boolean: If true, the indices of
-                                             newly adapted quadrants are stored
-                                             in the \ref newly_refined and
-                                             \ref newly_coarsened array of the
-                                             wrap. */
+                                             most recently adapted quadrants are
+                                             stored in the \ref newly_refined
+                                             and \ref newly_coarsened array of
+                                             the wrap. */
   void               *user_pointer;     /**< Set the user pointer in
                                              \ref p8est_wrap_t. Subsequently, we
                                              will never access it. */
@@ -108,7 +108,7 @@ typedef struct p8est_wrap
   p8est_t            *p4est;    /**< p4est->user_pointer is used internally */
 
   /* If \a params.store_adapted is true, these arrays store the indices of the
-   * quadrants refined and coarsened during the last call to
+   * quadrants refined and coarsened during the most recent call to
    * \ref p8est_wrap_adapt. The wrap's \a p4est has to be balanced when entering
    * the adaptation, to avoid multi-level refinement.
    * At every time the arrays index into the local quadrants of the p8est as it
@@ -303,8 +303,9 @@ void                p8est_wrap_set_partitioning (p8est_wrap_t *pp,
 
 /** Set a parameter that stores indices of newly adapted quadrants.
  * If positive, the local quadrant indices of all quadrants refined or coarsened
- * during the last call to \ref p8est_wrap_adapt (on entry the wrap's p8est has
- * to be balanced) are stored in \a newly_refined and \a newly_coarsened.
+ * during the most recent call to \ref p8est_wrap_adapt (on entry the wrap's
+ * p8est has to be balanced) are stored in \a newly_refined and
+ * \a newly_coarsened.
  * \param [in,out] pp           A valid p4est_wrap structure.
  * \param [in] store_adapted    Boolean: If true, the indices of newly adapted
  *                              quadrants are stored in future adaptations.

--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -111,8 +111,9 @@ typedef struct p8est_wrap
    * quadrants refined and coarsened during the most recent call to
    * \ref p8est_wrap_adapt. The wrap's \a p4est has to be balanced when entering
    * the adaptation, to avoid multi-level refinement.
+   * The arrays are allocated during the first call of \ref p8est_wrap_adapt.
    * At every time the arrays index into the local quadrants of the p8est as it
-   * was directly  after completion of \ref p8est_wrap_adapt. So, they are not
+   * was directly after completion of \ref p8est_wrap_adapt. So, they are not
    * updated in \ref p8est_wrap_partition. Newly_refined only stores newly
    * refined quadrants with child id 0. */
   sc_array_t         *newly_refined, *newly_coarsened;

--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -107,12 +107,13 @@ typedef struct p8est_wrap
   int                 p4est_children;
   p8est_t            *p4est;    /**< p4est->user_pointer is used internally */
 
-  /* These arrays are initialized during wrap creation, if \a params.store_adapted
-   * evaluates to true and contain the indices  of the quadrants refined during
-   * the last call to \ref p4est_wrap_adapt.
-   * At every time they index into the local quadrants of the p4est as it was
-   * directly  after completion of \ref p4est_wrap_adapt. So, they are not
-   * updated in \ref p4est_wrap_partition. Newly_refined only stores newly
+  /* If \a params.store_adapted is true, these arrays store the indices of the
+   * quadrants refined and coarsened during the last call to
+   * \ref p8est_wrap_adapt. The wrap's \a p4est has to be balanced when entering
+   * the adaptation, to avoid multi-level refinement.
+   * At every time the arrays index into the local quadrants of the p8est as it
+   * was directly  after completion of \ref p8est_wrap_adapt. So, they are not
+   * updated in \ref p8est_wrap_partition. Newly_refined only stores newly
    * refined quadrants with child id 0. */
   sc_array_t         *newly_refined, *newly_coarsened;
 
@@ -302,8 +303,8 @@ void                p8est_wrap_set_partitioning (p8est_wrap_t *pp,
 
 /** Set a parameter that stores indices of newly adapted quadrants.
  * If positive, the local quadrant indices of all quadrants refined or coarsened
- * during the last call to \ref p8est_wrap_adapt are stored in \a newly_refined
- * and \a newly_coarsened.
+ * during the last call to \ref p8est_wrap_adapt (on entry the wrap's p8est has
+ * to be balanced) are stored in \a newly_refined and \a newly_coarsened.
  * \param [in,out] pp           A valid p4est_wrap structure.
  * \param [in] store_adapted    Boolean: If true, the indices of newly adapted
  *                              quadrants are stored in future adaptations.


### PR DESCRIPTION
This PR adds two arrays `newly_refined` and `newly_coarsened` to the `p4est_wrap_t`. The arrays store the local quadrant indices of quadrants that were refined or coarsened during the most recent call to `p4est_wrap_adapt`. For refinement, only the index of the quadrant with child id 0 is stored. The arrays are not updated during other function calls like `p4est_wrap_partition`. So, they always index into the local quadrants of the p4est as it was right after adaptation.

The arrays are only initalized and set, if the new wrap parameter `store_adapted` is set to true. Furthermore, we assert that the wrap's p4est is balanced before the adaptation, which ensures a single level of refinement.

