### PR TITLE
Calculate quadrant boundary coordinates

### DIFF
--- a/src/p4est_bits.c
+++ b/src/p4est_bits.c
@@ -1296,6 +1296,25 @@ p4est_quadrant_child (const p4est_quadrant_t * q, p4est_quadrant_t * r,
 }
 
 void
+p4est_quadrant_volume_coordinates (const p4est_quadrant_t * q,
+                                   p4est_qcoord_t coords[])
+{
+  /* compute half length of qudrant: legal even when at P4EST_QMAXLEVEL */
+  const p4est_qcoord_t qhh = P4EST_QUADRANT_LEN (q->level + 1);
+
+  /* we require a quadrant in the unit tree, not outside of it */
+  P4EST_ASSERT (p4est_quadrant_is_valid (q));
+
+  /* for any coordinate axis shift by half the quadrant length */
+  coords[0] = q->x + qhh;
+  coords[1] = q->y + qhh;
+#ifdef P4_TO_P8
+  coords[2] = q->z + qhh;
+#endif
+  P4EST_ASSERT (p4est_coordinates_is_valid (coords, q->level + 1));
+}
+
+void
 p4est_quadrant_face_neighbor (const p4est_quadrant_t * q,
                               int face, p4est_quadrant_t * r)
 {

--- a/src/p4est_bits.c
+++ b/src/p4est_bits.c
@@ -1454,6 +1454,31 @@ p4est_quadrant_all_face_neighbors (const p4est_quadrant_t * q,
 }
 
 void
+p4est_quadrant_face_coordinates (const p4est_quadrant_t * q, int face,
+                                 p4est_qcoord_t coords[])
+{
+  /* compute half length of qudrant: legal even when at P4EST_QMAXLEVEL */
+  const p4est_qcoord_t qh = P4EST_QUADRANT_LEN (q->level);
+  const p4est_qcoord_t qhh = qh >> 1;
+
+  /* store the coordinate axis normal to the face */
+  const int           faceh = face >> 1;
+
+  P4EST_ASSERT (0 <= face && face < P4EST_FACES);
+  P4EST_ASSERT (0 <= faceh && faceh < P4EST_DIM);
+  P4EST_ASSERT (p4est_quadrant_is_valid (q));
+
+  /* for the coordinate axis normal to the face, choose shift of 0 or qh */
+  /* for a coordinate axis parallel to the face, shift by half */
+  coords[0] = q->x + ((faceh == 0) ? ((face & 1) ? qh : 0) : qhh);
+  coords[1] = q->y + ((faceh == 1) ? ((face & 1) ? qh : 0) : qhh);
+#ifdef P4_TO_P8
+  coords[2] = q->z + ((faceh == 2) ? ((face & 1) ? qh : 0) : qhh);
+#endif
+  P4EST_ASSERT (p4est_coordinates_is_valid (coords, q->level + 1));
+}
+
+void
 p4est_quadrant_corner_neighbor (const p4est_quadrant_t * q,
                                 int corner, p4est_quadrant_t * r)
 {
@@ -1668,6 +1693,23 @@ p4est_quadrant_corner_node (const p4est_quadrant_t * q,
 #endif
   r->level = P4EST_MAXLEVEL;
   P4EST_ASSERT (p4est_quadrant_is_node (r, 0));
+}
+
+void
+p4est_quadrant_corner_coordinates (const p4est_quadrant_t * q, int corner,
+                                   p4est_qcoord_t coords[])
+{
+  const p4est_qcoord_t qh = P4EST_QUADRANT_LEN (q->level);
+
+  P4EST_ASSERT (0 <= corner && corner < P4EST_CHILDREN);
+  P4EST_ASSERT (p4est_quadrant_is_valid (q));
+
+  coords[0] = q->x + ((corner & 1) ? qh : 0);
+  coords[1] = q->y + ((corner & 2) ? qh : 0);
+#ifdef P4_TO_P8
+  coords[2] = q->z + ((corner & 4) ? qh : 0);
+#endif
+  P4EST_ASSERT (p4est_coordinates_is_valid (coords, q->level));
 }
 
 void

--- a/src/p4est_bits.c
+++ b/src/p4est_bits.c
@@ -2191,6 +2191,38 @@ p4est_quadrant_touches_corner (const p4est_quadrant_t * q,
 }
 
 void
+p4est_coordinates_transform_corner (p4est_qcoord_t coords[], int corner)
+{
+  p4est_qcoord_t      shift[2];
+#ifdef P4EST_ENABLE_DEBUG
+  p4est_qcoord_t      rcoords[P4EST_DIM];
+  p4est_quadrant_t    root;
+#endif
+
+  P4EST_ASSERT (coords != NULL);
+  P4EST_ASSERT (0 <= corner && corner < P4EST_CHILDREN);
+
+  shift[0] = 0;
+  shift[1] = P4EST_ROOT_LEN;
+
+  coords[0] = shift[corner & 1];
+  coords[1] = shift[(corner >> 1) & 1];
+#ifdef P4_TO_P8
+  coords[2] = shift[corner >> 2];
+#endif
+
+#ifdef P4EST_ENABLE_DEBUG
+  p4est_quadrant_set_morton (&root, 0, 0);
+  p4est_quadrant_corner_coordinates (&root, corner, rcoords);
+  P4EST_ASSERT (rcoords[0] == coords[0]);
+  P4EST_ASSERT (rcoords[1] == coords[1]);
+#ifdef P4_TO_P8
+  P4EST_ASSERT (rcoords[2] == coords[2]);
+#endif
+#endif
+}
+
+void
 p4est_quadrant_transform_corner (p4est_quadrant_t * q, int corner, int inside)
 {
   p4est_qcoord_t      shift[2];

--- a/src/p4est_bits.c
+++ b/src/p4est_bits.c
@@ -659,11 +659,13 @@ p4est_quadrant_child_id (const p4est_quadrant_t * q)
 int
 p4est_coordinates_is_inside_root (const p4est_qcoord_t coord[])
 {
+  P4EST_ASSERT (coord != NULL);
+
   /* *INDENT-OFF* */
-  return (coord[0] >= 0 && coord[0] < P4EST_ROOT_LEN) &&
-         (coord[1] >= 0 && coord[1] < P4EST_ROOT_LEN) &&
+  return (coord[0] >= 0 && coord[0] <= P4EST_ROOT_LEN) &&
+         (coord[1] >= 0 && coord[1] <= P4EST_ROOT_LEN) &&
 #ifdef P4_TO_P8
-         (coord[2] >= 0 && coord[2] < P4EST_ROOT_LEN) &&
+         (coord[2] >= 0 && coord[2] <= P4EST_ROOT_LEN) &&
 #endif
   /* *INDENT-ON* */
   1;
@@ -672,15 +674,16 @@ p4est_coordinates_is_inside_root (const p4est_qcoord_t coord[])
 int
 p4est_quadrant_is_inside_root (const p4est_quadrant_t * q)
 {
-  p4est_qcoord_t      coord[P4EST_DIM];
+  P4EST_ASSERT (q != NULL);
 
-  coord[0] = q->x;
-  coord[1] = q->y;
+  /* *INDENT-OFF* */
+  return (q->x >= 0 && q->x < P4EST_ROOT_LEN) &&
+         (q->y >= 0 && q->y < P4EST_ROOT_LEN) &&
 #ifdef P4_TO_P8
-  coord[2] = q->z;
+         (q->z >= 0 && q->z < P4EST_ROOT_LEN) &&
 #endif
-
-  return p4est_coordinates_is_inside_root (coord);
+  /* *INDENT-ON* */
+  1;
 }
 
 int
@@ -752,8 +755,10 @@ p4est_quadrant_is_node (const p4est_quadrant_t * q, int inside)
 int
 p4est_coordinates_is_valid (const p4est_qcoord_t coord[], int level)
 {
+  P4EST_ASSERT (coord != NULL);
+
   return
-    (level >= 0 && level <= P4EST_QMAXLEVEL) &&
+    (level >= 0 && level <= P4EST_MAXLEVEL) &&
     ((coord[0] & (P4EST_QUADRANT_LEN (level) - 1)) == 0) &&
     ((coord[1] & (P4EST_QUADRANT_LEN (level) - 1)) == 0) &&
 #ifdef P4_TO_P8
@@ -765,15 +770,16 @@ p4est_coordinates_is_valid (const p4est_qcoord_t coord[], int level)
 int
 p4est_quadrant_is_valid (const p4est_quadrant_t * q)
 {
-  p4est_qcoord_t      coord[P4EST_DIM];
+  P4EST_ASSERT (q != NULL);
 
-  coord[0] = q->x;
-  coord[1] = q->y;
+  return
+    (q->level >= 0 && q->level <= P4EST_QMAXLEVEL) &&
+    ((q->x & (P4EST_QUADRANT_LEN (q->level) - 1)) == 0) &&
+    ((q->y & (P4EST_QUADRANT_LEN (q->level) - 1)) == 0) &&
 #ifdef P4_TO_P8
-  coord[2] = q->z;
+    ((q->z & (P4EST_QUADRANT_LEN (q->level) - 1)) == 0) &&
 #endif
-
-  return p4est_coordinates_is_valid (coord, q->level);
+    p4est_quadrant_is_inside_root (q);
 }
 
 int

--- a/src/p4est_bits.c
+++ b/src/p4est_bits.c
@@ -1222,6 +1222,21 @@ p4est_quadrant_enlarge_last (const p4est_quadrant_t * a, p4est_quadrant_t * q)
 }
 
 void
+p4est_quadrant_root (p4est_quadrant_t *root)
+{
+  P4EST_ASSERT (root != NULL);
+
+  root->x = 0;
+  root->y = 0;
+#ifdef P4_TO_P8
+  root->z = 0;
+#endif
+  root->level = 0;
+
+  P4EST_ASSERT (p4est_quadrant_is_valid (root));
+}
+
+void
 p4est_quadrant_ancestor (const p4est_quadrant_t * q,
                          int level, p4est_quadrant_t * r)
 {
@@ -2212,7 +2227,7 @@ p4est_coordinates_transform_corner (p4est_qcoord_t coords[], int corner)
 #endif
 
 #ifdef P4EST_ENABLE_DEBUG
-  p4est_quadrant_set_morton (&root, 0, 0);
+  p4est_quadrant_root (&root);
   p4est_quadrant_corner_coordinates (&root, corner, rcoords);
   P4EST_ASSERT (rcoords[0] == coords[0]);
   P4EST_ASSERT (rcoords[1] == coords[1]);

--- a/src/p4est_bits.h
+++ b/src/p4est_bits.h
@@ -419,6 +419,13 @@ void                p4est_quadrant_sibling (const p4est_quadrant_t * q,
 void                p4est_quadrant_child (const p4est_quadrant_t * q,
                                           p4est_quadrant_t * r, int child_id);
 
+/** Compute the coordinates of a quadrant's midpoint.
+ * \param [in]     q      Input quadrant, must be valid.
+ * \param [out]    coord  2D coordinates are strictly inside the unit tree.
+ */
+void                p4est_quadrant_volume_coordinates
+  (const p4est_quadrant_t * q, p4est_qcoord_t coords[]);
+
 /** Compute the face neighbor of a quadrant.
  * \param [in]     q      Input quadrant, must be valid.
  * \param [in]     face   The face across which to generate the neighbor.

--- a/src/p4est_bits.h
+++ b/src/p4est_bits.h
@@ -188,16 +188,18 @@ int                 p4est_quadrant_ancestor_id (const p4est_quadrant_t * q,
  */
 int                 p4est_quadrant_child_id (const p4est_quadrant_t * q);
 
-/** Test if Morton indices are inside the unit tree.
- * \param [in] coord   2d coordinates.
- * \return Returns true if \a (coord[0],coord[1]) is inside the unit tree.
+/** Test if Morton indices are inside the unit tree or on its boundary.
+ * For this function, coordinate values of \ref P4EST_ROOT_LEN are legal.
+ * It is like \ref p4est_quadrant_is_inside_root with infinite level.
+ * \param [in] coord    2d coordinates.
+ * \return          true if \a (coord[0],coord[1]) is inside the unit tree.
  */
 int                 p4est_coordinates_is_inside_root (const p4est_qcoord_t
                                                       coord[]);
 
 /** Test if a quadrant is inside the unit tree.
- * \param [in] q Quadrant to be tested.
- * \return Returns true if \a q is inside the unit tree.
+ * \param [in] q        Quadrant (not necessarily valid) to be tested.
+ * \return          true if \a q is inside the unit tree.
  */
 int                 p4est_quadrant_is_inside_root (const p4est_quadrant_t *
                                                    q);
@@ -231,17 +233,17 @@ int                 p4est_quadrant_is_outside_corner (const p4est_quadrant_t *
 int                 p4est_quadrant_is_node (const p4est_quadrant_t * q,
                                             int inside);
 
-/** Test if Morton indices are valid and are inside the unit tree.
- * \param [in] coord  2d coordinates.
- * \param [in] level  level
- * \return Returns true if \a (coord[0],coord[1],level) is valid.
+/** Test if Morton indices are valid and inside the unit tree.
+ * \param [in] coord    2d coordinates may validly lie on any tree boundary.
+ * \param [in] level    A level between 0 and \ref P4EST_MAXLEVEL included.
+ * \return              true if \a (coord[0],coord[1],level) is valid.
  */
 int                 p4est_coordinates_is_valid (const p4est_qcoord_t coord[],
                                                 int level);
 
 /** Test if a quadrant has valid Morton indices and is inside the unit tree.
- * \param [in] q Quadrant to be tested.
- * \return Returns true if \a q is valid.
+ * \param [in] q        Quadrant to be tested.
+ * \return              true if \a q is valid.
  */
 int                 p4est_quadrant_is_valid (const p4est_quadrant_t * q);
 

--- a/src/p4est_bits.h
+++ b/src/p4est_bits.h
@@ -687,24 +687,30 @@ void                p4est_coordinates_transform_face (const p4est_qcoord_t
                                                       const int ftransform[]);
 
 /** Checks if a quadrant touches a corner (diagonally inside or outside).
+ * \param [in] q    This quadrant must be valid (if \a inside is true)
+ *                  or at least extended (if \a inside is false).
+ *                  It may also be a node respecting the \a inside argument.
+ * \param [in] corner   Valid corner index from 0 to 3.
+ * \param [in] inside   Boolean to clarify whether the input \a q is
+ *                      inside or outside a unit tree (or root quadrant).
  */
 int                 p4est_quadrant_touches_corner (const p4est_quadrant_t * q,
                                                    int corner, int inside);
 
-
-
+/** Set a coordinate location to a given tree (root quadrant) corner.
+ * \param [out] coords  Output coordinates filled depending on \a corner.
+ * \param [in]  corner  Number of the corner in 0..3.
+ */
 void                p4est_coordinates_transform_corner
   (p4est_qcoord_t coords[], int corner);
 
-
-
 /** Move a quadrant inside or diagonally outside a corner position.
  * \param [in,out] q        This quadrant only requires a valid level.
- * \param [in]     icorner  Number of the corner in 0..3.
- * \param [int]    inside   Boolean flag for inside or diagonally outside.
+ * \param [in]     corner   Number of the corner in 0..3.
+ * \param [in]     inside   Boolean flag for inside or diagonally outside.
  */
 void                p4est_quadrant_transform_corner (p4est_quadrant_t * q,
-                                                     int icorner, int inside);
+                                                     int corner, int inside);
 
 /** Shifts a quadrant until it touches the specified corner from the inside.
  * \param [in]     q          Valid input quadrant.

--- a/src/p4est_bits.h
+++ b/src/p4est_bits.h
@@ -421,7 +421,7 @@ void                p4est_quadrant_child (const p4est_quadrant_t * q,
 
 /** Compute the coordinates of a quadrant's midpoint.
  * \param [in]     q      Input quadrant, must be valid.
- * \param [out]    coord  2D coordinates are strictly inside the unit tree.
+ * \param [out]    coords 2D coordinates are strictly inside the unit tree.
  */
 void                p4est_quadrant_volume_coordinates
   (const p4est_quadrant_t * q, p4est_qcoord_t coords[]);
@@ -504,7 +504,7 @@ void                p4est_quadrant_all_face_neighbors (const p4est_quadrant_t
  * \param [in]     q      Input quadrant, must be valid.
  * \param [in]     face   The face of which the midpoint coordinates
  *                        are computed.
- * \param [out]    coord  2D mid-face coordinates are in/on the unit tree.
+ * \param [out]    coords 2D mid-face coordinates are in/on the unit tree.
  */
 void                p4est_quadrant_face_coordinates
   (const p4est_quadrant_t * q, int face, p4est_qcoord_t coords[]);
@@ -570,7 +570,7 @@ void                p4est_quadrant_corner_node (const p4est_quadrant_t * q,
 /** Compute the coordinates of a specific quadrant corner.
  * \param [in]     q      Input quadrant, must be valid.
  * \param [in]     corner The corner for which the coordinates are computed.
- * \param [out]    coord  2D corner coordinates are in/on the unit tree.
+ * \param [out]    coords 2D corner coordinates are in/on the unit tree.
  */
 void                p4est_quadrant_corner_coordinates
   (const p4est_quadrant_t * q, int corner, p4est_qcoord_t coords[]);

--- a/src/p4est_bits.h
+++ b/src/p4est_bits.h
@@ -493,6 +493,15 @@ void                p4est_quadrant_all_face_neighbors (const p4est_quadrant_t
                                                        * q, int face,
                                                        p4est_quadrant_t n[]);
 
+/** Compute the coordinates of a specific quadrant face's midpoint.
+ * \param [in]     q      Input quadrant, must be valid.
+ * \param [in]     face   The face of which the midpoint coordinates
+ *                        are computed.
+ * \param [out]    coord  2D mid-face coordinates are in/on the unit tree.
+ */
+void                p4est_quadrant_face_coordinates
+  (const p4est_quadrant_t * q, int face, p4est_qcoord_t coords[]);
+
 /** Compute the corner neighbor of a quadrant.
  * \param [in]     q      Input quadrant, must be valid.
  * \param [in]     corner The corner across which to generate the neighbor.
@@ -541,7 +550,7 @@ void                p4est_quadrant_half_corner_neighbor (const
                                                          p4est_quadrant_t *
                                                          r);
 
-/** Compute the corner node of a quadrant.
+/** Compute a corner node of a quadrant.
  * \param [in]     q      Input quadrant, must be valid.
  * \param [in]     corner The corner across which to generate the neighbor.
  * \param [in,out] r      Node that will not be clamped inside.
@@ -550,6 +559,14 @@ void                p4est_quadrant_half_corner_neighbor (const
 void                p4est_quadrant_corner_node (const p4est_quadrant_t * q,
                                                 int corner,
                                                 p4est_quadrant_t * r);
+
+/** Compute the coordinates of a specific quadrant corner.
+ * \param [in]     q      Input quadrant, must be valid.
+ * \param [in]     corner The corner for which the coordinates are computed.
+ * \param [out]    coord  2D corner coordinates are in/on the unit tree.
+ */
+void                p4est_quadrant_corner_coordinates
+  (const p4est_quadrant_t * q, int corner, p4est_qcoord_t coords[]);
 
 /** Compute the 4 children of a quadrant.
  * \param [in]     q  Input quadrant.

--- a/src/p4est_bits.h
+++ b/src/p4est_bits.h
@@ -378,6 +378,14 @@ void                p4est_quadrant_enlarge_first (const p4est_quadrant_t * a,
 void                p4est_quadrant_enlarge_last (const p4est_quadrant_t * a,
                                                  p4est_quadrant_t * q);
 
+/** Generate the root quadrant of any tree.
+ * \param [out] root    Quadrant structure's coordinates and level are set.
+ *                      As with all other functions that generate or
+ *                      modify quadrants, the other bits of the structured
+ *                      data type are not touched at all.
+ */
+void                p4est_quadrant_root (p4est_quadrant_t *root);
+
 /** Compute the ancestor of a quadrant at a given level.
  * \param [in]  q       Input quadrant.
  * \param [in]  level   A smaller level than q.

--- a/src/p4est_bits.h
+++ b/src/p4est_bits.h
@@ -691,6 +691,13 @@ void                p4est_coordinates_transform_face (const p4est_qcoord_t
 int                 p4est_quadrant_touches_corner (const p4est_quadrant_t * q,
                                                    int corner, int inside);
 
+
+
+void                p4est_coordinates_transform_corner
+  (p4est_qcoord_t coords[], int corner);
+
+
+
 /** Move a quadrant inside or diagonally outside a corner position.
  * \param [in,out] q        This quadrant only requires a valid level.
  * \param [in]     icorner  Number of the corner in 0..3.

--- a/src/p4est_io.c
+++ b/src/p4est_io.c
@@ -2055,11 +2055,15 @@ p4est_file_read_p4est (p4est_file_context_t * fc, p4est_connectivity_t * conn,
   p4est_gloidx_t     *gfq, *pertree;
   sc_array_t          quadrants, quad_data, pertree_arr;
   p4est_qcoord_t     *comp_quad;
+  p4est_quadrant_t    check_quad;
 
   /* verify call convention */
   P4EST_ASSERT (fc != NULL);
   P4EST_ASSERT (conn != NULL);
   P4EST_ASSERT (p4est_connectivity_is_valid (conn));
+
+  /* initialize work quadrant */
+  P4EST_QUADRANT_INIT (&check_quad);
 
   /* initialize error return context */
   P4EST_ASSERT (p4est != NULL);
@@ -2138,7 +2142,13 @@ p4est_file_read_p4est (p4est_file_context_t * fc, p4est_connectivity_t * conn,
   /* check the read quadrants */
   for (jq = 0; jq < (p4est_gloidx_t) quadrants.elem_count; ++jq) {
     comp_quad = (p4est_qcoord_t *) sc_array_index (&quadrants, (size_t) jq);
-    if (!p4est_coordinates_is_valid (comp_quad, comp_quad[P4EST_DIM])) {
+    check_quad.x = comp_quad[0];
+    check_quad.y = comp_quad[1];
+#ifdef P4_TO_P8
+    check_quad.z = comp_quad[2];
+#endif
+    check_quad.level = (int8_t) comp_quad[P4EST_DIM];
+    if (!p4est_quadrant_is_valid (&check_quad)) {
       *errcode = P4EST_FILE_ERR_P4EST;
       /* clean up local variables and open file context */
       P4EST_FREE (gfq);

--- a/src/p4est_points.c
+++ b/src/p4est_points.c
@@ -303,7 +303,7 @@ p4est_new_points (sc_MPI_Comm mpicomm, p4est_connectivity_t * connectivity,
     /* determine largest possible last quadrant of this tree */
     if (jt < next_tree) {
       p4est_quadrant_last_descendant (&a, &l, maxlevel);
-      p4est_quadrant_set_morton_ext128 (&b, 0, &zero);
+      p4est_quadrant_root (&b);
       p4est_quadrant_last_descendant (&b, &b, maxlevel);
       if (p4est_quadrant_is_equal (&l, &b)) {
         onlyone = 1;

--- a/src/p4est_search.c
+++ b/src/p4est_search.c
@@ -768,7 +768,7 @@ p4est_search_local (p4est_t * p4est,
     tquadrants = &tree->quadrants;
 
     /* the recursion shrinks the search quadrant whenever possible */
-    p4est_quadrant_set_morton (&root, 0, 0);
+    p4est_quadrant_root (&root);
     p4est_local_recursion (rec, &root, tquadrants, NULL);
   }
 }
@@ -1033,7 +1033,7 @@ p4est_search_reorder (p4est_t * p4est, int skip_levels,
     for (tt = p4est->first_local_tree; tt <= p4est->last_local_tree; ++tt) {
       rit = tt - p4est->first_local_tree;
       proot = (p4est_quadrant_t *) sc_array_index (tquadrants, rit);
-      p4est_quadrant_set_morton (proot, 0, 0);
+      p4est_quadrant_root (proot);
       proot->p.piggy1.which_tree = tt;
       *(p4est_topidx_t *) sc_array_index (root_indices, rit) = rit;
     }
@@ -1073,7 +1073,7 @@ p4est_search_reorder (p4est_t * p4est, int skip_levels,
     tquadrants = &tree->quadrants;
 
     /* the recursion shrinks the search quadrant whenever possible */
-    p4est_quadrant_set_morton (&root, 0, 0);
+    p4est_quadrant_root (&root);
     p4est_reorder_recursion (rec, &root, tquadrants, NULL);
   }
 
@@ -1209,7 +1209,7 @@ static int          p4est_traverse_is_valid_tree
   P4EST_ASSERT (0 <= which_tree && which_tree < num_trees);
   P4EST_ASSERT (0 <= pfirst && pfirst <= plast && plast < num_procs);
 
-  p4est_quadrant_set_morton (&root, 0, 0);
+  p4est_quadrant_root (&root);
 
   return p4est_traverse_is_valid_quadrant
     (gfp, num_procs, num_trees, which_tree, &root, pfirst, plast);
@@ -1538,7 +1538,7 @@ void                p4est_search_partition_internal
   rec->point_fn = point_fn;
   rec->points = points;
   rec->position_array = &position_array;
-  p4est_quadrant_set_morton (&root, 0, 0);
+  p4est_quadrant_root (&root);
   for (pfirst = 0, tt = 0; tt < num_trees; pfirst = pnext, ++tt) {
     /* pfirst is the first processor indexed for this tree */
     rec->which_tree = root.p.which_tree = tt;
@@ -1909,7 +1909,7 @@ p4est_search_all (p4est_t * p4est,
   rec->point_fn = point_fn;
   rec->points = points;
   rec->position_array = &position_array;
-  p4est_quadrant_set_morton (&root, 0, 0);
+  p4est_quadrant_root (&root);
   for (pfirst = 0, tt = 0; tt < num_trees; pfirst = pnext, ++tt) {
     /* pfirst is the first processor indexed for this tree */
     rec->which_tree = root.p.which_tree = tt;

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -368,6 +368,7 @@
 #define p4est_quadrant_is_first_last    p8est_quadrant_is_first_last
 #define p4est_quadrant_enlarge_first    p8est_quadrant_enlarge_first
 #define p4est_quadrant_enlarge_last     p8est_quadrant_enlarge_last
+#define p4est_quadrant_root             p8est_quadrant_root
 #define p4est_quadrant_ancestor         p8est_quadrant_ancestor
 #define p4est_quadrant_parent           p8est_quadrant_parent
 #define p4est_quadrant_sibling          p8est_quadrant_sibling

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -372,6 +372,8 @@
 #define p4est_quadrant_parent           p8est_quadrant_parent
 #define p4est_quadrant_sibling          p8est_quadrant_sibling
 #define p4est_quadrant_child            p8est_quadrant_child
+#define p4est_quadrant_volume_coordinates       \
+        p8est_quadrant_volume_coordinates
 #define p4est_quadrant_face_neighbor    p8est_quadrant_face_neighbor
 #define p4est_quadrant_face_neighbor_extra p8est_quadrant_face_neighbor_extra
 #define p4est_quadrant_half_face_neighbors p8est_quadrant_half_face_neighbors

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -376,12 +376,15 @@
 #define p4est_quadrant_face_neighbor_extra p8est_quadrant_face_neighbor_extra
 #define p4est_quadrant_half_face_neighbors p8est_quadrant_half_face_neighbors
 #define p4est_quadrant_all_face_neighbors p8est_quadrant_all_face_neighbors
+#define p4est_quadrant_face_coordinates p8est_quadrant_face_coordinates
 #define p4est_quadrant_corner_neighbor  p8est_quadrant_corner_neighbor
 #define p4est_quadrant_corner_neighbor_extra    \
         p8est_quadrant_corner_neighbor_extra
 #define p4est_quadrant_half_corner_neighbor     \
         p8est_quadrant_half_corner_neighbor
 #define p4est_quadrant_corner_node      p8est_quadrant_corner_node
+#define p4est_quadrant_corner_coordinates       \
+        p8est_quadrant_corner_coordinates
 #define p4est_quadrant_children         p8est_quadrant_children
 #define p4est_quadrant_childrenv        p8est_quadrant_childrenv
 #define p4est_quadrant_childrenpv       p8est_quadrant_childrenpv

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -399,6 +399,8 @@
         p8est_coordinates_transform_face
 #define p4est_quadrant_transform_face   p8est_quadrant_transform_face
 #define p4est_quadrant_touches_corner   p8est_quadrant_touches_corner
+#define p4est_coordinates_transform_corner      \
+        p8est_coordinates_transform_corner
 #define p4est_quadrant_transform_corner p8est_quadrant_transform_corner
 #define p4est_quadrant_shift_corner     p8est_quadrant_shift_corner
 #define p4est_quadrant_linear_id        p8est_quadrant_linear_id

--- a/src/p8est_bits.c
+++ b/src/p8est_bits.c
@@ -687,3 +687,31 @@ p8est_quadrant_shift_edge (const p4est_quadrant_t * q,
   P4EST_ASSERT (rdown == NULL
                 || p8est_quadrant_touches_edge (rdown, edge, 1));
 }
+
+void
+p8est_quadrant_edge_coordinates (const p8est_quadrant_t * q, int edge,
+                                 p4est_qcoord_t coords[])
+{
+  /* compute half length of qudrant: legal even when at P4EST_QMAXLEVEL */
+  const p4est_qcoord_t qh = P4EST_QUADRANT_LEN (q->level);
+  const p4est_qcoord_t qhh = qh >> 1;
+
+  /* store the coordinate axis parallel to the edge */
+  const int           edgeh = edge >> 2;
+
+  /* the y coordinate is the first for an x-edge and the second for a z-edge */
+  const int           s = (edgeh == 0) ? 1 : 2;
+
+  P4EST_ASSERT (0 <= edge && edge < P8EST_EDGES);
+  P4EST_ASSERT (0 <= edgeh && edgeh < P4EST_DIM);
+  P4EST_ASSERT (p4est_quadrant_is_valid (q));
+
+  /* for the coordinate axis parallel to the edge, shift by half */
+  /* for a coordinate axis normal to the edge, choose shift of 0 or qh */
+  coords[0] = q->x + ((edgeh == 0) ? qhh : ((edge & 1) ? qh : 0));
+  coords[1] = q->y + ((edgeh == 1) ? qhh : ((edge & s) ? qh : 0));
+#ifdef P4_TO_P8
+  coords[2] = q->z + ((edgeh == 2) ? qhh : ((edge & 2) ? qh : 0));
+#endif
+  P4EST_ASSERT (p4est_coordinates_is_valid (coords, q->level + 1));
+}

--- a/src/p8est_bits.h
+++ b/src/p8est_bits.h
@@ -188,16 +188,18 @@ int                 p8est_quadrant_ancestor_id (const p8est_quadrant_t * q,
  */
 int                 p8est_quadrant_child_id (const p8est_quadrant_t * q);
 
-/** Test if Morton indices are inside the unit tree.
- * \param [in] coord   3d coordinates.
- * \return Returns true if \a (coord[0],coord[1],coord[2]) is inside the unit tree.
+/** Test if Morton indices are inside the unit tree or on its boundary.
+ * For this function, coordinate values of \ref P8EST_ROOT_LEN are legal.
+ * It is like \ref p8est_quadrant_is_inside_root with infinite level.
+ * \param [in] coord    3d coordinates.
+ * \return true if \a (coord[0],coord[1],coord[2]) is inside the unit tree.
  */
 int                 p8est_coordinates_is_inside_root (const p4est_qcoord_t
                                                       coord[]);
 
 /** Test if a quadrant is inside the unit tree.
- * \param [in] q Quadrant to be tested.
- * \return Returns true if \a q is inside the unit tree.
+ * \param [in] q        Quadrant (not necessarily valid) to be tested.
+ * \return          true if \a q is inside the unit tree.
  */
 int                 p8est_quadrant_is_inside_root (const p8est_quadrant_t *
                                                    q);
@@ -248,17 +250,17 @@ int                 p8est_quadrant_is_outside_corner (const p8est_quadrant_t *
 int                 p8est_quadrant_is_node (const p8est_quadrant_t * q,
                                             int inside);
 
-/** Test if Morton indices are valid and are inside the unit tree.
- * \param [in] coord  3d coordinates.
- * \param [in] level  level
- * \return Returns true if \a (coord[0],coord[1],coord[2],level) is valid.
+/** Test if Morton indices are valid and inside the unit tree.
+ * \param [in] coord    3d coordinates may validly lie on any tree boundary.
+ * \param [in] level    A level between 0 and \ref P8EST_MAXLEVEL included.
+ * \return          true if \a (coord[0],coord[1],coord[2],level) is valid.
  */
 int                 p8est_coordinates_is_valid (const p4est_qcoord_t coord[],
                                                 int level);
 
 /** Test if a quadrant has valid Morton indices and is inside the unit tree.
- * \param [in] q Quadrant to be tested.
- * \return Returns true if \a q is valid.
+ * \param [in] q        Quadrant to be tested.
+ * \return              true if \a q is valid.
  */
 int                 p8est_quadrant_is_valid (const p8est_quadrant_t * q);
 

--- a/src/p8est_bits.h
+++ b/src/p8est_bits.h
@@ -442,7 +442,7 @@ void                p8est_quadrant_sibling (const p8est_quadrant_t * q,
 
 /** Compute the coordinates of a quadrant's midpoint.
  * \param [in]     q      Input quadrant, must be valid.
- * \param [out]    coord  3D coordinates are strictly inside the unit tree.
+ * \param [out]    coords 3D coordinates are strictly inside the unit tree.
  */
 void                p8est_quadrant_volume_coordinates
   (const p8est_quadrant_t * q, p4est_qcoord_t coords[]);
@@ -525,7 +525,7 @@ void                p8est_quadrant_all_face_neighbors (const p8est_quadrant_t
  * \param [in]     q      Input quadrant, must be valid.
  * \param [in]     face   The face of which the midpoint coordinates
  *                        are computed.
- * \param [out]    coord  3D mid-face coordinates are in/on the unit tree.
+ * \param [out]    coords 3D mid-face coordinates are in/on the unit tree.
  */
 void                p8est_quadrant_face_coordinates
   (const p8est_quadrant_t * q, int face, p4est_qcoord_t coords[]);
@@ -569,7 +569,7 @@ void                p8est_quadrant_edge_neighbor_extra (const p8est_quadrant_t
  * \param [in]     q      Input quadrant, must be valid.
  * \param [in]     edge   The edge of which the midpoint coordinates
  *                        are computed.
- * \param [out]    coord  3D mid-edge coordinates are in/on the unit tree.
+ * \param [out]    coords 3D mid-edge coordinates are in/on the unit tree.
  */
 void                p8est_quadrant_edge_coordinates
   (const p8est_quadrant_t * q, int edge, p4est_qcoord_t coords[]);
@@ -635,7 +635,7 @@ void                p8est_quadrant_corner_node (const p8est_quadrant_t * q,
 /** Compute the coordinates of a specific quadrant corner.
  * \param [in]     q      Input quadrant, must be valid.
  * \param [in]     corner The corner for which the coordinates are computed.
- * \param [out]    coord  3D corner coordinates are in/on the unit tree.
+ * \param [out]    coords 3D corner coordinates are in/on the unit tree.
  */
 void                p8est_quadrant_corner_coordinates
   (const p8est_quadrant_t * q, int corner, p4est_qcoord_t coords[]);

--- a/src/p8est_bits.h
+++ b/src/p8est_bits.h
@@ -814,23 +814,29 @@ void                p8est_quadrant_shift_edge (const p8est_quadrant_t * q,
                                                int edge);
 
 /** Checks if a quadrant touches a corner (diagonally inside or outside).
+ * \param [in] q    This quadrant must be valid (if \a inside is true)
+ *                  or at least extended (if \a inside is false).
+ *                  It may also be a node respecting the \a inside argument.
+ * \param [in] corner   Valid corner index from 0 to 7.
+ * \param [in] inside   Boolean to clarify whether the input \a q is
+ *                      inside or outside a unit tree (or root quadrant).
  */
 int                 p8est_quadrant_touches_corner (const p8est_quadrant_t * q,
                                                    int corner, int inside);
 
-
-
+/** Set a coordinate location to a given tree (root quadrant) corner.
+ * \param [out] coords  Output coordinates filled depending on \a corner.
+ * \param [in]  corner  Number of the corner in 0..7.
+ */
 void                p8est_coordinates_transform_corner
   (p4est_qcoord_t coords[], int corner);
 
-
-
 /** Move a quadrant inside or diagonally outside a corner position.
  * \param [in,out] q        This quadrant only requires a valid level.
- * \param [in]     icorner  Number of the corner in 0..7.
- * \param [int]    inside   Boolean flag for inside or diagonally outside.
+ * \param [in]     corner   Number of the corner in 0..7.
+ * \param [in]     inside   Boolean flag for inside or diagonally outside.
  */
-void                p8est_quadrant_transform_corner (p8est_quadrant_t * r,
+void                p8est_quadrant_transform_corner (p8est_quadrant_t * q,
                                                      int corner, int inside);
 
 /** Shifts a quadrant until it touches the specified corner from the inside.

--- a/src/p8est_bits.h
+++ b/src/p8est_bits.h
@@ -514,6 +514,15 @@ void                p8est_quadrant_all_face_neighbors (const p8est_quadrant_t
                                                        * q, int face,
                                                        p8est_quadrant_t n[]);
 
+/** Compute the coordinates of a specific quadrant face's midpoint.
+ * \param [in]     q      Input quadrant, must be valid.
+ * \param [in]     face   The face of which the midpoint coordinates
+ *                        are computed.
+ * \param [out]    coord  3D mid-face coordinates are in/on the unit tree.
+ */
+void                p8est_quadrant_face_coordinates
+  (const p8est_quadrant_t * q, int face, p4est_qcoord_t coords[]);
+
 /** Compute the edge neighbor of a quadrant.
  * \param [in]     q      Input quadrant, must be valid.
  * \param [in]     edge   The edge across which to generate the neighbor.
@@ -548,6 +557,15 @@ void                p8est_quadrant_edge_neighbor_extra (const p8est_quadrant_t
                                                         sc_array_t * nedges,
                                                         p8est_connectivity_t *
                                                         conn);
+
+/** Compute the coordinates of a specific quadrant edge's midpoint.
+ * \param [in]     q      Input quadrant, must be valid.
+ * \param [in]     edge   The edge of which the midpoint coordinates
+ *                        are computed.
+ * \param [out]    coord  3D mid-edge coordinates are in/on the unit tree.
+ */
+void                p8est_quadrant_edge_coordinates
+  (const p8est_quadrant_t * q, int edge, p4est_qcoord_t coords[]);
 
 /** Compute the corner neighbor of a quadrant.
  * \param [in]     q      Input quadrant, must be valid.
@@ -597,7 +615,7 @@ void                p8est_quadrant_half_corner_neighbor (const
                                                          p8est_quadrant_t *
                                                          r);
 
-/** Compute the corner node of a quadrant.
+/** Compute a corner node of a quadrant.
  * \param [in]     q      Input quadrant, must be valid.
  * \param [in]     corner The corner across which to generate the neighbor.
  * \param [in,out] r      Node that will not be clamped inside.
@@ -606,6 +624,14 @@ void                p8est_quadrant_half_corner_neighbor (const
 void                p8est_quadrant_corner_node (const p8est_quadrant_t * q,
                                                 int corner,
                                                 p8est_quadrant_t * r);
+
+/** Compute the coordinates of a specific quadrant corner.
+ * \param [in]     q      Input quadrant, must be valid.
+ * \param [in]     corner The corner for which the coordinates are computed.
+ * \param [out]    coord  3D corner coordinates are in/on the unit tree.
+ */
+void                p8est_quadrant_corner_coordinates
+  (const p8est_quadrant_t * q, int corner, p4est_qcoord_t coords[]);
 
 /** Compute the 8 children of a quadrant.
  * \param [in]     q  Input quadrant.

--- a/src/p8est_bits.h
+++ b/src/p8est_bits.h
@@ -408,6 +408,14 @@ void                p8est_quadrant_enlarge_first (const p8est_quadrant_t * a,
 void                p8est_quadrant_enlarge_last (const p8est_quadrant_t * a,
                                                  p8est_quadrant_t * q);
 
+/** Generate the root quadrant of any tree.
+ * \param [out] root    Quadrant structure's coordinates and level are set.
+ *                      As with all other functions that generate or
+ *                      modify quadrants, the other bits of the structured
+ *                      data type are not touched at all.
+ */
+void                p8est_quadrant_root (p8est_quadrant_t *root);
+
 /** Compute the ancestor of a quadrant at a given level.
  * \param [in]  q       Input quadrant.
  * \param [in]  level   A smaller level than q.

--- a/src/p8est_bits.h
+++ b/src/p8est_bits.h
@@ -440,6 +440,13 @@ void                p8est_quadrant_sibling (const p8est_quadrant_t * q,
                                             p8est_quadrant_t * r,
                                             int sibling_id);
 
+/** Compute the coordinates of a quadrant's midpoint.
+ * \param [in]     q      Input quadrant, must be valid.
+ * \param [out]    coord  3D coordinates are strictly inside the unit tree.
+ */
+void                p8est_quadrant_volume_coordinates
+  (const p8est_quadrant_t * q, p4est_qcoord_t coords[]);
+
 /** Compute the face neighbor of a quadrant.
  * \param [in]     q      Input quadrant, must be valid.
  * \param [in]     face   The face across which to generate the neighbor.

--- a/src/p8est_bits.h
+++ b/src/p8est_bits.h
@@ -818,6 +818,13 @@ void                p8est_quadrant_shift_edge (const p8est_quadrant_t * q,
 int                 p8est_quadrant_touches_corner (const p8est_quadrant_t * q,
                                                    int corner, int inside);
 
+
+
+void                p8est_coordinates_transform_corner
+  (p4est_qcoord_t coords[], int corner);
+
+
+
 /** Move a quadrant inside or diagonally outside a corner position.
  * \param [in,out] q        This quadrant only requires a valid level.
  * \param [in]     icorner  Number of the corner in 0..7.

--- a/test/test_quadrants2.c
+++ b/test/test_quadrants2.c
@@ -148,6 +148,29 @@ check_predecessor_successor (const p4est_quadrant_t * q)
   SC_CHECK_ABORT (p4est_quadrant_is_equal (&temp2, q), "successor");
 }
 
+static void
+check_coordinates (const p4est_quadrant_t * q)
+{
+  int                 face;
+#ifdef P4_TO_P8
+  int                 edge;
+#endif
+  int                 corner;
+  p4est_qcoord_t      coord[P4EST_DIM];
+
+  for (face = 0; face < P4EST_FACES; ++face) {
+    p4est_quadrant_face_coordinates (q, face, coord);
+  }
+#ifdef P4_TO_P8
+  for (edge = 0; edge < P8EST_EDGES; ++edge) {
+    p8est_quadrant_edge_coordinates (q, edge, coord);
+  }
+#endif
+  for (corner = 0; corner < P4EST_CHILDREN; ++corner) {
+    p4est_quadrant_corner_coordinates (q, corner, coord);
+  }
+}
+
 #define NEG_ONE_MAXL (~((((p4est_qcoord_t) 1) << P4EST_MAXLEVEL) - 1))
 #define NEG_ONE_MAXLM1 (~((((p4est_qcoord_t) 1) << (P4EST_MAXLEVEL - 1)) - 1))
 #define NEG_ONE_MAXLP1 \
@@ -199,6 +222,9 @@ main (int argc, char **argv)
   p = NULL;
   for (iz = 0; iz < t1->quadrants.elem_count; ++iz) {
     q1 = p4est_quadrant_array_index (&t1->quadrants, iz);
+
+    /* test coordinates of all boundary objects */
+    check_coordinates (q1);
 
     /* test the index conversion */
     index1 = p4est_quadrant_linear_id (q1, (int) q1->level);
@@ -458,6 +484,15 @@ main (int argc, char **argv)
   P4EST_QUADRANT_INIT (&P);
   P4EST_QUADRANT_INIT (&Q);
 
+  /* test quadrant coordinates for first and last tree cornre */
+  p4est_quadrant_set_morton (&A, 0, 0);
+  check_coordinates (&A);
+  p4est_quadrant_first_descendant (&A, &B, P4EST_QMAXLEVEL);
+  check_coordinates (&B);
+  p4est_quadrant_last_descendant (&A, &B, P4EST_QMAXLEVEL);
+  check_coordinates (&B);
+
+  /* go through several hand-crafted quadrants */
   A.x = NEG_ONE_MAXL;
   A.y = NEG_ONE_MAXL;
   A.level = 0;

--- a/test/test_quadrants2.c
+++ b/test/test_quadrants2.c
@@ -158,6 +158,7 @@ check_coordinates (const p4est_quadrant_t * q)
   int                 corner;
   p4est_qcoord_t      coord[P4EST_DIM];
 
+  p4est_quadrant_volume_coordinates (q, coord);
   for (face = 0; face < P4EST_FACES; ++face) {
     p4est_quadrant_face_coordinates (q, face, coord);
   }


### PR DESCRIPTION
# Calculate quadrant boundary coordinates

## Proposed changes

Create functions to export any corner coordinates and face or odge midpoint of any valid p4est quadrant. The quadrant must thus be inside the unit tree. The coordinates may or may not be on any boundary of the unit tree.

This is an extension on top of #334. It can help the user create indexing the mesh topology and/or to use hashing to determine the quadrant connectivity.