### PR TITLE
Add generic geometry transformation

### DIFF
--- a/example/simple/simple2.c
+++ b/example/simple/simple2.c
@@ -239,36 +239,25 @@ static int
 refine_icosahedron_fn (p4est_t *p4est, p4est_topidx_t which_tree,
                        p4est_quadrant_t *quadrant)
 {
-
   p4est_geometry_t   *geom = (p4est_geometry_t *) p4est->user_pointer;
 
   /* logical coordinates */
-  double              xyz[3] = { 0, 0, 0 };
+  p4est_qcoord_t coords[2];
 
   /* physical coordinates */
-  double              XYZ[3] = { 0, 0, 0 };
+  double              XYZ[3];
 
-  double              h2 =
-    0.5 * P4EST_QUADRANT_LEN (quadrant->level) / P4EST_ROOT_LEN;
-  const double        intsize = 1.0 / P4EST_ROOT_LEN;
+  /* from logical coordinates to physical coordinates (Cartesian) */
+  p4est_quadrant_volume_coordinates (quadrant, coords);
+  p4est_geometry_transform_coordinates (geom, which_tree, coords, XYZ);
 
-  /*
-   * get coordinates at cell center
-   */
-  xyz[0] = intsize * quadrant->x + h2;
-  xyz[1] = intsize * quadrant->y + h2;
-#ifdef P4_TO_P8
-  xyz[2] = intsize * quadrant->z + h2;
-#endif
-
-  /* from logical coordinates to physical coordinates (cartesian) */
-  geom->X (geom, which_tree, xyz, XYZ);
-
+  /* evaluate refinement criterion */
   if (quadrant->level > 6)
     return 0;
-  if (XYZ[2] > 0 && quadrant->level >= 3)
+  if (XYZ[2] > 0. && quadrant->level >= 3)
     return 0;
 
+  /* otherwise: refine */
   return 1;
 }
 

--- a/example/simple/simple3.c
+++ b/example/simple/simple3.c
@@ -156,49 +156,43 @@ refine_pillow_fn (p8est_t *p8est, p4est_topidx_t which_tree,
   p8est_geometry_t   *geom = (p8est_geometry_t *) p8est->user_pointer;
 
   /* logical coordinates */
-  double              xyz0[3] = { 0, 0, 0 };
-  double              xyz1[3] = { 0, 0, 0 };
+  p4est_qcoord_t      coords[3];
+  p4est_qcoord_t      h2 = P8EST_QUADRANT_LEN (quadrant->level + 1);
 
   /* physical coordinates */
-  double              XYZ0[3] = { 0, 0, 0 };
-  double              XYZ1[3] = { 0, 0, 0 };
+  double              XYZ0[3];
+  double              XYZ1[3];
+  double              R0, R1;
 
-  double              h2 =
-    0.5 * P8EST_QUADRANT_LEN (quadrant->level) / P8EST_ROOT_LEN;
-  const double        intsize = 1.0 / P8EST_ROOT_LEN;
-
-  /*
-   * get coordinates in logical space
-   */
-  xyz0[0] = intsize * quadrant->x + 0 * h2;
-  xyz0[1] = intsize * quadrant->y + 0 * h2;
-  xyz0[2] = intsize * quadrant->z + 0 * h2;
-
-  xyz1[0] = intsize * quadrant->x + 1 * h2;
-  xyz1[1] = intsize * quadrant->y + 0 * h2;
-  xyz1[2] = intsize * quadrant->z + 0 * h2;
-
-  /* from logical coordinates to physical coordinates (cartesian) */
-  geom->X (geom, which_tree, xyz0, XYZ0);
-  geom->X (geom, which_tree, xyz1, XYZ1);
-
+  /* evaluate a criterion in reference coordinates */
   if ((int) quadrant->level >= refine_level) {
     return 0;
   }
-
-  if (quadrant->level < 3)
+  if (quadrant->level < 3) {
     return 1;
+  }
 
-  double              R0 =
-    sqrt (XYZ0[0] * XYZ0[0] + XYZ0[1] * XYZ0[1] + XYZ0[2] * XYZ0[2]);
-  double              R1 =
-    sqrt (XYZ1[0] * XYZ1[0] + XYZ1[1] * XYZ1[1] + XYZ1[2] * XYZ1[2]);
+  /* one reference point */
+  coords[0] = quadrant->x;
+  coords[1] = quadrant->y;
+  coords[2] = quadrant->z;
+
+  /* from logical coordinates to physical coordinates (Cartesian) */
+  p8est_geometry_transform_coordinates (geom, which_tree, coords, XYZ0);
+
+  /* another reference point */
+  coords[0] = quadrant->x + h2;
+  p8est_geometry_transform_coordinates (geom, which_tree, coords, XYZ1);
+
+  /* evaluate a refinement criterion in physical space */
+  R0 = sqrt (XYZ0[0] * XYZ0[0] + XYZ0[1] * XYZ0[1] + XYZ0[2] * XYZ0[2]);
+  R1 = sqrt (XYZ1[0] * XYZ1[0] + XYZ1[1] * XYZ1[1] + XYZ1[2] * XYZ1[2]);
   if (R0 > 0.7 && R0 < 0.8 && R1 > 0.7 && R1 < 0.8) {
     return 1;
   }
 
+  /* default: don't refine */
   return 0;
-
 }
 
 static int
