### PR TITLE
Extended documentation of ghost

### DIFF
--- a/doc/doxygen/ghost.dox
+++ b/doc/doxygen/ghost.dox
@@ -50,7 +50,7 @@
  * p4est_t (2D), \ref p8est_t (3D) and \ref p4est_is_valid (2D), \ref
  * p8est_is_valid (3D)). The forest does not need to be 2:1 balanced.
  *
- * The second and last required parameter to construct a ghost layer is is a
+ * The second and last required parameter to construct a ghost layer is a
  * \b btype (cf. \ref p4est_connect_type_t (2D), \ref p8est_connect_type_t (3D))
  * that specifies if the ghost layer should collect face adjacency, face and
  * edge adjacency in 3D, or full adjacency including corner neighbors.

--- a/doc/doxygen/ghost.dox
+++ b/doc/doxygen/ghost.dox
@@ -33,7 +33,8 @@
  * For parallel computations, we we need to ensure that neighboring mesh
  * elements, which are not local to the current process, become accessible
  * locally.
- * This leads is to the definition of the ghost (a.k.a. halo) layer:
+ * The need of process-neighboring mesh elements leads to the definition of the
+ * ghost (a.k.a. halo) layer:
  * The ghost layer is the set of all remote, i.e. non-local, mesh elements
  * that are adjacent to the process-local mesh elements.
  * This data structure is ideally suited to establish the communication pattern

--- a/doc/doxygen/ghost.dox
+++ b/doc/doxygen/ghost.dox
@@ -74,13 +74,27 @@
  * They store the number of MPI ranks and the number of trees of the ghost layer.
  * Both elements are as in the [p4est](\ref p4est_t) that was used to construct
  * the ghost layer.
+ *
  * The array \b ghosts stores the ghost elements that form the ghost layer of
- * the process local elements. The [quadrants](\ref p4est_quadrant_t) in the
+ * the process-local elements. The [quadrants](\ref p4est_quadrant_t) in the
  * \b ghost array store their tree index and the local number in the owner's
  * numbering in their union
  * [p4est_quadrant_data](\ref p4est_quadrant::p4est_quadrant_data) in piggy3.
+ * The \b ghosts array is windowed by the two arrays \b tree_offsets and
+ * \b proc_offsets. Therefore, the MPI rank and the tree number of each element
+ * in \b ghosts can be deduced.
+ * Naturally, some trees or processes may have zero ghost elements for a given
+ * process, in which case the window has length zero.
  *
- *
+ * The \b mirrors array stores all local quadrants that are ghosts to remote
+ * processes, sometimes called the (inside) parallel boundary elements.
+ * \b ghosts can be considered as the outside parallel boundary elements.
+ * One mirror quadrant may be ghost to more than one remote process.
+ * Thus, the indexing structure is slightly less direct than for \b ghosts:
+ * We have an array \b mirror_proc_mirrors that contains one set of indices into
+ * the mirrors for each remote process.
+ * The array \b mirror_proc_offsets indexes into these sets, which vary in
+ * length by remote process.
  *
  * For further elements of the ghost data structure see also \ref p4est_ghost_t
  * and \ref p8est_ghost_t.

--- a/doc/doxygen/ghost.dox
+++ b/doc/doxygen/ghost.dox
@@ -101,29 +101,37 @@
  *
  * For further elements of the ghost data structure see also \ref p4est_ghost_t
  * and \ref p8est_ghost_t.
+ *
+ * ## Example of ghost usage
+ * Besides the already mentioned parallel advection solver in
+ * [2D](\ref steps/p4est_step3.c) and [3D](\ref steps/p8est_step3.c), one can
+ * also find a simple synthetic usage of ghost in \ref timings/timings2.c (2D)
+ * and \ref timings/timings3.c (3D).
  */
 
- /** \example steps/p4est_step3.c
+/** \example steps/p4est_step3.c
+ *
  * This 2D example program uses p4est to solve a simple advection problem.  It
  * is numerically very simple, and intended to demonstrate several methods of
  * interacting with the p4est data after it has been refined and partitioned.
- * It demonstrates the construction of [ghost](\ref ghost) layers (see \ref
- * p4est_ghost_t in \ref p4est_ghost.h) and communication of ghost-layer data,
+ * It demonstrates the construction of [ghost](\ref ghost) layers (cf. also
+ * \ref p4est_ghost.h) and communication of ghost-layer data,
  * and it demonstrates interacting with the quadrants and quadrant boundaries
- * through the \ref p4est_iterate routine (see \ref p4est_iterate.h).
+ * through the \ref p4est_iterate routine (cf. \ref p4est_iterate.h).
  *
  * Usage:
  *    > `p4est_step3`
  */
 
