### PR TITLE
Fix tarball versioning

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -49,7 +49,7 @@ add_custom_command(
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt
   )
 
-add_custom_target(P4EST_GenerateVersionFile ALL DEPENDS ${VERSION_FILE})
+add_custom_target(${PROJECT_NAME}_VersionFile ALL DEPENDS ${VERSION_FILE})
 
 set(CPACK_PACKAGE_FILE_NAME "${_project_lower}-${PROJECT_VERSION}-${_sys}")
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "${_project_lower}-${PROJECT_VERSION}")

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -38,8 +38,21 @@ set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README")
 set(CPACK_PACKAGE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/package)
 string(TOLOWER ${CMAKE_SYSTEM_NAME} _sys)
 string(TOLOWER ${PROJECT_NAME} _project_lower)
-set(CPACK_PACKAGE_FILE_NAME "${_project_lower}-${git_version}-${_sys}")
-set(CPACK_SOURCE_PACKAGE_FILE_NAME "${_project_lower}-${git_version}")
+
+# Define a variable for the version file
+set(VERSION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/.tarball-version")
+
+# Generate .tarball-version file
+add_custom_command(
+    OUTPUT ${VERSION_FILE}
+    COMMAND ${CMAKE_COMMAND} -E echo "${PROJECT_VERSION}" > ${VERSION_FILE}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt
+    )
+
+add_custom_target(GenerateVersionFile ALL DEPENDS ${VERSION_FILE})
+
+set(CPACK_PACKAGE_FILE_NAME "${_project_lower}-${PROJECT_VERSION}-${_sys}")
+set(CPACK_SOURCE_PACKAGE_FILE_NAME "${_project_lower}-${PROJECT_VERSION}")
 
 # not .gitignore as its regex syntax is more advanced than CMake
 set(CPACK_SOURCE_IGNORE_FILES .git/ .github/ .vscode/ _CPack_Packages/

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -47,9 +47,9 @@ add_custom_command(
     OUTPUT ${VERSION_FILE}
     COMMAND ${CMAKE_COMMAND} -E echo "${PROJECT_VERSION}" > ${VERSION_FILE}
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt
-    )
+  )
 
-add_custom_target(GenerateVersionFile ALL DEPENDS ${VERSION_FILE})
+add_custom_target(P4EST_GenerateVersionFile ALL DEPENDS ${VERSION_FILE})
 
 set(CPACK_PACKAGE_FILE_NAME "${_project_lower}-${PROJECT_VERSION}-${_sys}")
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "${_project_lower}-${PROJECT_VERSION}")


### PR DESCRIPTION
# Fix tarball versioning

This PR addresses among others the issue of tarball naming in the CMake build system. Previously, an uninitialized variable, `git_version`, was used for the version in the package name, leading to incorrect tarball names.

Moreover,  this PR introduces a new CMake target `GenerateVersionFile` to generate the file `.tarball-version` analogous to the file used in the Autotools-based creation of a tarball in p4est.

Then the file `.tarball-version` is used by the script `git-version-gen` to get the version in the case `.git` is not present, as it is the case for creating a tarball. This ensures a correctly populated `p4est_config.h` after configuring in a tarball directory.

Currently, the CMake target `GenerateVersionFile` is only build if some arbitrary build command is executed. In particular calling only `make package_source` does not suffice to trigger `.tarball-version`'s creation.