### PR TITLE
Avoid CI fails due to busy file system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ on:
       - ".github/workflows/ci_valgrind.yml"
   pull_request:
 
+env:
+  # Due to busy file system problems on the CI runners, we deactivate the file
+  # checks in the CI.
+  P4EST_CI_CONFIG_OPT: --disable-file-checks
+
 jobs:
 
   linux-multi1:
@@ -39,7 +44,7 @@ jobs:
       run: |
         DIR="checkdebug_static" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --disable-shared --enable-debug \
-            CFLAGS="-O0 -g -Wall"
+                     CFLAGS="-O0 -g -Wall" $P4EST_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -48,7 +53,7 @@ jobs:
       run: |
         DIR="checkMPIdebug" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi --enable-debug \
-            CFLAGS="-O0 -g -Wall"
+                     CFLAGS="-O0 -g -Wall" $P4EST_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -57,7 +62,7 @@ jobs:
       run: |
         DIR="checkMPI" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi \
-            CFLAGS="-O2"
+                     CFLAGS="-O2" $P4EST_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -95,7 +100,7 @@ jobs:
       run: |
         DIR="checkMPIdebugCXX" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi --enable-debug \
-            CFLAGS="-O0" CC=mpicxx
+                     CFLAGS="-O0" CC=mpicxx $P4EST_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -103,7 +108,7 @@ jobs:
       shell: bash
       run: |
         DIR="distcheck" && mkdir -p "$DIR" && cd "$DIR"
-        ../configure
+        ../configure $P4EST_CI_CONFIG_OPT
         make -j distcheck V=0
 
     - name: Upload log files
@@ -149,7 +154,7 @@ jobs:
       run: |
         DIR="sc-checkdebug_static" && mkdir -p "$DIR" && cd "$DIR"
         ../sc/configure --disable-shared --enable-debug \
-            CFLAGS="-O0 -g -Wall -pedantic"
+                        CFLAGS="-O0 -g -Wall -pedantic" $P4EST_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
         make -j install V=0
@@ -161,8 +166,8 @@ jobs:
       run: |
         DIR="p4est-checkdebug_static" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --disable-shared --enable-debug \
-            --with-sc="$PWD/../sc-checkdebug_static/local" \
-            CFLAGS="-O0 -g -Wall -pedantic"
+                     --with-sc="$PWD/../sc-checkdebug_static/local" \
+                     CFLAGS="-O0 -g -Wall -pedantic" $P4EST_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
         make -j install V=0
@@ -208,8 +213,9 @@ jobs:
       run: |
         DIR="tarball" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi --enable-debug \
-            CFLAGS="-O0 -g -pedantic -Wall -Wextra -Werror -Wno-unused-parameter \
-                    -Wno-builtin-declaration-mismatch -Wno-implicit-fallthrough"
+                     CFLAGS="-O0 -g -pedantic -Wall -Wextra -Werror \
+                     -Wno-unused-parameter -Wno-builtin-declaration-mismatch \
+                     -Wno-implicit-fallthrough" $P4EST_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
         make -j distcheck V=0

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -21,6 +21,9 @@ env:
   CTEST_NO_TESTS_ACTION: "error"
   CMAKE_INSTALL_PREFIX: ~/local
   CMAKE_PREFIX_PATH: ~/local
+  # Due to busy file system problems on the CI runners, we deactivate the file
+  # checks in the CI.
+  P4EST_CI_CONFIG_OPT: -DP4EST_ENABLE_FILE_CHECKS=OFF
 
 jobs:
 
@@ -116,7 +119,7 @@ jobs:
 
     # Windows MPI is shaky in general on GitHub Actions, so we don't use it
     - name: CMake configure without MPI
-      run: cmake --preset default -Dmpi:BOOL=no
+      run: cmake --preset default -Dmpi:BOOL=no $env:P4EST_CI_CONFIG_OPT
 
     - name: CMake build
       run: cmake --build --preset default

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -23,7 +23,7 @@ env:
   CMAKE_PREFIX_PATH: ~/local
   # Due to busy file system problems on the CI runners, we deactivate the file
   # checks in the CI.