-  /** \example steps/p8est_step3.c
+/** \example steps/p8est_step3.c
+ *
  * This 3D example program uses p4est to solve a simple advection problem.  It
  * is numerically very simple, and intended to demonstrate several methods of
  * interacting with the p4est data after it has been refined and partitioned.
- * It demonstrates the construction of [ghost](\ref ghost) layers (see \ref
+ * It demonstrates the construction of [ghost](\ref ghost) layers (cf. also \ref
  * p8est_ghost.h) and communication of ghost-layer data, and it demonstrates
  * interacting with the quadrants and quadrant boundaries through the \ref
- * p8est_iterate routine (see \ref p8est_iterate.h).
+ * p8est_iterate routine (cf. \ref p8est_iterate.h).
  *
  * The header file \ref p4est_to_p8est.h defines preprocessor macros that map
  * 2D p4est routines and objects to their 3D p8est counterparts.  By including
@@ -137,3 +145,37 @@
  * Usage:
  *    > `p8est_step3`
  */
+
+/** \example timings/timings2.c
+ *
+ * This 2D example program calls p4est's core routines.
+ *
+ * The example's purpose is to measure the runtime of p4est's core routines.
+ *
+ * Usage:
+ *    > `p4est_timings <configuration> <level>`
+ * possible configurations:
+ *        * `unit`      Refinement on the unit square.
+ *        * `periodic`  Refinement on the unit square with periodic b.c.
+ *        * `three`     Refinement on a forest with three trees.
+ *        * `moebius`   Refinement on a 5-tree Moebius band.
+ *        * `star`      Refinement on a 6-tree star shaped domain.
+ */
+
+/** \example timings/timings3.c
+ *
+ * This 3D example program calls p4est's core routines.
+ *
+ * The example's purpose is to measure the runtime of p4est's core routines.
+ *
+ * Usage:
+ *    > `p8est_timings <configuration> <level>`
+ * possible configurations:
+ *        * `unit`      Refinement on the unit cube.
+ *        * `periodic`  Refinement on the unit cube with all-periodic b.c.
+ *        * `rotwrap`   Refinement on the unit cube with weird periodic b.c.
+ *        * `twocubes`  Refinement on a forest with two trees.
+ *        * `rotcubes`  Refinement on a forest with six rotated trees.
+ *        * `shell`     Refinement on a 24-tree spherical shell..
+ */
+ 

--- a/doc/doxygen/ghost.dox
+++ b/doc/doxygen/ghost.dox
@@ -29,7 +29,7 @@
  * Mesh-based computations may require neighboring elements.
  * For parallel computations, this requires making neighboring mesh elements
  * that are not local to the process available locally.
- * This leads is to the definition of the ghost (a.k.a. halo) layer.
+ * This leads is to the definition of the ghost (a.k.a. halo) layer:
  * The ghost layer is the set of all remote, i.e. non-local, mesh elements
  * that are adjacent to the process-local mesh elements.
  * This data structure is ideally suited to establish the communication pattern
@@ -37,4 +37,19 @@
  * information required to determine all sender-receiver pairs without
  * additional MPI communication. The pattern is necessarily symmetric: Each
  * sender of a pair is also a receiver and vice versa.
+ *
+ * ## Constructing the ghost layer
+ * \b p4est provides the functions \ref p4est_ghost_new (2D), \ref
+ * p8est_ghost_new (3D) to construct a ghost layer.
+ * A ghost layer can be constructed from a valid \ref p4est_t (cf. \ref
+ * p4est_is_valid). The forest does not need to be 2:1 balanced.
+ *
+ * The second and last required parameter to construct a ghost layer is the
+ * \ref p4est_connect_type_t (2D), \ref p8est_connect_type_t (3D) that specifies
+ * if the ghost layer should collect face adjacency, face and edge adjacency in
+ * 3D, or full adjacency including corner neighbors.
+ *
+ * ## The ghost data structure
+ *
+ * ## Functions for parallel ghost data exchange
  */

--- a/doc/doxygen/ghost.dox
+++ b/doc/doxygen/ghost.dox
@@ -41,15 +41,47 @@
  * ## Constructing the ghost layer
  * \b p4est provides the functions \ref p4est_ghost_new (2D), \ref
  * p8est_ghost_new (3D) to construct a ghost layer.
- * A ghost layer can be constructed from a valid \ref p4est_t (cf. \ref
- * p4est_is_valid). The forest does not need to be 2:1 balanced.
+ * A ghost layer can be constructed from a valid \b input_p4est (cf. \ref
+ * p4est_t (2D), \ref p8est_t (3D) and \ref p4est_is_valid (2D), \ref
+ * p8est_is_valid (3D)). The forest does not need to be 2:1 balanced.
  *
- * The second and last required parameter to construct a ghost layer is the
- * \ref p4est_connect_type_t (2D), \ref p8est_connect_type_t (3D) that specifies
- * if the ghost layer should collect face adjacency, face and edge adjacency in
- * 3D, or full adjacency including corner neighbors.
+ * The second and last required parameter to construct a ghost layer is is a
+ * \b btype (cf. \ref p4est_connect_type_t (2D), \ref p8est_connect_type_t (3D))
+ * that specifies if the ghost layer should collect face adjacency, face and
+ * edge adjacency in 3D, or full adjacency including corner neighbors.
+ *
+ * Ghost layer construction in 2D:
+ *  > `ghost = p4est_ghost_new (input_p4est, btype)`
+ *
+ * The returned ghost layer object is explained in the following section.
  *
  * ## The ghost data structure