@@ -208,43 +202,35 @@ refine_pillow_sphere_fn (p8est_t *p8est, p4est_topidx_t which_tree,
   p8est_geometry_t   *geom = (p8est_geometry_t *) p8est->user_pointer;
 
   /* logical coordinates */
-  double              xyz[3] = { 0, 0, 0 };
+  p4est_qcoord_t coords[3];
 
   /* physical coordinates */
-  double              XYZ[3] = { 0, 0, 0 };
+  double              XYZ[3];
+  double              R;
 
-  double              h2 =
-    0.5 * P8EST_QUADRANT_LEN (quadrant->level) / P8EST_ROOT_LEN;
-  const double        intsize = 1.0 / P8EST_ROOT_LEN;
-
-  /*
-   * get coordinates at cell center
-   */
-  xyz[0] = intsize * quadrant->x + h2;
-  xyz[1] = intsize * quadrant->y + h2;
-  xyz[2] = intsize * quadrant->z + h2;
-
-  /* from logical coordinates to physical coordinates (cartesian) */
-  geom->X (geom, which_tree, xyz, XYZ);
-
+  /* evaluate tree- and quadrant-based criterion */
   if (which_tree != 0) {
     return 0;
   }
   if ((int) quadrant->level >= refine_level) {
     return 0;
   }
-
-  if (quadrant->level < 3)
+  if (quadrant->level < 3) {
     return 1;
+  }
 
-  double              R =
-    sqrt (XYZ[0] * XYZ[0] + XYZ[1] * XYZ[1] + XYZ[2] * XYZ[2]);
+  /* from logical coordinates to physical coordinates (Cartesian) */
+  p8est_quadrant_volume_coordinates (quadrant, coords);
+  p8est_geometry_transform_coordinates (geom, which_tree, coords, XYZ);
+
+  /* evaluate coordinate-based refinement criterion */
+  R = sqrt (XYZ[0] * XYZ[0] + XYZ[1] * XYZ[1] + XYZ[2] * XYZ[2]);
   if (R > 0.5 && R < 0.7) {
     return 1;
   }
 
+  /* default: don't refine */
   return 0;
-
 }
 
 static int