-  P4EST_CI_CONFIG_OPT: -DP4EST_ENABLE_FILE_CHECKS=OFF
+  P4EST_CI_CONFIG_OPT: -DP4EST_ENABLE_FILE_CHECKS=OFF -DSC_ENABLE_FILE_CHECKS=OFF
 
 jobs:
 

--- a/.github/workflows/ci_darwin.yml
+++ b/.github/workflows/ci_darwin.yml
@@ -13,6 +13,11 @@ on:
       - ".github/workflows/ci_valgrind.yml"
   pull_request:
 
+env:
+  # Due to busy file system problems on the CI runners, we deactivate the file
+  # checks in the CI.
+  P4EST_CI_CONFIG_OPT: --disable-file-checks
+
 jobs:
 
   darwin1:
@@ -40,7 +45,8 @@ jobs:
        run: |
           DIR="checkdebug" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-debug \
-            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter"
+                       CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
+                       $P4EST_CI_CONFIG_OPT
           make -j V=0
           make -j check V=0
 
@@ -49,7 +55,8 @@ jobs:
        run: |
           DIR="checkMPIdebug" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-mpi --enable-debug \
-            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter"
+                       CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
+                       $P4EST_CI_CONFIG_OPT
           make -j V=0
           make -j check V=0
 
@@ -88,7 +95,8 @@ jobs:
        run: |
           DIR="checkMPIdebugCXX" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-mpi --enable-debug CC=mpicxx \
-            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter"
+                       CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
+                       $P4EST_CI_CONFIG_OPT
           make -j V=0
           make -j check V=0
 

--- a/.github/workflows/composite-unix/action.yml
+++ b/.github/workflows/composite-unix/action.yml
@@ -5,9 +5,9 @@ runs:
   steps:
   - name: CMake configure
     shell: bash
-    run: >-
-      cmake --preset default
-      -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
+    run: |
+      cmake --preset default $P4EST_CI_CONFIG_OPT \
+            -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
 
   - name: CMake build
     shell: bash
@@ -24,9 +24,9 @@ runs:
     # standalone examples tests that CMake packaging is correct
   - name: CMake configure examples
     shell: bash