+ * The ghost layer object (cf. \ref p4est_ghost_t (2D), \ref p8est_ghost_t (3D))
+ * can be queried and searched without accessing the original \b input_p4est.
+ * It is read-only immutable and must be destroyed when no longer needed
+ * (cf. \ref p4est_ghost_destroy (2D), \ref p8est_ghost_destroy (3D)).
  *
- * ## Functions for parallel ghost data exchange
+ * ### Elements of the ghost layer
+ * The ghost layer is a public struct with documented entries, most of them
+ * arrays.
+ * The [2D](\ref p4est_ghost_t) and [3D](\ref p8est_ghost_t) declarations are
+ * structurally identical: Linear tree storage is dimension independent, and
+ * ghost elements are ordered ascending just as mesh elements.
+ * We may index into the element storage by window start and offset indices.
+ * We may also use binary search in the linear order to find ghost elements.
+ *
+ * The elements of the ghost layer start with the \b mpisize and \b num_trees.
+ * They store the number of MPI ranks and the number of trees of the ghost layer.
+ * Both elements are as in the [p4est](\ref p4est_t) that was used to construct
+ * the ghost layer.
+ * The array \b ghosts stores the ghost elements that form the ghost layer of
+ * the process local elements. The [quadrants](\ref p4est_quadrant_t) in the
+ * \b ghost array store their tree index and the local number in the owner's
+ * numbering in their union
+ * [p4est_quadrant_data](\ref p4est_quadrant::p4est_quadrant_data) in piggy3.
+ *
+ *
+ *
+ * For further elements of the ghost data structure see also \ref p4est_ghost_t
+ * and \ref p8est_ghost_t.
  */

--- a/doc/doxygen/ghost.dox
+++ b/doc/doxygen/ghost.dox
@@ -99,8 +99,11 @@
  * The array \b mirror_proc_offsets indexes into these sets, which vary in
  * length by remote process.
  *
+ * ## Find more information
  * For further elements of the ghost data structure see also \ref p4est_ghost_t
- * and \ref p8est_ghost_t.
+ * and \ref p8est_ghost_t and for parallel ghost data exchange functions see
+ * the respective functions in \ref p4est_ghost.h (2D) and \ref p8est_ghost.h
+ * (3D).
  *
  * ## Example of ghost usage
  * Besides the already mentioned parallel advection solver in
@@ -178,4 +181,3 @@
  *        * `rotcubes`  Refinement on a forest with six rotated trees.
  *        * `shell`     Refinement on a 24-tree spherical shell..
  */
- 

--- a/doc/doxygen/ghost.dox
+++ b/doc/doxygen/ghost.dox
@@ -1,0 +1,40 @@
+/*
+  This file is part of p4est.
+  p4est is a C library to manage a collection (a forest) of multiple
+  connected adaptive quadtrees or octrees in parallel.
+
+  Copyright (C) 2010 The University of Texas System
+  Written by Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac
+
+  p4est is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  p4est is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with p4est; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \page ghost The ghost layer
+ *
+ * An overview of the ghost layer functionalities.
+ *
+ * ## The basic idea and definition
+ * Mesh-based computations may require neighboring elements.
+ * For parallel computations, this requires making neighboring mesh elements
+ * that are not local to the process available locally.
+ * This leads is to the definition of the ghost (a.k.a. halo) layer.
+ * The ghost layer is the set of all remote, i.e. non-local, mesh elements
+ * that are adjacent to the process-local mesh elements.
+ * This data structure is ideally suited to establish the communication pattern
+ * between mesh-adjacent parallel processes. The ghost layer contains all
+ * information required to determine all sender-receiver pairs without
+ * additional MPI communication. The pattern is necessarily symmetric: Each
+ * sender of a pair is also a receiver and vice versa.
+ */

--- a/doc/doxygen/ghost.dox
+++ b/doc/doxygen/ghost.dox
@@ -73,31 +73,43 @@
  * We may index into the element storage by window start and offset indices.
  * We may also use binary search in the linear order to find ghost elements.
  *
- * The elements of the ghost layer start with the \b mpisize and \b num_trees.
+ * The elements of the ghost layer start with the
+ * [mpisize](\ref p4est_ghost_t::mpisize) and
+ * [num_trees](\ref p4est_ghost_t::num_trees).
  * They store the number of MPI ranks and the number of trees of the ghost layer.
  * Both elements are as in the [p4est](\ref p4est) that was used to construct
  * the ghost layer.
  *
- * The array \b ghosts stores the ghost elements that form the ghost layer of
- * the process-local elements. The [quadrants](\ref p4est_quadrant_t) in the
- * \b ghost array store their tree index and the local number in the owner's
+ * The array [ghosts](\ref p4est_ghost_t::ghosts) stores the ghost elements that
+ * form the ghost layer of the process-local elements.
+ * The [quadrants](\ref p4est_quadrant_t) in the [ghosts](\ref p4est_ghost_t::ghosts)
+ * array store their tree index and the local number in the owner's
  * numbering in their union
  * [p4est_quadrant_data](\ref p4est_quadrant::p4est_quadrant_data) in piggy3.
