### PR TITLE
Fix unused variable warnings

### DIFF
--- a/src/p4est.c
+++ b/src/p4est.c
@@ -950,7 +950,10 @@ p4est_coarsen_ext (p4est_t * p4est,
   int                 i, maxlevel;
   int                 isfamily;
   size_t              zz;
-  size_t              incount, removed;
+  size_t              incount;
+#ifdef P4EST_ENABLE_DEBUG
+  size_t              removed;
+#endif
   size_t              window, start, length, cidz;
   p4est_locidx_t      num_quadrants, prev_offset;
   p4est_topidx_t      jt;
@@ -983,8 +986,8 @@ p4est_coarsen_ext (p4est_t * p4est,
     if (p4est->user_data_pool != NULL) {
       data_pool_size = p4est->user_data_pool->elem_count;
     }
-#endif
     removed = 0;
+#endif
 
     /* initial log message for this tree */
     P4EST_VERBOSEF ("Into coarsen tree %lld with %llu\n", (long long) jt,
@@ -1038,7 +1041,9 @@ p4est_coarsen_ext (p4est_t * p4est,
         p4est_quadrant_init_data (p4est, jt, cfirst, init_fn);
         tree->quadrants_per_level[cfirst->level] += 1;
         p4est->local_num_quadrants -= P4EST_CHILDREN - 1;
+#ifdef P4EST_ENABLE_DEBUG
         removed += P4EST_CHILDREN - 1;
+#endif
 
         cidz = (size_t) p4est_quadrant_child_id (cfirst);
         start = window + 1;
@@ -1261,7 +1266,9 @@ p4est_balance_ext (p4est_t * p4est, p4est_connect_type_t btype,
   size_t              zz, treecount, ctree;
   size_t              localcount;
   size_t              qcount, qbytes;
+#ifdef P4EST_ENABLE_DEBUG
   size_t              all_incount, all_outcount;
+#endif
   p4est_qcoord_t      qh;
   const p4est_qcoord_t rh = P4EST_ROOT_LEN;
   p4est_topidx_t      qtree, nt;
@@ -1439,7 +1446,9 @@ p4est_balance_ext (p4est_t * p4est, p4est_connect_type_t btype,
   last_tree = p4est->last_local_tree;
   first_peer = num_procs;
   last_peer = -1;
+#ifdef P4EST_ENABLE_DEBUG
   all_incount = 0;
+#endif
   skipped = 0;
   for (nt = first_tree; nt <= last_tree; ++nt) {
     p4est_comm_tree_info (p4est, nt, full_tree, tree_contact, NULL, NULL);
@@ -1453,7 +1462,9 @@ p4est_balance_ext (p4est_t * p4est, p4est_connect_type_t btype,
     }
     tree = p4est_tree_array_index (p4est->trees, nt);
     tquadrants = &tree->quadrants;
+#ifdef P4EST_ENABLE_DEBUG
     all_incount += tquadrants->elem_count;
+#endif
 
     /* initial log message for this tree */
     P4EST_VERBOSEF ("Into balance tree %lld with %llu\n", (long long) nt,
@@ -2360,10 +2371,14 @@ p4est_balance_ext (p4est_t * p4est, p4est_connect_type_t btype,
 #endif /* P4EST_ENABLE_MPI */
 
   /* loop over all local trees to finalize balance */
+#ifdef P4EST_ENABLE_DEBUG
   all_outcount = 0;
+#endif
   for (nt = first_tree; nt <= last_tree; ++nt) {
     tree = p4est_tree_array_index (p4est->trees, nt);
+#ifdef P4EST_ENABLE_DEBUG
     all_outcount += tree->quadrants.elem_count;
+#endif
 
     /* final log message for this tree */
     P4EST_VERBOSEF ("Done balance tree %lld now %llu\n", (long long) nt,

--- a/src/p4est_algorithms.c
+++ b/src/p4est_algorithms.c
@@ -1201,7 +1201,10 @@ void
 p4est_tree_uniqify_overlap (sc_array_t * out)
 {
   size_t              iz, jz;
-  size_t              outcount, dupcount, olcount;
+  size_t              outcount;
+#ifdef P4EST_ENABLE_DEBUG
+  size_t              dupcount, olcount;
+#endif
   p4est_quadrant_t   *q, *p, tempq;
 
   outcount = out->elem_count;
@@ -1211,7 +1214,9 @@ p4est_tree_uniqify_overlap (sc_array_t * out)
 
   /* sort array and remove duplicates */
   sc_array_sort (out, p4est_quadrant_compare_piggy);
+#ifdef P4EST_ENABLE_DEBUG
   dupcount = olcount = 0;
+#endif
   iz = 0;                       /* read counter */
   jz = 0;                       /* write counter */
   q = NULL;
@@ -1222,12 +1227,16 @@ p4est_tree_uniqify_overlap (sc_array_t * out)
       p4est_nearest_common_ancestor (p, q, &tempq);
       if (tempq.level >= SC_MIN (q->level, p->level) - 1) {
         if (p->level > q->level) {
+#ifdef P4EST_ENABLE_DEBUG
           olcount++;
+#endif
           *q = *p;
         }
         else {
           P4EST_ASSERT (p->level == q->level);
+#ifdef P4EST_ENABLE_DEBUG
           dupcount++;
+#endif
         }
         continue;
       }
@@ -2664,7 +2673,9 @@ p4est_linearize_tree (p4est_t * p4est, p4est_tree_t * tree)
 #endif
   size_t              incount, removed;
   size_t              current, rest;
+#ifdef P4EST_ENABLE_DEBUG
   p4est_locidx_t      num_quadrants;
+#endif
   int                 i, maxlevel;
   p4est_quadrant_t   *q1, *q2;
   sc_array_t         *tquadrants = &tree->quadrants;
@@ -2715,10 +2726,14 @@ p4est_linearize_tree (p4est_t * p4est, p4est_tree_t * tree)
 
   /* update level counters */
   maxlevel = 0;
+#ifdef P4EST_ENABLE_DEBUG
   num_quadrants = 0;
+#endif
   for (i = 0; i <= P4EST_QMAXLEVEL; ++i) {
     P4EST_ASSERT (tree->quadrants_per_level[i] >= 0);
+#ifdef P4EST_ENABLE_DEBUG
     num_quadrants += tree->quadrants_per_level[i];      /* same type */
+#endif
     if (tree->quadrants_per_level[i] > 0) {
       maxlevel = i;
     }
@@ -2825,7 +2840,9 @@ p4est_partition_given (p4est_t * p4est,
 
   int                 i;
   int                 from_proc, to_proc;
+#if defined(P4EST_ENABLE_DEBUG) || defined(P4EST_ENABLE_MPI)
   int                 num_proc_recv_from, num_proc_send_to;
+#endif
   char               *user_data_send_buf;
   char               *user_data_recv_buf;
   char              **recv_buf, **send_buf;
@@ -2972,7 +2989,9 @@ p4est_partition_given (p4est_t * p4est,
   my_begin = (rank == 0) ? 0 : (new_global_last_quad_index[rank - 1] + 1);
   my_end = new_global_last_quad_index[rank];
 
+#if defined(P4EST_ENABLE_DEBUG) || defined(P4EST_ENABLE_MPI)
   num_proc_recv_from = 0;
+#endif
 
   if (my_begin > my_end) {
     /* my_begin == my_end requires a search is legal for find_partition */
@@ -2994,8 +3013,10 @@ p4est_partition_given (p4est_t * p4est,
                                                                lower_bound)
           + 1;
         P4EST_ASSERT (num_recv_from[from_proc] >= 0);
+#if defined(P4EST_ENABLE_DEBUG) || defined(P4EST_ENABLE_MPI)
         if (from_proc != rank)
           ++num_proc_recv_from;
+#endif
       }
     }
   }
@@ -3094,7 +3115,9 @@ p4est_partition_given (p4est_t * p4est,
   my_begin = (rank == 0) ? 0 : (global_last_quad_index[rank - 1] + 1);
   my_end = global_last_quad_index[rank];
 
+#if defined(P4EST_ENABLE_DEBUG) || defined(P4EST_ENABLE_MPI)
   num_proc_send_to = 0;
+#endif
 
   if (my_begin > my_end) {
     /* my_begin == my_end requires a search is legal for find_partition */
@@ -3125,8 +3148,10 @@ p4est_partition_given (p4est_t * p4est,
           + 1;
         begin_send_to[to_proc] = SC_MAX (my_begin, lower_bound);
         P4EST_ASSERT (num_send_to[to_proc] >= 0);
+#ifdef P4EST_ENABLE_MPI
         if (to_proc != rank)
           ++num_proc_send_to;
+#endif
       }
     }
   }

--- a/src/p4est_connectivity.c
+++ b/src/p4est_connectivity.c
@@ -5216,7 +5216,6 @@ p4est_connectivity_read_inp_stream (FILE * stream,
                                     p4est_topidx_t * tree_to_vertex)
 {
   int                 reading_nodes = 0, reading_elements = 0;
-  int                 lines_read = 0, lines_free = 0;
   char               *line;
   p4est_topidx_t      num_nodes = 0;
   p4est_topidx_t      num_elements = 0;
@@ -5233,14 +5232,11 @@ p4est_connectivity_read_inp_stream (FILE * stream,
       break;
     }
 
-    ++lines_read;
-
     /* check for control line */
     if (line[0] == '*') {
       reading_elements = reading_nodes = 0;
       if (strstr (line, "*NODE")) {
         reading_nodes = 1;
-        ++lines_free;
         P4EST_FREE (line);
         continue;
       }
@@ -5254,7 +5250,6 @@ p4est_connectivity_read_inp_stream (FILE * stream,
 #endif
           ) {
           reading_elements = 1;
-          ++lines_free;
           P4EST_FREE (line);
           continue;
         }
@@ -5329,7 +5324,6 @@ p4est_connectivity_read_inp_stream (FILE * stream,
       ++num_elements;
     }
 
-    ++lines_free;
     P4EST_FREE (line);
   }
 

--- a/src/p4est_geometry.c
+++ b/src/p4est_geometry.c
@@ -1025,7 +1025,9 @@ p4est_geometry_coordinates_lnodes (p4est_t *p4est,
 #endif
   int                 dtb[P4EST_DIM], dth[P4EST_DIM], dts;
   size_t              numenodes;
+#ifdef P4EST_ENABLE_DEBUG
   size_t              volquery, treequery;
+#endif
   size_t              collected, duplicates;
   double              abc[3], *xyz, *ret;
   p4est_topidx_t      tt;
@@ -1078,7 +1080,10 @@ p4est_geometry_coordinates_lnodes (p4est_t *p4est,
     /* don't use sc_array_index since the array may have no elements */
     ecoords = (p4est_locidx_t *) element_coordinates->array;
   }
-  volquery = treequery = 0;
+#ifdef P4EST_ENABLE_DEBUG
+  volquery = 0;
+  treequery = 0;
+#endif
   collected = duplicates = 0;
   for (tt = p4est->first_local_tree; tt <= p4est->last_local_tree; ++tt) {
 
@@ -1129,7 +1134,9 @@ p4est_geometry_coordinates_lnodes (p4est_t *p4est,
 
           /* if we identify coordinates with local nodes, shortcut */
           if (ecoords == NULL) {
+#ifdef P4EST_ENABLE_DEBUG
             ++volquery;
+#endif
             if (volcoord[tn->local_node] >= 0) {
               /* this local node has been computed already */
               ++duplicates;
@@ -1225,13 +1232,17 @@ p4est_geometry_coordinates_lnodes (p4est_t *p4est,
             /* volume points, never on a tree boundary, need no hashing */
             xyz = p4est_geometry_coordinates_volume (volcoord, coordinates,
                                                      ecoords + kji, tn);
+#ifdef P4EST_ENABLE_DEBUG
             ++volquery;
+#endif
           }
           else {
             /* codimension points may be on a tree boundary */
             xyz = p4est_geometry_coordinates_insert (hash, pool, coordinates,
                                                      ecoords + kji, tn);
+#ifdef P4EST_ENABLE_DEBUG
             ++treequery;
+#endif
           }
 
           /* evaluate reference coordinates if this point is a new one */

--- a/src/p6est.c
+++ b/src/p6est.c
@@ -1163,7 +1163,6 @@ p6est_compress_columns (p6est_t * p6est)
   sc_array_t         *tquadrants;
   size_t              offset, nkeep;
   int                 count;
-  size_t              this_col;
   p4est_t            *columns = p6est->columns;
   sc_array_t         *layers = p6est->layers;
   size_t             *newindex;
@@ -1177,11 +1176,11 @@ p6est_compress_columns (p6est_t * p6est)
   }
 
   offset = 0;
-  for (this_col = 0, jt = columns->first_local_tree;
+  for (jt = columns->first_local_tree;
        jt <= columns->last_local_tree; ++jt) {
     tree = p4est_tree_array_index (columns->trees, jt);
     tquadrants = &tree->quadrants;
-    for (zz = 0; zz < tquadrants->elem_count; ++zz, this_col++) {
+    for (zz = 0; zz < tquadrants->elem_count; ++zz) {
       col = p4est_quadrant_array_index (tquadrants, zz);
       P6EST_COLUMN_GET_RANGE (col, &first, &last);
       count = last - first;

--- a/test/test_coarsen2.c
+++ b/test/test_coarsen2.c
@@ -46,7 +46,10 @@ p4est_coarsen_old (p4est_t * p4est, int coarsen_recursive,
   int                 i, maxlevel;
   int                 couldbegood;
   size_t              zz;
-  size_t              incount, removed;
+  size_t              incount;
+#ifdef P4EST_ENABLE_DEBUG
+  size_t              removed;
+#endif
   size_t              cidz, first, last, rest, before;
   p4est_locidx_t      num_quadrants, prev_offset;
   p4est_topidx_t      jt;
@@ -71,8 +74,8 @@ p4est_coarsen_old (p4est_t * p4est, int coarsen_recursive,
     if (p4est->user_data_pool != NULL) {
       data_pool_size = p4est->user_data_pool->elem_count;
     }
-#endif
     removed = 0;
+#endif
 
     /* initial log message for this tree */
     P4EST_VERBOSEF ("Into coarsen tree %lld with %llu\n", (long long) jt,
@@ -116,7 +119,9 @@ p4est_coarsen_old (p4est_t * p4est, int coarsen_recursive,
         p4est_quadrant_init_data (p4est, jt, cfirst, init_fn);
         tree->quadrants_per_level[cfirst->level] += 1;
         p4est->local_num_quadrants -= P4EST_CHILDREN - 1;
+#ifdef P4EST_ENABLE_DEBUG
         removed += P4EST_CHILDREN - 1;
+#endif
 
         rest += P4EST_CHILDREN - before;
         if (coarsen_recursive) {

--- a/test/test_wrap2.c
+++ b/test/test_wrap2.c
@@ -51,14 +51,13 @@ wrap_adapt_partition (p4est_wrap_t * wrap, int weight_exponent)
 static void
 test_coarsen_delay (p4est_wrap_t * wrap)
 {
-  p4est_locidx_t      jl;
   p4est_wrap_leaf_t  *leaf;
   p4est_wrap_t       *copy1, *copy2;
 
   p4est_wrap_set_coarsen_delay (wrap, 2, 0);
 
-  for (jl = 0, leaf = p4est_wrap_leaf_first (wrap, 1); leaf != NULL;
-       jl++, leaf = p4est_wrap_leaf_next (leaf)) {
+  for (leaf = p4est_wrap_leaf_first (wrap, 1); leaf != NULL;
+       leaf = p4est_wrap_leaf_next (leaf)) {
     if (leaf->which_quad % 4 == 0) {
       p4est_wrap_mark_refine (wrap, leaf->which_tree, leaf->which_quad);
     }
@@ -72,8 +71,8 @@ test_coarsen_delay (p4est_wrap_t * wrap)
   /* copies must be destroyed before the original is destroyed, in any order */
   p4est_wrap_destroy (copy1);
 
-  for (jl = 0, leaf = p4est_wrap_leaf_first (wrap, 1); leaf != NULL;
-       jl++, leaf = p4est_wrap_leaf_next (leaf)) {
+  for (leaf = p4est_wrap_leaf_first (wrap, 1); leaf != NULL;
+       leaf = p4est_wrap_leaf_next (leaf)) {
     p4est_wrap_mark_coarsen (wrap, leaf->which_tree, leaf->which_quad);
   }
   wrap_adapt_partition (wrap, 1);


### PR DESCRIPTION
# Fix set-but-unused-variable warnings

Proposed changes:
This PR addresses a recent issue in the CI (https://github.com/cburstedde/p4est/actions/runs/26040411092/job/76567611984). There were some set-but-unused-variable warnings for variables that are only used in assertions. This PR removes the warnings by enclosing the variables in an #ifdef P4EST_ENABLE_DEBUG. Also, it updates the submodule to include similar fixes in sc (see https://github.com/cburstedde/libsc/pull/240).