### PR TITLE
CI:Windows:MSYS2: use UCRT packages

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -98,28 +98,31 @@ jobs:
     timeout-minutes: 60
 
     env:
-      CMAKE_GENERATOR: "MinGW Makefiles"
+      CMAKE_GENERATOR: Ninja
 
     steps:
     - uses: msys2/setup-msys2@v2
+      id: msys2
       with:
         update: true
         install: >-
-          mingw-w64-x86_64-zlib
+          mingw-w64-ucrt-x86_64-gcc
+          mingw-w64-ucrt-x86_64-zlib
 
     - name: Put MSYS2_MinGW64 on PATH
-      run: echo "${{ runner.temp }}/msys64/mingw64/bin/" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      run: echo "${{ steps.msys2.outputs.msys2-location }}/ucrt64/bin/" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - uses: actions/checkout@v4
       name: Checkout source code
 
     - run: echo "CMAKE_INSTALL_PREFIX=$HOME/local" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - run: echo "CMAKE_PREFIX_PATH=$HOME/local" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-    - run: echo "ZLIB_ROOT=$env:RUNNER_TEMP/msys64/mingw64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     # Windows MPI is shaky in general on GitHub Actions, so we don't use it
     - name: CMake configure without MPI
       run: cmake --preset default -Dmpi:BOOL=no $env:P4EST_CI_CONFIG_OPT
+      env:
+        ZLIB_ROOT: ${{ steps.msys2.outputs.msys2-location }}/ucrt64
 
     - name: CMake build
       run: cmake --build --preset default
@@ -132,6 +135,8 @@ jobs:
 
     - name: CMake configure examples
       run: cmake -B example/build -S example
+      env:
+        ZLIB_ROOT: ${{ steps.msys2.outputs.msys2-location }}/ucrt64
 
     - name: CMake build examples
       run: cmake --build example/build


### PR DESCRIPTION


# CI use MSYS2 UCRT environment prefix

Proposed changes:
UCRT is the recommend environment prefix of the MSYS2 project and what Microsoft promotes as well. UCRT is what MSYS2 end-users would be using. This makes the CI tests best represent what end users experience.

