### PR TITLE
Update README: Install instructions

### DIFF
--- a/README
+++ b/README
@@ -145,7 +145,7 @@ tree.  For development or for testing multiple configure options, create an
 empty directory for each configuration and invoke configure with a relative
 path.
 Note that the `--disable-shared` option suppresses the build of `.so` shared object lib files.
-In case these are also required the option needs to be omitted or changed to `--enable-shared`.
+In case these are also required this option needs to be omitted or changed to `--enable-shared`.
 
 The `configure` call is then followed by the usual `make` and `make install` commands, 
 potentially in `sudo` mode depending on the desired installation directory.

--- a/README
+++ b/README
@@ -148,7 +148,7 @@ Note that the `--disable-shared` option suppresses the build of `.so` shared obj
 In case these are also required this option needs to be omitted or changed to `--enable-shared`.
 
 The `configure` call is then followed by the usual `make` and `make install` commands, 
-potentially in `sudo` mode depending on the desired installation directory.
+the latter potentially in `sudo` mode depending on the desired installation directory.
 
 The subpackage `sc` is contained in the tarball and used by default.  It is
 possible to use a version of `libsc` that has been `make install`ed independently:

--- a/README
+++ b/README
@@ -144,7 +144,7 @@ installation, `./configure` can be called in the root directory of the unpacked
 tree.  For development or for testing multiple configure options, create an
 empty directory for each configuration and invoke configure with a relative
 path.
-Note that the `disable-shared` suppresses the build of `.so` shared object lib files.
+Note that the `--disable-shared` option suppresses the build of `.so` shared object lib files.
 In case these are also required the option needs to be changed to `--enable-shared`.
 
 The `configure` call is then followed by the usual `make` and `make install` commands, 

--- a/README
+++ b/README
@@ -145,7 +145,7 @@ tree.  For development or for testing multiple configure options, create an
 empty directory for each configuration and invoke configure with a relative
 path.
 Note that the `--disable-shared` option suppresses the build of `.so` shared object lib files.
-In case these are also required the option needs to be changed to `--enable-shared`.
+In case these are also required the option needs to be omitted or changed to `--enable-shared`.
 
 The `configure` call is then followed by the usual `make` and `make install` commands, 
 potentially in `sudo` mode depending on the desired installation directory.

--- a/README
+++ b/README
@@ -144,6 +144,11 @@ installation, `./configure` can be called in the root directory of the unpacked
 tree.  For development or for testing multiple configure options, create an
 empty directory for each configuration and invoke configure with a relative
 path.
+Note that the `disable-shared` suppresses the build of `.so` shared object lib files.
+In case these are also required the option needs to be changed to `--enable-shared`.
+
+The `configure` call is then followed by the usual `make` and `make install` commands, 
+potentially in `sudo` mode depending on the desired installation directory.
 
 The subpackage `sc` is contained in the tarball and used by default.  It is
 possible to use a version of `libsc` that has been `make install`ed independently:

--- a/doc/author_doehring.txt
+++ b/doc/author_doehring.txt
@@ -1,0 +1,1 @@
+I place my contributions to p4est under the FreeBSD license. Daniel Doehring (doehringd2@gmail.com)


### PR DESCRIPTION
# Update README: Install instructions

Following up on issue # . -

Proposed changes:

I would add the `make`, `make install` commands for completeness (and especially for people less familiar with the GNU build process, e.g. for folks coming from Julia.)