### PR TITLE
Reinstate set_partitioning in wrap

### DIFF
--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -613,6 +613,7 @@
 #define p4est_wrap_destroy              p8est_wrap_destroy
 #define p4est_wrap_set_hollow           p8est_wrap_set_hollow
 #define p4est_wrap_set_coarsen_delay    p8est_wrap_set_coarsen_delay
+#define p4est_wrap_set_partitioning     p8est_wrap_set_partitioning
 #define p4est_wrap_get_ghost            p8est_wrap_get_ghost
 #define p4est_wrap_get_mesh             p8est_wrap_get_mesh
 #define p4est_wrap_mark_refine          p8est_wrap_mark_refine

--- a/src/p4est_wrap.c
+++ b/src/p4est_wrap.c
@@ -585,6 +585,14 @@ p4est_wrap_set_coarsen_delay (p4est_wrap_t * pp,
   }
 }
 
+/*** OUTDATED FUNCTION ***/
+void
+p4est_wrap_set_partitioning (p4est_wrap_t *pp, int partition_for_coarsening)
+{
+  P4EST_ASSERT (pp != NULL);
+  pp->params.partition_for_coarsening = partition_for_coarsening;
+}
+
 p4est_ghost_t      *
 p4est_wrap_get_ghost (p4est_wrap_t * pp)
 {

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -305,6 +305,22 @@ void                p4est_wrap_set_coarsen_delay (p4est_wrap_t * pp,
                                                   int coarsen_delay,
                                                   int coarsen_affect);
 
+/*** OUTDATED FUNCTION ***/
+/** Set a parameter that ensures future partitions allow one level of coarsening.
+ * The partition_for_coarsening parameter is passed to \ref p4est_partition_ext
+ * in \ref p4est_wrap_partition.
+ * If not zero, all future calls to \ref p4est_wrap_partition will partition
+ * in a manner that allows one level of coarsening. This function does not
+ * automatically repartition the mesh, when switching partition_for_coarsening
+ * to a non-zero value.
+ * \param [in,out] pp           A valid p4est_wrap structure.
+ * \param [in] partition_for_coarsening Boolean:  If true, all future partitions
+ *                              of the wrap allow one level of coarsening.
+ *                              Suggested default: 1.
+ */
+void                p4est_wrap_set_partitioning (p4est_wrap_t *pp,
+                                                 int partition_for_coarsening);
+
 /** Return the appropriate ghost layer.
  * This function is necessary since two versions may exist simultaneously
  * after refinement and before partition/complete.

--- a/src/p4est_wrap.h
+++ b/src/p4est_wrap.h
@@ -26,10 +26,15 @@
 #define P4EST_WRAP_H
 
 /** \file p4est_wrap.h
- * The logic in p4est_wrap encapsulates core p4est data structures and provides
+ *
+ * This wrapper API encapsulates core p4est data structures and provides
  * functions that clarify the mark-adapt-partition cycle.  There is also an
  * element iterator that can replace the nested loops over trees and tree
  * quadrants, respectively, which can help make application code cleaner.
+ *
+ * For most new code, using this API is likely not necessary.
+ *
+ * \ingroup p4est
  */
 
 #include <p4est_extended.h>
@@ -77,15 +82,17 @@ typedef struct
                                                      \ref p4est_wrap_partition. */
   int                 store_adapted;    /**< Boolean: If true, the indices of
                                              most recently adapted quadrants are
-                                             stored in the \ref newly_refined
-                                             and \ref newly_coarsened array of
+                                             stored in the \c newly_refined
+                                             and \c newly_coarsened array of
                                              the wrap. */
-  void               *user_pointer;     /**< Set the user pointer in
-                                             \ref p4est_wrap_t. Subsequently, we
+  void               *user_pointer;     /**< Set the user pointer in the
+                                             \ref p4est_wrap. Subsequently, we
                                              will never access it. */
 }
 p4est_wrap_params_t;
 