-    run: >-
-      cmake -B example/build -S example
-      -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
+    run: |
+      cmake -B example/build -S example \
+            -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
 
   - name: CMake build examples
     shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ target_include_directories(p4est PUBLIC
 target_link_libraries(p4est PUBLIC SC::SC )
 
 if (WIN32)
-  target_linke_libaries(p4est PUBLIC ${WINSOCK_LIBRARIES})
+  target_link_libraries(p4est PUBLIC ${WINSOCK_LIBRARIES})
 endif()
 
 # imported target, for use from parent projects

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -4,6 +4,8 @@ option(enable_p8est "build p8est" on)
 option(P4EST_BUILD_TESTING "build p4est testing" on)
 option(P4EST_BUILD_EXAMPLES "build p4est examples" ON)
 
+option( P4EST_ENABLE_FILE_CHECKS "activate tests that use file functions" ON)
+
 option(enable-file-deprecated "use deprecated data file format" off)
 
 option( P4EST_USE_SYSTEM_SC "Use system-installed sc library" OFF )

--- a/cmake/p4est_config.h.in
+++ b/cmake/p4est_config.h.in
@@ -30,6 +30,9 @@
 /* Define to 1 if we are using MPI */
 #cmakedefine P4EST_ENABLE_MPI 1
 
+/* Define to 1 if we compile the file checks */
+#cmakedefine P4EST_ENABLE_FILE_CHECKS 1
+
 /* Define to 1 if we can use MPI_COMM_TYPE_SHARED */
 #cmakedefine P4EST_ENABLE_MPICOMMSHARED 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,8 @@ P4EST_ARG_DISABLE([vtk-zlib], [disable zlib compression for vtk binary data],
 P4EST_ARG_DISABLE([2d], [disable the 2D library], [BUILD_2D])
 P4EST_ARG_DISABLE([3d], [disable the 3D library], [BUILD_3D])
 P4EST_ARG_DISABLE([p6est], [disable hybrid 2D+1D p6est library], [BUILD_P6EST])
+P4EST_ARG_DISABLE([file-checks], [disable tests that use file i/o functions],
+                  [FILE_CHECKS])
 
 echo "o---------------------------------------"
 echo "| Checking MPI and related programs"

--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -23,6 +23,8 @@
  - Make the CI configuration more long-term stable.
  - Add creation of the file .tarball-version in CMake.
  - Enable automake silent rules by default
+ - Add an option to disable the file checks; affects
+   p{4,8}est_test_{io,loadsave}
 
 ### Documentation
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ if(enable_p8est)
   endif()
 
   if(P4EST_HAVE_GETOPT_H)
-    list(APPEND p8est_tests test_load3)
+    list(APPEND p8est_tests test_load3 test_loadsave3)
   endif()
 endif()
 

--- a/test/test_io2.c
+++ b/test/test_io2.c
@@ -209,10 +209,10 @@ compressed_quadrant_t;
 int
 main (int argc, char **argv)
 {
-#ifdef P4EST_ENABLE_FILE_DEPRECATED
-
   sc_MPI_Comm         mpicomm;
-  int                 mpiret, errcode;
+  int                 mpiret;
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+  int                 errcode;
   int                 rank, size;
   int                 level = 3;
   int                 empty_header, read_only, header_only;
@@ -239,18 +239,23 @@ main (int argc, char **argv)
   sc_options_t       *opt;
   char                current_user_string[P4EST_FILE_USER_STRING_BYTES];
   compressed_quadrant_t *qr, *qs;
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
   /* initialize MPI */
   mpiret = sc_MPI_Init (&argc, &argv);
   SC_CHECK_MPI (mpiret);
   mpicomm = sc_MPI_COMM_WORLD;
+
+  sc_init (mpicomm, 1, 1, NULL, SC_LP_DEFAULT);
+  p4est_init (NULL, SC_LP_DEFAULT);
+
+#ifdef P4EST_ENABLE_FILE_DEPRECATED
+
   mpiret = sc_MPI_Comm_size (mpicomm, &size);
   SC_CHECK_MPI (mpiret);
   mpiret = sc_MPI_Comm_rank (mpicomm, &rank);
   SC_CHECK_MPI (mpiret);
 
-  sc_init (mpicomm, 1, 1, NULL, SC_LP_DEFAULT);
-  p4est_init (NULL, SC_LP_DEFAULT);
 
   /* parse command line parameters */
   opt = sc_options_new (argv[0]);
@@ -635,12 +640,12 @@ main (int argc, char **argv)
   sc_array_reset (&elem_size);
   sc_options_destroy (opt);
 
+#endif /* P4EST_ENABLE_FILE_DEPRECATED */
+
   sc_finalize ();
 
   mpiret = sc_MPI_Finalize ();
   SC_CHECK_MPI (mpiret);
-
-#endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
   return 0;
 }

--- a/test/test_io2.c
+++ b/test/test_io2.c
@@ -33,7 +33,7 @@
 #endif
 #include <sc_options.h>
 
-#ifdef P4EST_ENABLE_FILE_DEPRECATED
+#if defined(P4EST_ENABLE_FILE_DEPRECATED) && defined(P4EST_ENABLE_FILE_CHECKS)
 
 #ifndef P4_TO_P8
 #define P4EST_DATA_FILE_EXT "p4d" /**< file extension of p4est data files */
@@ -204,14 +204,14 @@ typedef struct compressed_quadrant
 }
 compressed_quadrant_t;
 
