### PR TITLE
Add tree offsets to newly adapted quadrants in wrap

### DIFF
--- a/src/p4est_wrap.c
+++ b/src/p4est_wrap.c
@@ -821,14 +821,14 @@ p4est_wrap_adapt (p4est_wrap_t * pp)
         if (quadrant->level > *level) {
           /* quadrant was newly refined, store its index in the new p4est */
           lqid = (p4est_locidx_t *) sc_array_push (pp->newly_refined);
-          *lqid = (p4est_locidx_t) zz;
+          *lqid = (p4est_locidx_t) zz + tree->quadrants_offset;
           zz += P4EST_CHILDREN;
           qz++;
         }
         else if (quadrant->level < *level) {
           /* quadrant was newly coarsened, store its index in the new p4est */
           lqid = (p4est_locidx_t *) sc_array_push (pp->newly_coarsened);
-          *lqid = (p4est_locidx_t) zz;
+          *lqid = (p4est_locidx_t) zz + tree->quadrants_offset;
           zz++;
           qz += P4EST_CHILDREN;
         }


### PR DESCRIPTION
This PR adds the tree offsets to the indices of recently adapted quadrants, which are stored in the `newly_refined` and `newly_coarsened` arrays introduced in https://github.com/cburstedde/p4est/pull/310, thereby ensuring a unique index for every locally refined quadrant.