--- a/example/simple/simple3.c
+++ b/example/simple/simple3.c
@@ -157,7 +157,6 @@ refine_pillow_fn (p8est_t *p8est, p4est_topidx_t which_tree,
 
   /* logical coordinates */
   p4est_qcoord_t      coords[3];
-  p4est_qcoord_t      h2 = P8EST_QUADRANT_LEN (quadrant->level + 1);
 
   /* physical coordinates */
   double              XYZ0[3];
@@ -172,16 +171,12 @@ refine_pillow_fn (p8est_t *p8est, p4est_topidx_t which_tree,
     return 1;
   }
 
-  /* one reference point */
-  coords[0] = quadrant->x;
-  coords[1] = quadrant->y;
-  coords[2] = quadrant->z;
-
-  /* from logical coordinates to physical coordinates (Cartesian) */
+  /* one reference point at the bottom z face */
+  p8est_quadrant_face_coordinates (quadrant, 4, coords);
   p8est_geometry_transform_coordinates (geom, which_tree, coords, XYZ0);
 
-  /* another reference point */
-  coords[0] = quadrant->x + h2;
+  /* another reference point at the top z face */
+  p8est_quadrant_face_coordinates (quadrant, 5, coords);
   p8est_geometry_transform_coordinates (geom, which_tree, coords, XYZ1);
 
   /* evaluate a refinement criterion in physical space */

--- a/src/p4est_geometry.c
+++ b/src/p4est_geometry.c
@@ -124,6 +124,30 @@ p4est_geometry_builtin_t;
 #endif /* !P4_TO_P8 */
 
 void
+p4est_geometry_transform_coordinates (p4est_geometry_t *geom,
+                                      p4est_topidx_t which_tree,
+                                      p4est_qcoord_t coords_in[P4EST_DIM],
+                                      double coords_out[3])
+{
+  static const double irl = 1. / P4EST_ROOT_LEN;
+  double              abc[3];
+
+  P4EST_ASSERT (geom != NULL);
+  P4EST_ASSERT (geom->X != NULL);
+  P4EST_ASSERT (coords_in != NULL);
+  P4EST_ASSERT (coords_out != NULL);
+
+  abc[0] = irl * coords_in[0];
+  abc[1] = irl * coords_in[1];
+#ifndef P4_TO_P8
+  abc[2] = 0.;
+#else
+  abc[2] = irl * coords_in[2];
+#endif
+  geom->X (geom, which_tree, abc, coords_out);
+}
+
+void
 p4est_geometry_destroy (p4est_geometry_t *geom)
 {
   if (geom->destroy != NULL) {

--- a/src/p4est_geometry.h
+++ b/src/p4est_geometry.h
@@ -71,6 +71,18 @@ typedef void        (*p4est_geometry_X_t) (p4est_geometry_t * geom,
  */
 typedef void        (*p4est_geometry_destroy_t) (p4est_geometry_t * geom);
 
+/** Transform a quadrant reference coordinate into the geometry.
+ * \param [in] geom     Properly initialized geometry object.
+ * \param [in] which_tree   Valid tree number relative to the
+ *                          connectivity that is underlying the geometry.
+ * \param [in] coords_in    Valid quadrant reference coordinates.
+ *                          They must be in [0, P4EST_ROOT_LEN]^2.
+ * \param [out] coords_out  Coordinates in the physical geometry.
+ */
+void                p4est_geometry_transform_coordinates
+  (p4est_geometry_t *geom, p4est_topidx_t which_tree,
+   p4est_qcoord_t coords_in[2], double coords_out[3]);
+
 /** Encapsulates a custom transformation from tree-local coordinates to
  * user defined physical space.
  *

--- a/src/p4est_geometry.h
+++ b/src/p4est_geometry.h
@@ -216,9 +216,9 @@ pillow_disk_config_t;
  * See companion routine \ref p8est_geometry_new_pillow_sphere which maps the 3d solid sphere
  * using 1-tree unit connectivity.
  *
- * \param[in] conn      The result of \ref p4est_connectivity_new_unit.
+ * \param[in] conn      The result of \ref p4est_connectivity_new_unitsquare.
  * \param[in] R         The radius of the disk.
- * \param[in] conf      The config to identify a mapping variant
+ * \param[in] config    The configuration to identify a mapping variant.
  */
 p4est_geometry_t   *p4est_geometry_new_pillow_disk (p4est_connectivity_t *
                                                     conn, double R,

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -529,6 +529,8 @@
 #endif /* P4EST_ENABLE_FILE_DEPRECATED */
 
 /* functions in p4est_geometry */
+#define p4est_geometry_transform_coordinates    \
+        p8est_geometry_transform_coordinates
 #define p4est_geometry_destroy          p8est_geometry_destroy
 #define p4est_geometry_new_connectivity p8est_geometry_new_connectivity
 #define p4est_geometry_connectivity_X   p8est_geometry_connectivity_X

--- a/src/p4est_to_p8est.h
+++ b/src/p4est_to_p8est.h
@@ -225,11 +225,11 @@
 #define p4est_expand_face_transform     p8est_expand_face_transform
 #define p4est_find_face_transform       p8est_find_face_transform
 #define p4est_find_corner_transform     p8est_find_corner_transform
-#define p4est_neighbor_transform_coordinates \
+#define p4est_neighbor_transform_coordinates    \
         p8est_neighbor_transform_coordinates
-#define p4est_neighbor_transform_coordinates_reverse \
+#define p4est_neighbor_transform_coordinates_reverse    \
         p8est_neighbor_transform_coordinates_reverse
-#define p4est_connectivity_get_neighbor_transforms \
+#define p4est_connectivity_get_neighbor_transforms      \
         p8est_connectivity_get_neighbor_transforms
 #define p4est_connectivity_coordinates_canonicalize     \
         p8est_connectivity_coordinates_canonicalize
@@ -414,11 +414,11 @@
 #define p4est_quadrant_srand            p8est_quadrant_srand
 #define p4est_neighbor_transform_quadrant       \
         p8est_neighbor_transform_quadrant
-#define p4est_neighbor_transform_quadrant_reverse    \
+#define p4est_neighbor_transform_quadrant_reverse       \
         p8est_neighbor_transform_quadrant_reverse
-#define p4est_quadrant_is_ancestor_face          \
+#define p4est_quadrant_is_ancestor_face         \
         p8est_quadrant_is_ancestor_face
-#define p4est_quadrant_is_ancestor_corner        \
+#define p4est_quadrant_is_ancestor_corner       \
         p8est_quadrant_is_ancestor_corner
 
 /* functions in p4est_search */

--- a/src/p8est_geometry.h
+++ b/src/p8est_geometry.h
@@ -155,9 +155,9 @@ pillow_sphere_config_t;
  * See companion routine \ref p4est_geometry_new_pillow_disk which maps the 2d disk
  * using 1-tree unit connectivity.
  *
- * \param[in] conn      The result of \ref p8est_connectivity_new_unit.
+ * \param[in] conn      The result of \ref p8est_connectivity_new_unitcube.
  * \param[in] R         The radius of the solid sphere.
- * \param[in] conf      The config to identify a mapping variant
+ * \param[in] config    The configuration to identify a mapping variant.
  */
 p8est_geometry_t   *p8est_geometry_new_pillow_sphere (p8est_connectivity_t *
                                                       conn, double R,
@@ -189,18 +189,19 @@ p8est_geometry_t   *p8est_geometry_new_sphere (p8est_connectivity_t * conn,
 /** Create a geometry structure for the torus.
  *
  * This geometry maps a revolution torus, obtained using
- * \ref p8est_connectivity_new_torus
+ * \ref p8est_connectivity_new_torus.
  *
  * The torus is divided into into segments around the revolution axis,
- * each segments is made of 5 trees; so here we provided the geometric
+ * each segment is made of 5 trees; so here we provided the geometric
  * transformation in a piecewise manner for each tree of the connectivity.
  *
  * \param [in] conn Result of p8est_connectivity_new_torus or equivalent.
  *                  We do NOT take ownership and expect it to stay alive.
  *
- * \param [in] R0   The inner radius of the 2d disk slice.
- * \param [in] R1   The outer radius of the 2d disk slice.
- * \param [in] R2   The outer radius of the torus.
+ * \param [in] R0   The inner radius of the 2d disk slice as cross section.
+ * \param [in] R1   The outer radius of the 2d disk slice as cross section.
+ * \param [in] R2   The radius of the center circle of the torus.
+ *                  The outer radius of the torus is thus \a R1 + \a R2.
  * \return          Geometry structure; use with \ref p4est_geometry_destroy.
  */
 p8est_geometry_t   *p8est_geometry_new_torus (p8est_connectivity_t * conn,

--- a/src/p8est_geometry.h
+++ b/src/p8est_geometry.h
@@ -59,6 +59,18 @@ typedef void        (*p8est_geometry_X_t) (p8est_geometry_t * geom,
  */
 typedef void        (*p8est_geometry_destroy_t) (p8est_geometry_t * geom);
 
+/** Transform a quadrant reference coordinate into the geometry.
+ * \param [in] geom     Properly initialized geometry object.
+ * \param [in] which_tree   Valid tree number relative to the
+ *                          connectivity that is underlying the geometry.
+ * \param [in] coords_in    Valid quadrant reference coordinates.
+ *                          They must be in [0, P4EST_ROOT_LEN]^3.
+ * \param [out] coords_out  Coordinates in the physical geometry.
+ */
+void                p8est_geometry_transform_coordinates
+  (p8est_geometry_t *geom, p4est_topidx_t which_tree,
+   p4est_qcoord_t coords_in[3], double coords_out[3]);
+
 /** This structure can be created by the user,
  * p4est will never change its contents.
  */


### PR DESCRIPTION
# Generic geometry transformation

## Proposed changes

So far, calling a geometry map was left to the user and required reading quite some documentation.
Here we introduce the function p4est_geometry_transform_coordinates that does the job.
It can be called given any valid geometry structure to map quadrant reference coordinates into space.

Along the way, we add minor documentation fixes.

Any comments @pkestene ?