-#endif /* P4EST_ENABLE_FILE_DEPRECATED */
+#endif /* P4EST_ENABLE_FILE_DEPRECATED && P4EST_ENABLE_FILE_CHECKS */
 
 int
 main (int argc, char **argv)
 {
   sc_MPI_Comm         mpicomm;
   int                 mpiret;
-#ifdef P4EST_ENABLE_FILE_DEPRECATED
+#if defined(P4EST_ENABLE_FILE_DEPRECATED) && defined(P4EST_ENABLE_FILE_CHECKS)
   int                 errcode;
   int                 rank, size;
   int                 level = 3;
@@ -239,7 +239,7 @@ main (int argc, char **argv)
   sc_options_t       *opt;
   char                current_user_string[P4EST_FILE_USER_STRING_BYTES];
   compressed_quadrant_t *qr, *qs;
-#endif /* P4EST_ENABLE_FILE_DEPRECATED */
+#endif /* P4EST_ENABLE_FILE_DEPRECATED && P4EST_ENABLE_FILE_CHECKS*/
 
   /* initialize MPI */
   mpiret = sc_MPI_Init (&argc, &argv);
@@ -249,7 +249,7 @@ main (int argc, char **argv)
   sc_init (mpicomm, 1, 1, NULL, SC_LP_DEFAULT);
   p4est_init (NULL, SC_LP_DEFAULT);
 
-#ifdef P4EST_ENABLE_FILE_DEPRECATED
+#if defined(P4EST_ENABLE_FILE_DEPRECATED) && defined(P4EST_ENABLE_FILE_CHECKS)
 
   mpiret = sc_MPI_Comm_size (mpicomm, &size);
   SC_CHECK_MPI (mpiret);
@@ -640,7 +640,7 @@ main (int argc, char **argv)
   sc_array_reset (&elem_size);
   sc_options_destroy (opt);
 
-#endif /* P4EST_ENABLE_FILE_DEPRECATED */
+#endif /* P4EST_ENABLE_FILE_DEPRECATED && P4EST_ENABLE_FILE_CHECKS */
 
   sc_finalize ();
 

--- a/test/test_loadsave2.c
+++ b/test/test_loadsave2.c
@@ -38,6 +38,7 @@
 #include <sc_options.h>
 #include <sc_statistics.h>
 
+#ifdef P4EST_ENABLE_FILE_CHECKS
 #ifndef P4_TO_P8
 #define P4EST_CONN_SUFFIX "p4c"
 #define P4EST_FOREST_SUFFIX "p4p"
@@ -298,6 +299,7 @@ test_loadsave (p4est_connectivity_t * connectivity, const char *prefix,
   sc_stats_print (p4est_package_id, SC_LP_STATISTICS,
                   STATS_COUNT, stats, 0, 1);
 }
+#endif /* P4EST_ENABLE_FILE_CHECKS */
 
 int
 main (int argc, char **argv)
@@ -305,10 +307,12 @@ main (int argc, char **argv)
   sc_MPI_Comm         mpicomm;
   int                 mpiret;
   int                 mpirank;
+#ifdef P4EST_ENABLE_FILE_CHECKS
   int                 first_arg;
   const char         *prefix;
   p4est_connectivity_t *connectivity;
   sc_options_t       *opt;
+#endif /* P4EST_ENABLE_FILE_CHECKS */
 
   /* initialize MPI */
   mpiret = sc_MPI_Init (&argc, &argv);
@@ -320,6 +324,8 @@ main (int argc, char **argv)
   /* initialize libsc and p4est */
   sc_init (mpicomm, 1, 1, NULL, SC_LP_DEFAULT);
   p4est_init (NULL, SC_LP_DEFAULT);
+
+#ifdef P4EST_ENABLE_FILE_CHECKS
 
   /* handle command line options */
   opt = sc_options_new (argv[0]);
@@ -355,6 +361,16 @@ main (int argc, char **argv)
   /* clean up and exit */
   p4est_connectivity_destroy (connectivity);
   sc_options_destroy (opt);
+
+#else
+  P4EST_GLOBAL_INFO ("The file checks were deactivated during the"
+                     " configuration.\n");
+  P4EST_GLOBAL_INFO ("The file checks can be activated by not passing\n");
+  P4EST_GLOBAL_INFO ("--disable-file-checks to the Autoconf configure script"
+                     " and for CMake you must set the option"
+                     " P4EST_ENABLE_FILE_CHECKS to ON.\n");
+#endif /* !P4EST_ENABLE_FILE_CHECKS */
+
   sc_finalize ();
 
   mpiret = sc_MPI_Finalize ();


### PR DESCRIPTION
# Avoid CI fails due to busy file system

This PR provides analogous changes as implemented in libsc in the PR https://github.com/cburstedde/libsc/pull/214. This means that this PR adds an option in Autoconf and in CMake to disable the file I/O checks, which cause frequent CI failures due to a busy file system on the CI runners. This option is used in the three CI workflows.

In addition, this PR adds `test_loadsave3` as target in CMake since it was missing and this PR fixes a typo in `CMakeLists.txt` that caused the CMake build to fail on Windows.