- * The \b ghosts array is windowed by the two arrays \b tree_offsets and
- * \b proc_offsets. Therefore, the MPI rank and the tree number of each element
- * in \b ghosts can be deduced.
+ * The [ghosts](\ref p4est_ghost_t::ghosts) array is windowed by the two arrays
+ * [tree_offsets](\ref p4est_ghost_t::tree_offsets) and
+ * [proc_offsets](\ref p4est_ghost_t::proc_offsets).
+ * Therefore, the MPI rank and the tree number of each element
+ * in [ghosts](\ref p4est_ghost_t::ghosts) can be deduced.
  * Naturally, some trees or processes may have zero ghost elements for a given
  * process, in which case the window has length zero.
  *
- * The \b mirrors array stores all local quadrants that are ghosts to remote
- * processes, sometimes called the (inside) parallel boundary elements.
- * \b ghosts can be considered as the outside parallel boundary elements.
+ * The [mirrors](\ref p4est_ghost_t::mirrors) array stores all local quadrants
+ * that are ghosts to remote processes, sometimes called the (inside) parallel
+ * boundary elements.
+ * [ghosts](\ref p4est_ghost_t::ghosts) can be considered as the outside
+ * parallel boundary elements.
  * One mirror quadrant may be ghost to more than one remote process.
- * Thus, the indexing structure is slightly less direct than for \b ghosts:
- * We have an array \b mirror_proc_mirrors that contains one set of indices into
- * the mirrors for each remote process.
- * The array \b mirror_proc_offsets indexes into these sets, which vary in
- * length by remote process.
+ * Thus, the indexing structure is slightly less direct than for
+ * [ghosts](\ref p4est_ghost_t::ghosts):
+ * We have an array [mirror_proc_mirrors](\ref p4est_ghost_t::mirror_proc_mirrors)
+ * that contains one set of indices into the mirrors for each remote process.
+ * The array [mirror_proc_offsets](\ref p4est_ghost_t::mirror_proc_offsets)
+ * indexes into these sets, which vary in length by remote process.
+ * As for [ghosts](\ref p4est_ghost_t::ghosts) we have for
+ * [mirrors](\ref p4est_ghost_t::mirrors) also an array with tree offsets,
+ * namely the array
+ * [mirror_tree_offsets](\ref p4est_ghost_t::mirror_tree_offsets).
  *
  * ## Find more information
  * For further elements of the ghost data structure see also \ref p4est_ghost_t

--- a/doc/doxygen/ghost.dox
+++ b/doc/doxygen/ghost.dox
@@ -27,6 +27,9 @@
  *
  * ## The basic idea and definition
  * Mesh-based computations may require neighboring elements.
+ * An example of such a computation using a ghost layer can be found
+ * \ref steps/p4est_step3.c (2D) and \ref steps/p8est_step3.c (3D)
+ * -- a simple parallel advection solver.
  * For parallel computations, this requires making neighboring mesh elements
  * that are not local to the process available locally.
  * This leads is to the definition of the ghost (a.k.a. halo) layer:
@@ -72,7 +75,7 @@
  *
  * The elements of the ghost layer start with the \b mpisize and \b num_trees.
  * They store the number of MPI ranks and the number of trees of the ghost layer.
- * Both elements are as in the [p4est](\ref p4est_t) that was used to construct
+ * Both elements are as in the [p4est](\ref p4est) that was used to construct
  * the ghost layer.
  *
  * The array \b ghosts stores the ghost elements that form the ghost layer of
@@ -98,4 +101,39 @@
  *
  * For further elements of the ghost data structure see also \ref p4est_ghost_t
  * and \ref p8est_ghost_t.
+ */
+
+ /** \example steps/p4est_step3.c
+ * This 2D example program uses p4est to solve a simple advection problem.  It
+ * is numerically very simple, and intended to demonstrate several methods of
+ * interacting with the p4est data after it has been refined and partitioned.
+ * It demonstrates the construction of [ghost](\ref ghost) layers (see \ref
+ * p4est_ghost_t in \ref p4est_ghost.h) and communication of ghost-layer data,
+ * and it demonstrates interacting with the quadrants and quadrant boundaries
+ * through the \ref p4est_iterate routine (see \ref p4est_iterate.h).
+ *
+ * Usage:
+ *    > `p4est_step3`
+ */
+
+  /** \example steps/p8est_step3.c
+ * This 3D example program uses p4est to solve a simple advection problem.  It
+ * is numerically very simple, and intended to demonstrate several methods of
+ * interacting with the p4est data after it has been refined and partitioned.
+ * It demonstrates the construction of [ghost](\ref ghost) layers (see \ref
+ * p8est_ghost.h) and communication of ghost-layer data, and it demonstrates
+ * interacting with the quadrants and quadrant boundaries through the \ref
+ * p8est_iterate routine (see \ref p8est_iterate.h).
+ *
+ * The header file \ref p4est_to_p8est.h defines preprocessor macros that map
+ * 2D p4est routines and objects to their 3D p8est counterparts.  By including
+ * this file and then including the source for the 2D example \ref
+ * steps/p4est_step3.c, we convert the 2D example to a 3D example.
+ *
+ * It is entirely possible to write a 3D-only program without relying on this
+ * mechanism.  In this case use the p8est* header files, functions, and data
+ * structures.
+ *
+ * Usage:
+ *    > `p8est_step3`
  */

