### PR TITLE
Fix git-version-gen path

### DIFF
--- a/cmake/git.cmake
+++ b/cmake/git.cmake
@@ -5,7 +5,7 @@ set(PROJECT_MINOR 0)
 set(PROJECT_PATCH 0)
 set(PROJECT_VERSION 0.0.0)
 find_program(GIT_VERSION_GEN NAMES git-version-gen
-             PATHS ${PROJECT_SOURCE_DIR}/build-aux NO_DEFAULT_PATH)
+             PATHS ${CMAKE_CURRENT_SOURCE_DIR}/build-aux NO_DEFAULT_PATH)
 if(GIT_VERSION_GEN)
   execute_process(COMMAND ${GIT_VERSION_GEN} .tarball-version
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
# Fix git-version-gen path

### Problem description
Currently calling cmake on the source directory generates a file `include/p4est_config.h` with

```
[...]

/* Define to the full name and version of this package. */
#define P4EST_PACKAGE_STRING "p4est 0.0.0"

/* Define to the one symbol short name of this package. */
#define P4EST_PACKAGE_TARNAME "p4est"

/* Define to the home page for this package. */
#define P4EST_PACKAGE_URL ""

/* Define to the version of this package. */
#define P4EST_PACKAGE_VERSION "0.0.0"

/* Version number of package */
#define P4EST_VERSION "0.0.0"

/* Package major version */
#define P4EST_VERSION_MAJOR 0

/* Package minor version */
#define P4EST_VERSION_MINOR 0

/* Package point version */
#define P4EST_VERSION_POINT 0
```
as reported in https://github.com/DLR-AMR/t8code/issues/1294.

### Proposed change
The reason for the described problem is that the variable `PROJECT_SOURCE_DIR` in `cmake/git.cmake` is used to search for the `git-version-gen` program that is used to get the version number. However, `PROJECT_SOURCE_DIR` is an empty variable since `project` was not yet called. Since we want to pass the version number to `project` we can not change the call sequence. Therefore, I replaced `PROJECT_SOURCE_DIR` by `CMAKE_CURRENT_SOURCE_DIR`, which is the path to the current source directory.

Remark: We do not need an analogous PR in libsc since libsc's `include/sc_config.h` is already set correctly. 
