### PR TITLE
seperat link command for Winsock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,11 @@ target_include_directories(p4est PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-target_link_libraries(p4est PUBLIC SC::SC $<$<BOOL:${P4EST_HAVE_WINSOCK2_H}>:${WINSOCK_LIBRARIES}>)
+target_link_libraries(p4est PUBLIC SC::SC )
+
+if (P4EST_HAVE_WINSOCK2_H)
+  target_linke_libaries(p4est PUBLIC ${WINSOCK_LIBRARIES})
+endif()
 
 # imported target, for use from parent projects
 add_library(P4EST::P4EST INTERFACE IMPORTED GLOBAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ target_include_directories(p4est PUBLIC
   $<INSTALL_INTERFACE:include>)
 target_link_libraries(p4est PUBLIC SC::SC )
 
-if (P4EST_HAVE_WINSOCK2_H)
+if ( WIN32)
   target_linke_libaries(p4est PUBLIC ${WINSOCK_LIBRARIES})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ target_include_directories(p4est PUBLIC
   $<INSTALL_INTERFACE:include>)
 target_link_libraries(p4est PUBLIC SC::SC )
 
-if ( WIN32)
+if (WIN32)
   target_linke_libaries(p4est PUBLIC ${WINSOCK_LIBRARIES})
 endif()
 

--- a/doc/author_knapp.txt
+++ b/doc/author_knapp.txt
@@ -1,0 +1,1 @@
+I place my contributions to p4est under the FreeBSD license. David Knapp (david.knapp@dlr.de)


### PR DESCRIPTION
# Title Use seperate link command for WINSOCK_LIBRARY

Following up on issue https://github.com/cburstedde/libsc/issues/206

Proposed changes: Use a seperate command instead of a generator expression. It prevents linker-errors with p4est if these expression fails to be properly generated.