--- a/doc/doxygen/ghost.dox
+++ b/doc/doxygen/ghost.dox
@@ -26,12 +26,13 @@
  * An overview of the ghost layer functionalities.
  *
  * ## The basic idea and definition
- * Mesh-based computations may require neighboring elements.
- * An example of such a computation using a ghost layer can be found
+ * Mesh-based computations may require access to neighboring elements.
+ * An example of such a computation using a ghost layer can be found in
  * \ref steps/p4est_step3.c (2D) and \ref steps/p8est_step3.c (3D)
  * -- a simple parallel advection solver.
- * For parallel computations, this requires making neighboring mesh elements
- * that are not local to the process available locally.
+ * For parallel computations, we we need to ensure that neighboring mesh
+ * elements, which are not local to the current process, become accessible
+ * locally.
  * This leads is to the definition of the ghost (a.k.a. halo) layer:
  * The ghost layer is the set of all remote, i.e. non-local, mesh elements
  * that are adjacent to the process-local mesh elements.
@@ -84,8 +85,7 @@
  * form the ghost layer of the process-local elements.
  * The [quadrants](\ref p4est_quadrant_t) in the [ghosts](\ref p4est_ghost_t::ghosts)
  * array store their tree index and the local number in the owner's
- * numbering in their union
- * [p4est_quadrant_data](\ref p4est_quadrant::p4est_quadrant_data) in piggy3.
+ * numbering in [piggy3](\ref p4est_quadrant::p4est_quadrant_data::piggy3).
  * The [ghosts](\ref p4est_ghost_t::ghosts) array is windowed by the two arrays
  * [tree_offsets](\ref p4est_ghost_t::tree_offsets) and
  * [proc_offsets](\ref p4est_ghost_t::proc_offsets).
@@ -103,10 +103,11 @@
  * Thus, the indexing structure is slightly less direct than for
  * [ghosts](\ref p4est_ghost_t::ghosts):
  * We have an array [mirror_proc_mirrors](\ref p4est_ghost_t::mirror_proc_mirrors)
- * that contains one set of indices into the mirrors for each remote process.
+ * that contains one set of indices into the
+ * [mirrors](\ref p4est_ghost_t::mirrors) for each remote process.
  * The array [mirror_proc_offsets](\ref p4est_ghost_t::mirror_proc_offsets)
- * indexes into these sets, which vary in length by remote process.
- * As for [ghosts](\ref p4est_ghost_t::ghosts) we have for
+ * indexes into these sets, which vary in length by the remote process.
+ * As for [ghosts](\ref p4est_ghost_t::ghosts), we have for
  * [mirrors](\ref p4est_ghost_t::mirrors) also an array with tree offsets,
  * namely the array
  * [mirror_tree_offsets](\ref p4est_ghost_t::mirror_tree_offsets).
@@ -120,8 +121,8 @@
  * ## Example of ghost usage
  * Besides the already mentioned parallel advection solver in
  * [2D](\ref steps/p4est_step3.c) and [3D](\ref steps/p8est_step3.c), one can
- * also find a simple synthetic usage of ghost in \ref timings/timings2.c (2D)
- * and \ref timings/timings3.c (3D).
+ * also find a simple synthetic usage examples of ghost in \ref
+ * timings/timings2.c (2D) and \ref timings/timings3.c (3D).
  */
 
 /** \example steps/p4est_step3.c

--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -25,6 +25,10 @@
 ### Documentation
 
  - Activate doxygen and add to comments for p4est_lnodes.
+ - Add a doxygen page on the ghost layer.
+ - Fix all doxygen warnings in p{4,8}est_ghost.h.
+ - Extend the documentation of the piggies in the quadrant data.
+ - Add the p{4,8}est_step3 and timings as examples in doxygen.
 
 ### Functionality
 

--- a/src/p4est.h
+++ b/src/p4est.h
@@ -76,6 +76,15 @@ typedef struct p4est_quadrant
   int8_t              level,    /**< level of refinement */
                       pad8;     /**< padding */
   int16_t             pad16;    /**< padding */
+  /** Union for quadrant data.
+   *
+   * It is important to notice that \ref piggy1 and \ref piggy2 are only used
+   * internally. Hence, they are not part of the API.
+   *
+   * Usually \ref piggy3 is also not part of the API. The only exception holds
+   * for quadrants in the [ghosts](\ref p4est_ghost_t::ghosts) array of
+   * p4est_ghost_t (cf. documentation of [ghosts](\ref p4est_ghost_t::ghosts)).
+   */
   union p4est_quadrant_data
   {
     void               *user_data;      /**< never changed by p4est */
@@ -90,21 +99,22 @@ typedef struct p4est_quadrant
       p4est_topidx_t      which_tree;
       int                 owner_rank;
     }