+/** Wrapping a \ref p4est object for an alternative API.
+ */
 typedef struct p4est_wrap
 {
   /* collection of wrap-related parameters */
@@ -248,11 +255,12 @@ p4est_wrap_t       *p4est_wrap_new_copy (p4est_wrap_t * source,
                                          p4est_replace_t replace_fn,
                                          void *user_pointer);
 
-/** Create p4est and auxiliary data structures.
+/** Create a \ref p4est_wrap and internal helper data structures.
  * Expects sc_MPI_Init to be called beforehand.
  */
 p4est_wrap_t       *p4est_wrap_new_unitsquare (sc_MPI_Comm mpicomm,
                                                int initial_level);
+
 p4est_wrap_t       *p4est_wrap_new_periodic (sc_MPI_Comm mpicomm,
                                              int initial_level);
 p4est_wrap_t       *p4est_wrap_new_rotwrap (sc_MPI_Comm mpicomm,
@@ -265,8 +273,12 @@ p4est_wrap_t       *p4est_wrap_new_moebius (sc_MPI_Comm mpicomm,
                                             int initial_level);
 p4est_wrap_t       *p4est_wrap_new_cubed (sc_MPI_Comm mpicomm,
                                           int initial_level);
+
+/** Create a five-tree setup suitable to build a 2D disk. */
 p4est_wrap_t       *p4est_wrap_new_disk (sc_MPI_Comm mpicomm, int px, int py,
                                          int initial_level);
+
+/** The rectangular brick is one of the most useful connectivities. */
 p4est_wrap_t       *p4est_wrap_new_brick (sc_MPI_Comm mpicomm,
                                           int bx, int by, int px, int py,
                                           int initial_level);
@@ -305,7 +317,6 @@ void                p4est_wrap_set_coarsen_delay (p4est_wrap_t * pp,
                                                   int coarsen_delay,
                                                   int coarsen_affect);
 
-/*** OUTDATED FUNCTION ***/
 /** Set a parameter that ensures future partitions allow one level of coarsening.
  * The partition_for_coarsening parameter is passed to \ref p4est_partition_ext
  * in \ref p4est_wrap_partition.
@@ -313,6 +324,10 @@ void                p4est_wrap_set_coarsen_delay (p4est_wrap_t * pp,
  * in a manner that allows one level of coarsening. This function does not
  * automatically repartition the mesh, when switching partition_for_coarsening
  * to a non-zero value.
+ *
+ * \deprecated      The function will be removed in the future.  Flags for
+ *                  partitioning can be set using \ref p4est_wrap_new_params.
+ *
  * \param [in,out] pp           A valid p4est_wrap structure.
  * \param [in] partition_for_coarsening Boolean:  If true, all future partitions
  *                              of the wrap allow one level of coarsening.

--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -26,10 +26,15 @@
 #define P8EST_WRAP_H
 
 /** \file p8est_wrap.h
- * The logic in p8est_wrap encapsulates core p4est data structures and provides
+ *
+ * This wrapper API encapsulates core p4est data structures and provides
  * functions that clarify the mark-adapt-partition cycle.  There is also an
  * element iterator that can replace the nested loops over trees and tree
  * quadrants, respectively, which can help make application code cleaner.
+ *
+ * For most new code, using this API is likely not necessary.
+ *
+ * \ingroup p8est
  */
 
 #include <p8est_extended.h>
@@ -77,15 +82,17 @@ typedef struct
                                                      \ref p8est_wrap_partition. */
   int                 store_adapted;    /**< Boolean: If true, the indices of
                                              most recently adapted quadrants are
-                                             stored in the \ref newly_refined
-                                             and \ref newly_coarsened array of
+                                             stored in the \c newly_refined
+                                             and \c newly_coarsened array of
                                              the wrap. */
-  void               *user_pointer;     /**< Set the user pointer in
-                                             \ref p8est_wrap_t. Subsequently, we
+  void               *user_pointer;     /**< Set the user pointer in the
+                                             \ref p8est_wrap. Subsequently, we
                                              will never access it. */
 }
 p8est_wrap_params_t;
 
+/** Wrapping a \ref p8est object for an alternative API.
+ */
 typedef struct p8est_wrap
 {
   /* collection of wrap-related parameters */
@@ -248,7 +255,7 @@ p8est_wrap_t       *p8est_wrap_new_copy (p8est_wrap_t * source,
                                          p8est_replace_t replace_fn,
                                          void *user_pointer);
 
-/** Create p8est and auxiliary data structures.
+/** Create a \ref p8est_wrap and internal helper data structures.
  * Expects sc_MPI_Init to be called beforehand.
  */
 p8est_wrap_t       *p8est_wrap_new_unitcube (sc_MPI_Comm mpicomm,
@@ -290,7 +297,6 @@ void                p8est_wrap_set_coarsen_delay (p8est_wrap_t * pp,
                                                   int coarsen_delay,
                                                   int coarsen_affect);
 
-/*** OUTDATED FUNCTION ***/
 /** Set a parameter that ensures future partitions allow one level of coarsening.
  * The partition_for_coarsening parameter is passed to \ref p8est_partition_ext
  * in \ref p8est_wrap_partition.
@@ -298,6 +304,10 @@ void                p8est_wrap_set_coarsen_delay (p8est_wrap_t * pp,
  * in a manner that allows one level of coarsening. This function does not
  * automatically repartition the mesh, when switching partition_for_coarsening
  * to a non-zero value.
+ *
+ * \deprecated      The function will be removed in the future.  Flags for
+ *                  partitioning can be set using \ref p8est_wrap_new_params.
+ *
  * \param [in,out] pp           A valid p4est_wrap structure.
  * \param [in] partition_for_coarsening Boolean:  If true, all future partitions
  *                              of the wrap allow one level of coarsening.

--- a/src/p8est_wrap.h
+++ b/src/p8est_wrap.h
@@ -290,6 +290,22 @@ void                p8est_wrap_set_coarsen_delay (p8est_wrap_t * pp,
                                                   int coarsen_delay,
                                                   int coarsen_affect);
 
+/*** OUTDATED FUNCTION ***/
+/** Set a parameter that ensures future partitions allow one level of coarsening.
+ * The partition_for_coarsening parameter is passed to \ref p8est_partition_ext
+ * in \ref p8est_wrap_partition.
+ * If not zero, all future calls to \ref p8est_wrap_partition will partition
+ * in a manner that allows one level of coarsening. This function does not
+ * automatically repartition the mesh, when switching partition_for_coarsening
+ * to a non-zero value.
+ * \param [in,out] pp           A valid p4est_wrap structure.
+ * \param [in] partition_for_coarsening Boolean:  If true, all future partitions
+ *                              of the wrap allow one level of coarsening.
+ *                              Suggested default: 1.
+ */
+void                p8est_wrap_set_partitioning (p8est_wrap_t *pp,
+                                                 int partition_for_coarsening);
+
 /** Return the appropriate ghost layer.
  * This function is necessary since two versions may exist simultaneously
  * after refinement and before partition/complete.


### PR DESCRIPTION
This PR temporarily reinstates the function  `p4est_wrap_set_partitioning` to ensure backwards compatibility.
The function is now marked as outdated. 
