### PR TITLE
Add edge side structure for iterator

### DIFF
--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -39,6 +39,7 @@
 ### Functionality
 
  - Add new members on hanging nodes to p4est_lnodes.
+ - Add explicit iterator edge side type
  - Update libsc to the latest version
 
 ## 2.8.6

--- a/src/p8est_iterate.h
+++ b/src/p8est_iterate.h
@@ -144,6 +144,25 @@ p8est_iter_face_info_t;
 typedef void        (*p8est_iter_face_t) (p8est_iter_face_info_t * info,
                                           void *user_data);
 
+/** Shortcut to access full edge information */
+typedef struct p8est_iter_edge_side_full
+{
+  int8_t              is_ghost; /**< boolean: local (0) or ghost */
+  p8est_quadrant_t   *quad;     /**< the actual quadrant */
+  p4est_locidx_t      quadid;   /**< index in tree or ghost array */
+
+}
+p8est_iter_edge_side_full_t;
+
+/** Shortcut to access hanging edge information */
+typedef struct p8est_iter_edge_side_hanging
+{
+  int8_t              is_ghost[2];      /**< boolean: local (0) or ghost */
+  p8est_quadrant_t   *quad[2];          /**< the actual quadrant */
+  p4est_locidx_t      quadid[2];        /**< index in tree or ghost array */
+}
+p8est_iter_edge_side_hanging_t;
+
 /* The information that is available to the user-defined p8est_iter_edge_t
  * callback.
  *
@@ -172,23 +191,11 @@ typedef struct p8est_iter_edge_side
                                             two smaller quads (1) */
   union p8est_iter_edge_side_data
   {
-    struct
-    {
-      int8_t              is_ghost;    /**< boolean: local (0) or ghost (1) */
-      p8est_quadrant_t   *quad;        /**< the actual quadrant */
-      p4est_locidx_t      quadid;      /**< index in tree or ghost array */
-    }
-    full; /**< if \a is_hanging = 0,
-               use is.full to access per-quadrant data */
+    /** if \a !is_hanging, use is.full to access per-quadrant data */
+    p8est_iter_edge_side_full_t full;
 
-    struct
-    {
-      int8_t              is_ghost[2]; /**< boolean: local (0) or ghost (1) */
-      p8est_quadrant_t   *quad[2];     /**< the actual quadrant */
-      p4est_locidx_t      quadid[2];   /**< index in tree or ghost array */
-    }
-    hanging; /**< if \a is_hanging = 1,
-                  use is.hanging to access per-quadrant data */
+    /** if \a is_hanging, use is.hanging to access per-quadrant data */
+    p8est_iter_edge_side_hanging_t hanging;
   }
   is;
   int8_t              faces[2];


### PR DESCRIPTION
# Add edge iterator struct type

## Proposed changes

We had made the side types of the face iterator explicit by giving them a named struct and a typedef. In this PR, we add the analogous definitions for the edge iterator in 3D. This change is backwards compatible.