-    piggy1; /**< of ghost octants, store the tree and owner rank */
+    piggy1; /**< of ghost octants, store the tree and owner rank; not part of
+                 the API */
     struct
     {
       p4est_topidx_t      which_tree;
       p4est_topidx_t      from_tree;
     }
     piggy2; /**< of transformed octants, store the original tree and the
-                 target tree */
+                 target tree; not part of the API */
     struct
     {
       p4est_topidx_t      which_tree;
       p4est_locidx_t      local_num;
     }
     piggy3; /**< of ghost octants, store the tree and index in the owner's
-                 numbering */
+                 numbering; only part of the API in \ref p4est_ghost_t::ghosts */
   }
   p; /**< a union of additional data attached to a quadrant */
 }

--- a/src/p4est_ghost.h
+++ b/src/p4est_ghost.h
@@ -64,7 +64,7 @@ typedef struct
    * inside, i.e., that are ghosts in the perspective of at least one other
    * processor.  The storage convention is the same as for \c ghosts above.
    */
-  sc_array_t          mirrors; /**< array of p4est_quadrant_t type */
+  sc_array_t          mirrors;
   p4est_locidx_t     *mirror_tree_offsets;      /**< num_trees + 1 mirror indices */
   p4est_locidx_t     *mirror_proc_mirrors;      /**< indices into mirrors grouped by
                                                    outside processor rank and

--- a/src/p4est_ghost.h
+++ b/src/p4est_ghost.h
@@ -268,14 +268,18 @@ typedef struct p4est_ghost_exchange
 {
   int                 is_custom;        /**< False for p4est_ghost_exchange_data */
   int                 is_levels;        /**< Are we restricted to levels or not */
-  p4est_t            *p4est;            /**< The forest used for reference. */
-  p4est_ghost_t      *ghost;            /**< The ghost layer used for reference. */
-  int                 minlevel, maxlevel;       /**< Meaningful with is_levels */
-  size_t              data_size;        /**< The data size to transfer per quadrant.*/
-  void               *ghost_data;       /**< Allocated contiguous array for ghost quadrants */
-  int                *qactive, *qbuffer;
-  sc_array_t          requests, sbuffers;
-  sc_array_t          rrequests, rbuffers;
+  p4est_t            *p4est;            /**< The forest used for reference */
+  p4est_ghost_t      *ghost;            /**< The ghost layer used for reference */
+  int                 minlevel;         /**< Meaningful with is_levels */
+  int                 maxlevel;         /**< Meaningful with is_levels */
+  size_t              data_size;        /**< The data size to transfer per quadrant */
+  void               *ghost_data;       /**< Allocated contiguous array for ghost data */
+  int                *qactive;          /**< p4est->mpisize many integers */
+  int                *qbuffer;          /**< p4est->mpisize many integers */
+  sc_array_t          requests;         /**< Array of send requests */
+  sc_array_t          sbuffers;         /**< Array of send buffers */
+  sc_array_t          rrequests;        /**< Array of receive requests */
+  sc_array_t          rbuffers;         /**< Array of receive buffers */
 }
 p4est_ghost_exchange_t;
 

--- a/src/p4est_ghost.h
+++ b/src/p4est_ghost.h
@@ -43,14 +43,15 @@ typedef struct
   p4est_topidx_t      num_trees; /**< number of trees of the ghost */
   p4est_connect_type_t btype; /**< which neighbors are in the ghost layer */
 
-  /** An array of quadrants which make up the ghost layer around \a
-   * p4est.  Their piggy3 data member is filled with their owner's tree
-   * and local number (cumulative over trees).  Quadrants are ordered in \c
-   * p4est_quadrant_compare_piggy order.  These are quadrants inside the
-   * neighboring tree, i.e., \c p4est_quadrant_is_inside() is true for the
-   * quadrant and the neighboring tree.
+  /** An array of \ref p4est_quadrant_t quadrants which make up the ghost layer
+   * around \b p4est.  Their piggy3 (cf. \ref
+   * p4est_quadrant::p4est_quadrant_data) data member is filled with their
+   * owner's tree and local number (cumulative over trees).  Quadrants are
+   * ordered in \ref p4est_quadrant_compare_piggy order. These are quadrants
+   * inside the neighboring tree, i.e., \c p4est_quadrant_is_inside is true for
+   * the quadrant and the neighboring tree.
    */
-  sc_array_t          ghosts; /**< array of p4est_quadrant_t type */
+  sc_array_t          ghosts;
   p4est_locidx_t     *tree_offsets;     /**< num_trees + 1 ghost indices */
   p4est_locidx_t     *proc_offsets;     /**< mpisize + 1 ghost indices */
 

--- a/src/p4est_ghost.h
+++ b/src/p4est_ghost.h
@@ -65,7 +65,6 @@ typedef struct
                                                    ascending within each rank */
   p4est_locidx_t     *mirror_proc_offsets;      /**< mpisize + 1 indices into 
                                                    mirror_proc_mirrors */
-
   p4est_locidx_t     *mirror_proc_fronts;       /**< like mirror_proc_mirrors,
                                                    but limited to the
                                                    outermost octants.  This is

--- a/src/p4est_ghost.h
+++ b/src/p4est_ghost.h
@@ -24,7 +24,9 @@
 
 /** \file p4est_ghost.h
  *
- * passing quadrants and data to neighboring processes
+ * Passing quadrants and data to neighboring processes.
+ *
+ * See also the page \ref ghost for general information.
  *
  * \ingroup p4est
  */
