### PR TITLE
Unify example executable names

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -65,7 +65,10 @@ endfunction()
 # --- setup examples
 
 p4est_p8est_example(points points)
-p4est_p8est_example(generate_points points)
+p4est_example (points_generate points/generate_points2.c "points")
+if(enable_p8est)
+  p8est_example (points_generate points/generate_points3.c "points")
+endif()
 
 if(P4EST_HAVE_GETOPT_H)
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -22,9 +22,9 @@ endif()
 # --- helper functions
 function(p4est_example name files dir)
 
-add_executable(${name} ${files})
-target_link_libraries(${name} PRIVATE P4EST::P4EST)
-set_target_properties(${name}
+add_executable(p4est_${name} ${files})
+target_link_libraries(p4est_${name} PRIVATE P4EST::P4EST)
+set_target_properties(p4est_${name}
   PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${dir}"
   LABELS p4est
@@ -34,9 +34,9 @@ endfunction(p4est_example)
 
 function(p8est_example name files dir)
 
-add_executable(${name} ${files})
-target_link_libraries(${name} PRIVATE P4EST::P4EST)
-set_target_properties(${name}
+add_executable(p8est_${name} ${files})
+target_link_libraries(p8est_${name} PRIVATE P4EST::P4EST)
+set_target_properties(p8est_${name}
   PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${dir}"
   LABELS p8est
@@ -46,10 +46,10 @@ endfunction(p8est_example)
 
 function(p4est_p8est_example name dir)
 
-p4est_example(${name}2 ${dir}/${name}2.c ${dir})
+p4est_example(${name} ${dir}/${name}2.c ${dir})
 
 if(enable_p8est)
-  p8est_example(${name}3 ${dir}/${name}3.c ${dir})
+  p8est_example(${name} ${dir}/${name}3.c ${dir})
 endif()
 endfunction(p4est_p8est_example)
 
@@ -105,15 +105,15 @@ if(enable_p8est)
   p4est_copy_resource(tetgen p8est_box_tetgen.node)
 endif()
 
-p4est_example(spheres2 "spheres/spheres2.c;spheres/p4est_spheres.c" "spheres")
+p4est_example(spheres "spheres/spheres2.c;spheres/p4est_spheres.c" "spheres")
 if(enable_p8est)
-  p8est_example(spheres3 "spheres/spheres3.c;spheres/p8est_spheres.c" "spheres")
+  p8est_example(spheres "spheres/spheres3.c;spheres/p8est_spheres.c" "spheres")
 endif()
 
 foreach(i RANGE 1 5)
-  p4est_example(p4est_step${i} steps/p4est_step${i}.c "steps")
+  p4est_example(step${i} steps/p4est_step${i}.c "steps")
   if(enable_p8est)
-    p8est_example(p8est_step${i} steps/p8est_step${i}.c "steps")
+    p8est_example(step${i} steps/p8est_step${i}.c "steps")
   endif()
 endforeach()
 
@@ -123,3 +123,8 @@ foreach(n IN ITEMS cubit.inp cubit.jou gmsh.geo gmsh.inp)
     p4est_copy_resource(steps hole_3d_${n})
   endif()
 endforeach()
+
+p4est_example (userdata "userdata/userdata2.c;userdata/userdata_run2.c" "userdata")
+if(enable_p8est)
+  p8est_example(userdata "userdata/userdata3.c;userdata/userdata_run3.c" "userdata")
+endif()

--- a/example/mesh/Makefile.am
+++ b/example/mesh/Makefile.am
@@ -15,3 +15,5 @@ bin_PROGRAMS += example/mesh/p8est_mesh \
 example_mesh_p8est_mesh_SOURCES = example/mesh/mesh3.c
 example_mesh_p8est_periodicity_SOURCES = example/mesh/periodicity3.c
 endif
+
+EXTRA_DIST += example/mesh/conndebug.p8c

--- a/example/particles/Makefile.am
+++ b/example/particles/Makefile.am
@@ -19,6 +19,8 @@ example_particles_p8est_particles_SOURCES = \
   example/particles/particles3.c
 endif
 
+EXTRA_DIST += example/particles/separt.pl
+
 ## from example/steps for future reference
 ##
 ## EXTRA_DIST +=

--- a/example/points/Makefile.am
+++ b/example/points/Makefile.am
@@ -7,14 +7,14 @@ if P4EST_ENABLE_BUILD_2D
 bin_PROGRAMS += example/points/p4est_points
 example_points_p4est_points_SOURCES = example/points/points2.c
 
-bin_PROGRAMS += example/points/p4est_points_generate
-example_points_p4est_points_generate_SOURCES = example/points/generate_points2.c
+bin_PROGRAMS += example/points/p4est_generate_points
+example_points_p4est_generate_points_SOURCES = example/points/generate_points2.c
 endif
 
 if P4EST_ENABLE_BUILD_3D
 bin_PROGRAMS += example/points/p8est_points
 example_points_p8est_points_SOURCES = example/points/points3.c
 
-bin_PROGRAMS += example/points/p8est_points_generate
-example_points_p8est_points_generate_SOURCES = example/points/generate_points3.c
+bin_PROGRAMS += example/points/p8est_generate_points
+example_points_p8est_generate_points_SOURCES = example/points/generate_points3.c
 endif

--- a/example/points/Makefile.am
+++ b/example/points/Makefile.am
@@ -7,14 +7,14 @@ if P4EST_ENABLE_BUILD_2D
 bin_PROGRAMS += example/points/p4est_points
 example_points_p4est_points_SOURCES = example/points/points2.c
 
-bin_PROGRAMS += example/points/p4est_generate_points
-example_points_p4est_generate_points_SOURCES = example/points/generate_points2.c
+bin_PROGRAMS += example/points/p4est_points_generate
+example_points_p4est_points_generate_SOURCES = example/points/generate_points2.c
 endif
 
 if P4EST_ENABLE_BUILD_3D
 bin_PROGRAMS += example/points/p8est_points
 example_points_p8est_points_SOURCES = example/points/points3.c
 
-bin_PROGRAMS += example/points/p8est_generate_points
-example_points_p8est_generate_points_SOURCES = example/points/generate_points3.c
+bin_PROGRAMS += example/points/p8est_points_generate
+example_points_p8est_points_generate_SOURCES = example/points/generate_points3.c
 endif

--- a/example/timings/Makefile.am
+++ b/example/timings/Makefile.am
@@ -27,4 +27,6 @@ example_timings_p8est_loadconn_SOURCES = example/timings/loadconn3.c
 example_timings_p8est_tsearch_SOURCES = example/timings/tsearch3.c
 endif
 
-EXTRA_DIST += example/timings/timana.awk example/timings/timana.sh
+EXTRA_DIST += example/timings/timana.awk example/timings/timana.sh \
+              example/timings/tsrana.awk example/timings/tsrana.sh \
+              example/timings/perfscript.sh


### PR DESCRIPTION
# Unify example executable names

This PR changes the naming scheme of the executables in example/CMakeLists.txt to match the `p4est_` naming scheme used in Autotools.
Additionally, it adds the userdata example to example/CMakeLists.txt.
Furthermore, it adds some missing files from the example folders to the autotools distribution.