### PR TITLE
Change default parameters in spheres2.c

### DIFF
--- a/example/spheres/spheres2.c
+++ b/example/spheres/spheres2.c
@@ -1073,16 +1073,16 @@ main (int argc, char **argv)
   /*** read command line parameters ***/
 
   opt = sc_options_new (argv[0]);
-  sc_options_add_int (opt, 'l', "minlevel", &g->minlevel, 0, "Lowest level");
-  sc_options_add_int (opt, 'L', "maxlevel", &g->maxlevel, -1,
+  sc_options_add_int (opt, 'l', "minlevel", &g->minlevel, 2, "Lowest level");
+  sc_options_add_int (opt, 'L', "maxlevel", &g->maxlevel, g->minlevel + 5,
                       "Highest level");
   sc_options_add_double (opt, 'r', "rmax", &g->rmax, .5, "Max sphere radius");
   sc_options_add_double (opt, 't', "thickness", &g->thickness, .05,
                          "Relative sphere thickness");
-  sc_options_add_double (opt, 'f', "lfraction", &g->lfraction, .3,
+  sc_options_add_double (opt, 'f', "lfraction", &g->lfraction, .7,
                          "Length density of spheres");
-  sc_options_add_double (opt, 's', "spherelems", &g->spherelems, 1.,
-                         "Min elements per sphere diameter");
+  sc_options_add_double (opt, 's', "spherquads", &g->spherelems, 20.,
+                         "Min quadrants per sphere diameter");
 
   g->ntop = g->nint = P4EST_CHILDREN;
   sc_options_add_int (opt, 'N', "nbottom", &g->nbot, 24,

--- a/example/spheres/spheres2.c
+++ b/example/spheres/spheres2.c
@@ -1081,7 +1081,7 @@ main (int argc, char **argv)
                          "Relative sphere thickness");
   sc_options_add_double (opt, 'f', "lfraction", &g->lfraction, .7,
                          "Length density of spheres");
-  sc_options_add_double (opt, 's', "spherquads", &g->spherelems, 20.,
+  sc_options_add_double (opt, 's', "spherequads", &g->spherelems, 20.,
                          "Min quadrants per sphere diameter");
 
   g->ntop = g->nint = P4EST_CHILDREN;


### PR DESCRIPTION
# More intuitive default parameters in spheres2.c

This PR changes some of the default  parameters in `example/spheres/spheres2.c` in order to create results that better fit the expectations for this example. In particular, we
 - set `maxlevel` above `minlevel`, so that the forest is adaptively refined,
 - increase `spherelems` to obtain higher resolution of the spheres and
 - increase `lfraction` to obtain multiple spheres.

Some of the spheres in this example overlap each other or lie partially outside of the forest, thereby demonstrating that the code is able to deal with these special cases as well. 