@@ -36,7 +38,10 @@
 
 SC_EXTERN_C_BEGIN;
 
-/** quadrants that neighbor the local domain */
+/** Quadrants that neighbor the local domain.
+ *
+ * See also the page \ref ghost for general information.
+ */
 typedef struct
 {
   int                 mpisize; /**< MPI size of the ghost */

--- a/src/p8est.h
+++ b/src/p8est.h
@@ -72,6 +72,15 @@ typedef struct p8est_quadrant
   int8_t              level,    /**< level of refinement */
                       pad8;     /**< padding */
   int16_t             pad16;    /**< padding */
+  /** Union for quadrant data.
+   *
+   * It is important to notice that \ref piggy1 and \ref piggy2 are only used
+   * internally. Hence, they are not part of the API.
+   *
+   * Usually \ref piggy3 is also not part of the API. The only exception holds
+   * for quadrants in the [ghosts](\ref p8est_ghost_t::ghosts) array of
+   * p8est_ghost_t (cf. documentation of [ghosts](\ref p8est_ghost_t::ghosts)).
+   */
   union p8est_quadrant_data
   {
     void               *user_data;      /**< never changed by p4est */
@@ -86,21 +95,22 @@ typedef struct p8est_quadrant
       p4est_topidx_t      which_tree;
       int                 owner_rank;
     }
-    piggy1; /**< of ghost octants, store the tree and owner rank */
+    piggy1; /**< of ghost octants, store the tree and owner rank; not part of
+                 the API */
     struct
     {
       p4est_topidx_t      which_tree;
       p4est_topidx_t      from_tree;
     }
     piggy2; /**< of transformed octants, store the original tree and the
-                 target tree */
+                 target tree; not part of the API */
     struct
     {
       p4est_topidx_t      which_tree;
       p4est_locidx_t      local_num;
     }
     piggy3; /**< of ghost octants, store the tree and index in the owner's
-                 numbering */
+                 numbering; only part of the API in \ref p8est_ghost_t::ghosts */
   }
   p; /**< a union of additional data attached to a quadrant */
 }

--- a/src/p8est_ghost.h
+++ b/src/p8est_ghost.h
@@ -64,7 +64,7 @@ typedef struct
    * inside, i.e., that are ghosts in the perspective of at least one other
    * processor.  The storage convention is the same as for \c ghosts above.
    */
-  sc_array_t          mirrors; /**< array of p8est_quadrant_t type */
+  sc_array_t          mirrors;
   p4est_locidx_t     *mirror_tree_offsets;      /**< num_trees + 1 mirror indices */
   p4est_locidx_t     *mirror_proc_mirrors;      /**< indices into mirrors grouped by
                                                    outside processor rank and

--- a/src/p8est_ghost.h
+++ b/src/p8est_ghost.h
@@ -39,8 +39,8 @@ SC_EXTERN_C_BEGIN;
 /** quadrants that neighbor the local domain */
 typedef struct
 {
-  int                 mpisize;
-  p4est_topidx_t      num_trees;
+  int                 mpisize; /**< MPI size of the ghost */
+  p4est_topidx_t      num_trees; /**< number of trees of the ghost */
   p8est_connect_type_t btype; /**< which neighbors are in the ghost layer */
 
   /** An array of quadrants which make up the ghost layer around \a
@@ -267,14 +267,18 @@ typedef struct p8est_ghost_exchange
 {
   int                 is_custom;        /**< False for p8est_ghost_exchange_data */
   int                 is_levels;        /**< Are we restricted to levels or not */
-  p8est_t            *p4est;
-  p8est_ghost_t      *ghost;
-  int                 minlevel, maxlevel;       /**< Meaningful with is_levels */
-  size_t              data_size;
-  void               *ghost_data;
-  int                *qactive, *qbuffer;
-  sc_array_t          requests, sbuffers;
-  sc_array_t          rrequests, rbuffers;
+  p8est_t            *p4est;            /**< The forest used for reference */
+  p8est_ghost_t      *ghost;            /**< The ghost layer used for reference */
+  int                 minlevel;         /**< Meaningful with is_levels */
+  int                 maxlevel;         /**< Meaningful with is_levels */
+  size_t              data_size;        /**< The data size to transfer per quadrant */
+  void               *ghost_data;       /**< Allocated contiguous array for ghost data */
+  int                *qactive;          /**< p4est->mpisize many integers */
+  int                *qbuffer;          /**< p4est->mpisize many integers */
+  sc_array_t          requests;         /**< Array of send requests */
+  sc_array_t          sbuffers;         /**< Array of send buffers */
+  sc_array_t          rrequests;        /**< Array of receive requests */
+  sc_array_t          rbuffers;         /**< Array of receive buffers */
 }
 p8est_ghost_exchange_t;
 
@@ -283,6 +287,8 @@ p8est_ghost_exchange_t;
  * The return type is always non-NULL and must be passed to
  * p8est_ghost_exchange_data_end to complete the exchange.
  * The ghost data must not be accessed before completion.
+ * \param [in] p8est            The forest used for reference.
+ * \param [in] ghost            The ghost layer used for reference.
  * \param [in,out]  ghost_data  Must stay alive into the completion call.
  * \return          Transient storage for messages in progress.
  */
@@ -320,6 +326,9 @@ void                p8est_ghost_exchange_custom (p8est_t * p8est,
  * The ghost data must not be accessed before completion.
  * The mirror data can be safely discarded right after this function returns
  * since it is copied into internal send buffers.
+ * \param [in]      p8est       The forest used for reference.
+ * \param [in]      ghost       The ghost layer used for reference.
+ * \param [in]      data_size   The data size to transfer per quadrant.
  * \param [in]      mirror_data Not required to stay alive any longer.
  * \param [in,out]  ghost_data  Must stay alive into the completion call.
  * \return          Transient storage for messages in progress.
@@ -330,7 +339,7 @@ p8est_ghost_exchange_t *p8est_ghost_exchange_custom_begin
 
 /** Complete an asynchronous ghost data exchange.
  * This function waits for all pending MPI communications.
- * \param [in,out]  Data created ONLY by p8est_ghost_exchange_custom_begin.
+ * \param [in,out]  exc created ONLY by p8est_ghost_exchange_custom_begin.
  *                  It is deallocated before this function returns.
  */
 void                p8est_ghost_exchange_custom_end
@@ -367,6 +376,13 @@ void                p8est_ghost_exchange_custom_levels (p8est_t * p8est,
  * The ghost data must not be accessed before completion.
  * The mirror data can be safely discarded right after this function returns
  * since it is copied into internal send buffers.
+ * \param [in]      p8est       The forest used for reference.
+ * \param [in]      ghost       The ghost layer used for reference.
+ * \param [in]      minlevel    Level of the largest quads to be exchanged.
+ *                              Use <= 0 for no restriction.
+ * \param [in]      maxlevel    Level of the smallest quads to be exchanged.
+ *                              Use >= P8EST_QMAXLEVEL for no restriction.
+ * \param [in]      data_size   The data size to transfer per quadrant.
  * \param [in]      mirror_data Not required to stay alive any longer.
  * \param [in,out]  ghost_data  Must stay alive into the completion call.
  * \return          Transient storage for messages in progress.

--- a/src/p8est_ghost.h
+++ b/src/p8est_ghost.h
@@ -24,7 +24,9 @@
 
 /** \file p8est_ghost.h
  *
- * passing quadrants and data to neighboring processes
+ * Passing quadrants and data to neighboring processes.
+ *
+ * See also the page \ref ghost for general information.
  *
  * \ingroup p8est
  */
@@ -36,7 +38,10 @@
 
 SC_EXTERN_C_BEGIN;
 
-/** quadrants that neighbor the local domain */
+/** Quadrants that neighbor the local domain.
+ *
+ * See also the page \ref ghost for general information.
+ */
 typedef struct
 {
   int                 mpisize; /**< MPI size of the ghost */

--- a/src/p8est_ghost.h
+++ b/src/p8est_ghost.h
@@ -43,14 +43,15 @@ typedef struct
   p4est_topidx_t      num_trees; /**< number of trees of the ghost */
   p8est_connect_type_t btype; /**< which neighbors are in the ghost layer */
 
-  /** An array of quadrants which make up the ghost layer around \a
-   * forest.  Their piggy3 data member is filled with their owner's tree
-   * and local number (cumulative over trees).  Quadrants are ordered in \c
-   * p8est_quadrant_compare_piggy order.  These are quadrants inside the
-   * neighboring tree, i.e., \c p8est_quadrant_is_inside() is true for the
-   * quadrant and the neighboring tree.
+  /** An array of \ref p8est_quadrant_t quadrants which make up the ghost layer
+   * around \b p8est.  Their piggy3 (cf. \ref
+   * p8est_quadrant::p8est_quadrant_data) data member is filled with their
+   * owner's tree and local number (cumulative over trees).  Quadrants are
+   * ordered in \ref p8est_quadrant_compare_piggy order. These are quadrants
+   * inside the neighboring tree, i.e., \c p8est_quadrant_is_inside is true for
+   * the quadrant and the neighboring tree.
    */
-  sc_array_t          ghosts; /**< array of p8est_quadrant_t type */
+  sc_array_t          ghosts;
   p4est_locidx_t     *tree_offsets;     /**< num_trees + 1 ghost indices */
   p4est_locidx_t     *proc_offsets;     /**< mpisize + 1 ghost indices */
 


### PR DESCRIPTION
# Extended documentation of ghost

This PR extends and adds documentation on the ghost layer in p4est. The concrete changes are
- a new Doxygen page on the ghost layer that gives a general introduction (in parts based on https://p4est.org/tutorial-ghost.html),
- add and reference existing examples for ghost,
- fix all Doxygen warnings in `p{4,8}est_ghost.h` and
- extend the documentation on piggies in the `p{4,8}est_quadrant_data` and clarify the role of the piggies.